### PR TITLE
Typings for generateHydrationScript({ resolved })

### DIFF
--- a/packages/dom-expressions/src/runtime.d.ts
+++ b/packages/dom-expressions/src/runtime.d.ts
@@ -35,7 +35,7 @@ export function assignProps(target: any, ...sources: any): any
 export function getHydrationKey(): string;
 export function getNextElement(template: HTMLTemplateElement, isSSR: boolean): Node;
 export function getNextMarker(start: Node): [Node, Array<Node>];
-export function generateHydrationScript(options: { eventNames: string[], streaming: boolean }): string;
+export function generateHydrationScript(options?: { eventNames?: string[], streaming?: boolean, resolved?: boolean }): string;
 
 export function ssrClassList(value: { [k: string]: boolean }): string;
 export function ssrStyle(value: { [k: string]: string }): string;


### PR DESCRIPTION
Just found a [usage](https://github.com/ryansolid/solid/blob/e99f2ad590cad09a9ab1983369f097b6c16bf666/packages/solid-ssr/examples/async/index.js#L29) but not the typings:
https://github.com/ryansolid/dom-expressions/blob/ba1ea6b2d8136d9fcae412682ec162bc010f6c50/packages/dom-expressions/src/runtime.js#L329-L333