### PR TITLE
Allow props to be null or undefined, for parcel.js

### DIFF
--- a/packages/hyper-dom-expressions/src/index.ts
+++ b/packages/hyper-dom-expressions/src/index.ts
@@ -62,7 +62,7 @@ export function createHyperScript(r: Runtime): HyperScript {
           let props: Props = {},
             dynamic = [],
             next = args[0];
-          if (typeof next === "object" && !Array.isArray(next) && !(next instanceof Element))
+          if (typeof next === "object" && next != null && !Array.isArray(next) && !(next instanceof Element))
             props = args.shift();
           for (const k in props) {
             if (typeof props[k] === "function") dynamic.push(k);


### PR DESCRIPTION
Using parcel.js with the following jsx pragma and code:

```jsx
/** @jsx h */
import h from 'solid-js/h'
import { render } from 'solid-js/dom'

render(
  () => <h1>HELLO</h1>,
  document.getElementById('root')
);
```
...causes it to call `h` like this:

```js
h("h1", null, "HELLO")
```

...which fails, because `props` is `null`, and is seen as being `typeof "object"`.

This commit allows `props` to be ignored if `null`, instead of being treated like an `object`.