### PR TITLE
Fix multi-line text paragraphs

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -126,7 +126,7 @@ export function trimWhitespace(text) {
       .split("\n")
       .map((t, i) => (i ? t.replace(/^\s*/g, "") : t))
       .filter(s => !/^\s*$/.test(s))
-      .join("");
+      .join(" ");
   }
   return text.replace(/\s+/g, " ");
 }

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/code.js
@@ -30,6 +30,12 @@ const multiLineTrailingSpace = <span>
 </span>
 
 /* prettier-ignore */
+const multiLineNoTrailingSpace = <span>
+  Hello
+  John
+</span>
+
+/* prettier-ignore */
 const escape = <span>
   &nbsp;&lt;Hi&gt;&nbsp;
 </span>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
@@ -84,4 +84,7 @@ const multiLine = _tmpl$7.cloneNode(true);
 const multiLineTrailingSpace = _tmpl$3.cloneNode(true);
 /* prettier-ignore */
 
+const multiLineNoTrailingSpace = _tmpl$3.cloneNode(true);
+/* prettier-ignore */
+
 const escape = _tmpl$8.cloneNode(true);


### PR DESCRIPTION
Hi Ryan,

I had an issue where a multi-line text paragraph in my JSX source code, had its **last word of a line** and the **first word of the next line**, smushed together without any whitespace between them.

_Of course, a newline is considered whitespace in HTML. [I had to double-check!](https://developer.mozilla.org/en-US/docs/Glossary/Whitespace)_

Example:

```html
<p>sadf asdf asdf asd fas df asdf asdf asdf asdf asd fsad fas dfs adf LAST_WORD_OF_LINE
      FIRST_WORD_OF_NEXT_LINE jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg</p>
```

...would turn into this in the DOM:

```html
<p>sadf asdf asdf asd fas df asdf asdf asdf asdf asd fsad fas dfs adf LAST_WORD_OF_LINEFIRST_WORD_OF_NEXT_LINE jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg jhg</p>
```

This PR fixes that, while still keeping all existing tests passing.