### PR TITLE
Partially revert 86c9ff1 Add static template hoisting to SSR

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -342,7 +342,9 @@ function transformAttributes(path, results) {
           ) {
             // can only hydrate delegated events
             hasHydratableEvent = true;
-            const events = path.state.events;
+            const events =
+              attribute.scope.getProgramParent().data.events ||
+              (attribute.scope.getProgramParent().data.events = new Set());
             events.add(ev);
             let handler = value.expression;
             const resolveable = detectResolvableEventHandler(attribute, handler);

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
@@ -60,7 +60,9 @@ function registerTemplate(path, results) {
   const { hydratable } = config;
   let decl;
   if (results.template.length) {
-    const templates = path.state.templates;
+    const templates =
+      path.scope.getProgramParent().data.templates ||
+      (path.scope.getProgramParent().data.templates = []);
     let templateDef, templateId;
     if ((templateDef = templates.find(t => t.template === results.template))) {
       templateId = templateDef.id;

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/postprocess.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/postprocess.js
@@ -6,18 +6,18 @@ import config from "../config";
 
 // add to the top/bottom of the module.
 export default path => {
-  if (path.state.events.size) {
+  if (path.scope.data.events) {
     registerImportMethod(path, "delegateEvents");
     path.node.body.push(
       t.expressionStatement(
         t.callExpression(t.identifier("_$delegateEvents"), [
-          t.arrayExpression(Array.from(path.state.events).map(e => t.stringLiteral(e)))
+          t.arrayExpression(Array.from(path.scope.data.events).map(e => t.stringLiteral(e)))
         ])
       )
     );
   }
-  if (path.state.templates.length) {
+  if (path.scope.data.templates) {
     const appendTemplates = config.generate === "ssr" ? appendTemplatesSSR : appendTemplatesDOM;
-    appendTemplates(path, path.state.templates);
+    appendTemplates(path, path.scope.data.templates);
   }
 };

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/preprocess.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/preprocess.js
@@ -11,8 +11,4 @@ export default path => {
     }
     path.skip();
   }
-  path.state = {
-    templates: [],
-    events: new Set()
-  }
 };

--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/template.js
@@ -18,7 +18,10 @@ export function createTemplate(path, result) {
     template = t.arrayExpression(strings);
   }
 
-  const found = path.state.templates.find(tmp => {
+  const templates =
+      path.scope.getProgramParent().data.templates ||
+      (path.scope.getProgramParent().data.templates = []);
+  const found = templates.find(tmp => {
     if (t.isArrayExpression(tmp[1]) && t.isArrayExpression(template)) {
       return tmp[1].elements.every(
         (el, i) => template.elements[i] && el.value === template.elements[i].value
@@ -28,7 +31,7 @@ export function createTemplate(path, result) {
   });
   if (!found) {
     id = path.scope.generateUidIdentifier("tmpl$");
-    path.state.templates.push([id, template]);
+    templates.push([id, template]);
   } else id = found[0];
 
   return t.callExpression(


### PR DESCRIPTION
In 86c9ff1, state for templates and events was moved from `path.scope.data` to `path.state`. Newer versions of babel have a bug with the way that `TraversalContext`s are tracked and it can cause `path.state` to be clobbered. This issue manifests itself when other babel plugins (notably `@babel/plugin-proposal-class-properties`) are used that visit the same AST nodes. This pull request moves template and events state back to `path.scope.data`.

The issue seems to have first occurred after this https://github.com/babel/babel/pull/12302
I believe this unfinished PR will fix the `TraversalContext` bug https://github.com/babel/babel/pull/12634
