### PR TITLE
Increase escapeHTML performance up to 10 times!

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -221,6 +221,7 @@ export function escapeHTML(html, attr) {
   for (index = match.index; index < html.length; index++) {
     switch (html.charCodeAt(index)) {
       case 34: // "
+        if (!attr) continue;
         escape = "&quot;";
         break;
       case 38: // &

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -212,14 +212,29 @@ const ATTR_REGEX = /[&<"]/g,
 
 export function escapeHTML(html, attr) {
   if (typeof html !== "string") return html;
-  return html.replace(attr ? ATTR_REGEX : CONTENT_REGEX, m => {
-    switch (m) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case '"':
-        return "&quot;";
+  const match = (attr ? ATTR_REGEX : CONTENT_REGEX).exec(html);
+  if (!match) return html;
+  let index = 0;
+  let lastIndex = 0;
+  let out = "";
+  let escape = "";
+  for (index = match.index; index < html.length; index++) {
+    switch (html.charCodeAt(index)) {
+      case 34: // "
+        escape = "&quot;";
+        break;
+      case 38: // &
+        escape = "&amp;";
+        break;
+      case 60: // <
+        escape = "&lt;";
+        break;
+      default:
+        continue;
     }
-  });
+    if (lastIndex !== index) out += html.substring(lastIndex, index);
+    lastIndex = index + 1;
+    out += escape;
+  }
+  return lastIndex !== index ? out + html.substring(lastIndex, index) : out;
 }

--- a/packages/dom-expressions/src/runtime.js
+++ b/packages/dom-expressions/src/runtime.js
@@ -240,16 +240,32 @@ const ATTR_REGEX = /[&<"]/g,
 
 export function escape(html, attr) {
   if (typeof html !== "string") return html;
-  return html.replace(attr ? ATTR_REGEX : CONTENT_REGEX, m => {
-    switch (m) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case '"':
-        return "&quot;";
+  const match = (attr ? ATTR_REGEX : CONTENT_REGEX).exec(html);
+  if (!match) return html;
+  let index = 0;
+  let lastIndex = 0;
+  let out = "";
+  let escape = "";
+  for (index = match.index; index < html.length; index++) {
+    switch (html.charCodeAt(index)) {
+      case 34: // "
+        if (!attr) continue;
+        escape = "&quot;";
+        break;
+      case 38: // &
+        escape = "&amp;";
+        break;
+      case 60: // <
+        escape = "&lt;";
+        break;
+      default:
+        continue;
     }
-  });
+    if (lastIndex !== index) out += html.substring(lastIndex, index);
+    lastIndex = index + 1;
+    out += escape;
+  }
+  return lastIndex !== index ? out + html.substring(lastIndex, index) : out;
 }
 
 // Hydrate


### PR DESCRIPTION
I compared performance for `escapeHTML` function using @dougwilson's [benchmark](https://github.com/component/escape-html/blob/master/benchmark/index.js) from [escape-html](https://github.com/component/escape-html) repo.

**Before:**

<img width="525" alt="Screenshot 2020-09-09 at 14 58 25" src="https://user-images.githubusercontent.com/640669/92595405-f829b100-f2ac-11ea-9b08-3e8ca3d91392.png">

**After:**

<img width="525" alt="Screenshot 2020-09-09 at 14 58 41" src="https://user-images.githubusercontent.com/640669/92595420-011a8280-f2ad-11ea-815c-e80a8bf08ee4.png">

Bundle size will increase a bit but it shouldn't matter if this code is mostly used on backend side during server-side rendering where the performance is much more important.