### PR TITLE
Add setAttributesWrapper and dynamicExpressionWrapper config options

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/config.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/config.js
@@ -8,5 +8,7 @@ export default {
   requireImportSource: false,
   wrapConditionals: true,
   contextToCustomElements: false,
-  staticMarker: "@once"
+  staticMarker: "@once",
+  setAttributesWrapper: "effect",
+  dynamicExpressionWrapper: "memo",
 };

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -437,7 +437,7 @@ function transformAttributes(path, results) {
             }
           }
         } else if (
-          isDynamic(attribute.get("value").get("expression"), {
+          config.setAttributesWrapper && isDynamic(attribute.get("value").get("expression"), {
             checkMember: true
           })
         ) {

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
@@ -28,9 +28,9 @@ export function createTemplate(path, result, wrap) {
       );
     }
   }
-  if (wrap && result.dynamic) {
-    registerImportMethod(path, "memo");
-    return t.callExpression(t.identifier("_$memo"), [result.exprs[0]]);
+  if (wrap && result.dynamic && config.dynamicExpressionWrapper) {
+    registerImportMethod(path, config.dynamicExpressionWrapper);
+    return t.callExpression(t.identifier(`_$${config.dynamicExpressionWrapper}`), [result.exprs[0]]);
   }
   return result.exprs[0];
 }
@@ -94,14 +94,18 @@ function registerTemplate(path, results) {
 
 function wrapDynamics(path, dynamics) {
   if (!dynamics.length) return;
-  registerImportMethod(path, "effect");
+  registerImportMethod(path, config.setAttributesWrapper);
+
+  const setAttributesWrapperId = `_$${config.setAttributesWrapper}`;
+
   if (dynamics.length === 1) {
     const prevValue =
       dynamics[0].key === "classList" || dynamics[0].key === "style"
         ? t.identifier("_$p")
         : undefined;
+
     return t.expressionStatement(
-      t.callExpression(t.identifier("_$effect"), [
+      t.callExpression(t.identifier(setAttributesWrapperId), [
         t.arrowFunctionExpression(
           prevValue ? [prevValue] : [],
           setAttr(
@@ -159,7 +163,7 @@ function wrapDynamics(path, dynamics) {
   });
 
   return t.expressionStatement(
-    t.callExpression(t.identifier("_$effect"), [
+    t.callExpression(t.identifier(setAttributesWrapperId), [
       t.arrowFunctionExpression(
         [prevId],
         t.blockStatement([

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -152,7 +152,9 @@ export function toPropertyName(name) {
 
 export function transformCondition(path, deep) {
   const expr = path.node;
-  registerImportMethod(path, "memo");
+  if (config.dynamicExpressionWrapper) {
+    registerImportMethod(path, config.dynamicExpressionWrapper);
+  }
   let dTest, cond, id;
   if (
     t.isConditionalExpression(expr) &&
@@ -198,10 +200,12 @@ export function transformCondition(path, deep) {
       t.variableDeclaration("const", [
         t.variableDeclarator(
           id,
-          t.callExpression(t.identifier("_$memo"), [
-            t.arrowFunctionExpression([], cond),
-            t.booleanLiteral(true)
-          ])
+          config.dynamicExpressionWrapper
+            ? t.callExpression(t.identifier(`_$${config.dynamicExpressionWrapper}`), [
+                t.arrowFunctionExpression([], cond),
+                t.booleanLiteral(true)
+            ])
+            : t.arrowFunctionExpression([], cond)
         )
       ]),
       t.arrowFunctionExpression([], expr)

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/attributeExpressions/code.js
@@ -1,0 +1,59 @@
+const template = (
+  <div id="main" {...results} classList={{ selected: selected }} style={{ color }}>
+    <h1
+      {...results()}
+      disabled
+      title={welcoming()}
+      style={{ "background-color": color(), "margin-right": "40px" }}
+      classList={{ selected: selected() }}
+    >
+      <a href={"/"} ref={link}>
+        Welcome
+      </a>
+    </h1>
+  </div>
+);
+
+const template2 = (
+  <div>
+    <div textContent={rowId} />
+    <div textContent={row.label} />
+  </div>
+);
+
+const template3 = (
+  <div
+    id={/*@once*/ state.id}
+    style={/*@once*/ { "background-color": state.color }}
+    name={state.name}
+    textContent={/*@once*/ state.content}
+  />
+);
+
+const template4 = <div class="hi" className={state.class} />;
+
+const template5 = <div class="a" className="b"></div>;
+
+const template6 = <div style={someStyle()} textContent="Hi" />;
+
+const template7 = (
+  <div
+    style={{ "background-color": color(), "margin-right": "40px", ...props.style }}
+    style:padding-top={props.top}
+  />
+);
+
+let refTarget;
+const template8 = <div ref={refTarget} />;
+
+const template9 = <div ref={e => console.log(e)} />;
+
+const template10 = <div ref={refFactory()} />;
+
+const template11 = <div use:something use:another={thing} />;
+
+const template12 = <div prop:htmlFor={thing} />;
+
+const template13 = <input type="checkbox" checked={true} />;
+
+const template14 = <input type="checkbox" checked={state.visible} />;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/attributeExpressions/output.js
@@ -1,0 +1,167 @@
+import { template as _$template } from "r-dom";
+import { style as _$style } from "r-dom";
+import { setAttribute as _$setAttribute } from "r-dom";
+import { classList as _$classList } from "r-dom";
+import { spread as _$spread } from "r-dom";
+
+const _tmpl$ = _$template(`<div id="main"><h1 disabled=""><a href="/">Welcome</a></h1></div>`, 6),
+  _tmpl$2 = _$template(`<div><div></div><div></div></div>`, 6),
+  _tmpl$3 = _$template(`<div></div>`, 2),
+  _tmpl$4 = _$template(`<input type="checkbox">`, 1);
+
+const template = (() => {
+  const _el$ = _tmpl$.cloneNode(true),
+    _el$2 = _el$.firstChild,
+    _el$3 = _el$2.firstChild;
+
+  _$spread(_el$, results, false, true);
+
+  _$classList(_el$, {
+    selected: selected
+  });
+
+  _el$.style.setProperty("color", color);
+
+  _$spread(_el$2, () => results(), false, true);
+
+  _$setAttribute(_el$2, "title", welcoming());
+
+  _el$2.style.setProperty("background-color", color());
+
+  _el$2.style.setProperty("margin-right", "40px");
+
+  _$classList(_el$2, {
+    selected: selected()
+  });
+
+  const _ref$ = link;
+  typeof _ref$ === "function" ? _ref$(_el$3) : (link = _el$3);
+  return _el$;
+})();
+
+const template2 = (() => {
+  const _el$4 = _tmpl$2.cloneNode(true),
+    _el$5 = _el$4.firstChild,
+    _el$6 = _el$5.nextSibling;
+
+  _el$5.textContent = rowId;
+  _el$6.textContent = row.label;
+  return _el$4;
+})();
+
+const template3 = (() => {
+  const _el$7 = _tmpl$3.cloneNode(true);
+
+  _$setAttribute(
+    _el$7,
+    "id",
+    /*@once*/
+    state.id
+  );
+
+  _el$7.style.setProperty(
+    "background-color",
+    /*@once*/
+    state.color
+  );
+
+  _$setAttribute(_el$7, "name", state.name);
+
+  _el$7.textContent =
+    /*@once*/
+    state.content;
+  return _el$7;
+})();
+
+const template4 = (() => {
+  const _el$8 = _tmpl$3.cloneNode(true);
+
+  _el$8.className = `hi ${state.class || ""}`;
+  return _el$8;
+})();
+
+const template5 = (() => {
+  const _el$9 = _tmpl$3.cloneNode(true);
+
+  _el$9.className = `a  b`;
+  return _el$9;
+})();
+
+const template6 = (() => {
+  const _el$10 = _tmpl$3.cloneNode(true);
+
+  _$style(_el$10, someStyle());
+
+  _el$10.textContent = "Hi";
+  return _el$10;
+})();
+
+const template7 = (() => {
+  const _el$11 = _tmpl$3.cloneNode(true);
+
+  _$style(_el$11, {
+    "background-color": color(),
+    "margin-right": "40px",
+    ...props.style
+  });
+
+  _el$11.style.setProperty("padding-top", props.top);
+
+  return _el$11;
+})();
+
+let refTarget;
+
+const template8 = (() => {
+  const _el$12 = _tmpl$3.cloneNode(true);
+
+  const _ref$2 = refTarget;
+  typeof _ref$2 === "function" ? _ref$2(_el$12) : (refTarget = _el$12);
+  return _el$12;
+})();
+
+const template9 = (() => {
+  const _el$13 = _tmpl$3.cloneNode(true);
+
+  (e => console.log(e))(_el$13);
+
+  return _el$13;
+})();
+
+const template10 = (() => {
+  const _el$14 = _tmpl$3.cloneNode(true);
+
+  const _ref$3 = refFactory();
+
+  typeof _ref$3 === "function" && _ref$3(_el$14);
+  return _el$14;
+})();
+
+const template11 = (() => {
+  const _el$15 = _tmpl$3.cloneNode(true);
+
+  another(_el$15, () => thing);
+  something(_el$15, () => true);
+  return _el$15;
+})();
+
+const template12 = (() => {
+  const _el$16 = _tmpl$3.cloneNode(true);
+
+  _el$16.htmlFor = thing;
+  return _el$16;
+})();
+
+const template13 = (() => {
+  const _el$17 = _tmpl$4.cloneNode(true);
+
+  _el$17.checked = true;
+  return _el$17;
+})();
+
+const template14 = (() => {
+  const _el$18 = _tmpl$4.cloneNode(true);
+
+  _el$18.checked = state.visible;
+  return _el$18;
+})();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/code.js
@@ -1,0 +1,124 @@
+import { Show } from "somewhere"
+
+const Child = props => (
+  <>
+    <div ref={props.ref}>Hello {props.name}</div>
+    <div>{props.children}</div>
+  </>
+);
+
+const template = props => {
+  let childRef;
+  const { content } = props;
+  return (
+    <div>
+      <Child name="John" {...props} ref={childRef} booleanProperty>
+        <div>From Parent</div>
+      </Child>
+      <Child name="Jason" {...dynamicSpread()} ref={props.ref}>
+        {/* Comment Node */}
+        <div>{content}</div>
+      </Child>
+      <Context.Consumer ref={props.consumerRef()}>{context => context}</Context.Consumer>
+    </div>
+  );
+};
+
+const template2 = (
+  <Child
+    name="Jake"
+    dynamic={state.data}
+    stale={/*@once*/ state.data}
+    handleClick={clickHandler}
+    hyphen-ated={state.data}
+    ref={el => (e = el)}
+  />
+);
+
+const template3 = (
+  <Child>
+    <div />
+    <div />
+    <div />
+    After
+  </Child>
+);
+
+const template4 = <Child>{<div />}</Child>;
+
+const template5 = <Child dynamic={state.dynamic}>{state.dynamic}</Child>;
+
+// builtIns
+const template6 = (
+  <For each={state.list} fallback={<Loading />}>
+    {item => <Show when={state.condition}>{item}</Show>}
+  </For>
+);
+
+const template7 = (
+  <Child>
+    <div />
+    {state.dynamic}
+  </Child>
+);
+
+const template8 = (
+  <Child>
+    {item => item}
+    {item => item}
+  </Child>
+);
+
+const template9 = <_garbage>Hi</_garbage>;
+
+const template10 = (
+  <div>
+    <Link>new</Link>
+    {" | "}
+    <Link>comments</Link>
+    {" | "}
+    <Link>show</Link>
+    {" | "}
+    <Link>ask</Link>
+    {" | "}
+    <Link>jobs</Link>
+    {" | "}
+    <Link>submit</Link>
+  </div>
+);
+
+const template11 = (
+  <div>
+    <Link>new</Link>
+    {" | "}
+    <Link>comments</Link>
+    <Link>show</Link>
+    {" | "}
+    <Link>ask</Link>
+    <Link>jobs</Link>
+    {" | "}
+    <Link>submit</Link>
+  </div>
+);
+
+const template12 = (
+  <div>
+    {" | "}
+    <Link>comments</Link>
+    {" | "}
+    {" | "}
+    {" | "}
+    <Link>show</Link>
+    {" | "}
+  </div>
+);
+
+class Template13 {
+  render() {
+    <Component prop={this.something}>
+      <Nested prop={this.data}>{this.content}</Nested>
+    </Component>;
+  }
+}
+
+const Template14 = <Component>{data()}</Component>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
@@ -1,0 +1,366 @@
+import { template as _$template } from "r-dom";
+import { For as _$For } from "r-dom";
+import { createComponent as _$createComponent } from "r-dom";
+import { mergeProps as _$mergeProps } from "r-dom";
+import { insert as _$insert } from "r-dom";
+
+const _tmpl$ = _$template(`<div>Hello </div>`, 2),
+  _tmpl$2 = _$template(`<div></div>`, 2),
+  _tmpl$3 = _$template(`<div>From Parent</div>`, 2),
+  _tmpl$4 = _$template(`<div> | <!> | <!> | <!> | <!> | </div>`, 6),
+  _tmpl$5 = _$template(`<div> | <!> | <!> | </div>`, 4),
+  _tmpl$6 = _$template(`<div> | <!> |  |  | <!> | </div>`, 4);
+
+import { Show } from "somewhere";
+
+const Child = props => [
+  (() => {
+    const _el$ = _tmpl$.cloneNode(true),
+      _el$2 = _el$.firstChild;
+
+    const _ref$ = props.ref;
+    typeof _ref$ === "function" ? _ref$(_el$) : (props.ref = _el$);
+
+    _$insert(_el$, () => props.name, null);
+
+    return _el$;
+  })(),
+  (() => {
+    const _el$3 = _tmpl$2.cloneNode(true);
+
+    _$insert(_el$3, () => props.children);
+
+    return _el$3;
+  })()
+];
+
+const template = props => {
+  let childRef;
+  const { content } = props;
+  return (() => {
+    const _el$4 = _tmpl$2.cloneNode(true);
+
+    _$insert(
+      _el$4,
+      _$createComponent(
+        Child,
+        _$mergeProps(
+          {
+            name: "John"
+          },
+          props,
+          {
+            ref(r$) {
+              const _ref$2 = childRef;
+              typeof _ref$2 === "function" ? _ref$2(r$) : (childRef = r$);
+            },
+
+            booleanProperty: true,
+
+            get children() {
+              return _tmpl$3.cloneNode(true);
+            }
+          }
+        )
+      ),
+      null
+    );
+
+    _$insert(
+      _el$4,
+      _$createComponent(
+        Child,
+        _$mergeProps(
+          {
+            name: "Jason"
+          },
+          dynamicSpread(),
+          {
+            ref(r$) {
+              const _ref$3 = props.ref;
+              typeof _ref$3 === "function" ? _ref$3(r$) : (props.ref = r$);
+            },
+
+            get children() {
+              const _el$6 = _tmpl$2.cloneNode(true);
+
+              _$insert(_el$6, content);
+
+              return _el$6;
+            }
+          }
+        )
+      ),
+      null
+    );
+
+    _$insert(
+      _el$4,
+      _$createComponent(Context.Consumer, {
+        ref(r$) {
+          const _ref$4 = props.consumerRef();
+
+          typeof _ref$4 === "function" && _ref$4(r$);
+        },
+
+        children: context => context
+      }),
+      null
+    );
+
+    return _el$4;
+  })();
+};
+
+const template2 = _$createComponent(Child, {
+  name: "Jake",
+
+  get dynamic() {
+    return state.data;
+  },
+
+  stale: state.data,
+  handleClick: clickHandler,
+
+  get ["hyphen-ated"]() {
+    return state.data;
+  },
+
+  ref: el => (e = el)
+});
+
+const template3 = _$createComponent(Child, {
+  get children() {
+    return [_tmpl$2.cloneNode(true), _tmpl$2.cloneNode(true), _tmpl$2.cloneNode(true), "After"];
+  }
+});
+
+const template4 = _$createComponent(Child, {
+  get children() {
+    return _tmpl$2.cloneNode(true);
+  }
+});
+
+const template5 = _$createComponent(Child, {
+  get dynamic() {
+    return state.dynamic;
+  },
+
+  get children() {
+    return state.dynamic;
+  }
+}); // builtIns
+
+const template6 = _$createComponent(_$For, {
+  get each() {
+    return state.list;
+  },
+
+  get fallback() {
+    return _$createComponent(Loading, {});
+  },
+
+  children: item =>
+    _$createComponent(Show, {
+      get when() {
+        return state.condition;
+      },
+
+      children: item
+    })
+});
+
+const template7 = _$createComponent(Child, {
+  get children() {
+    return [_tmpl$2.cloneNode(true), () => state.dynamic];
+  }
+});
+
+const template8 = _$createComponent(Child, {
+  get children() {
+    return [item => item, item => item];
+  }
+});
+
+const template9 = _$createComponent(_garbage, {
+  children: "Hi"
+});
+
+const template10 = (() => {
+  const _el$12 = _tmpl$4.cloneNode(true),
+    _el$13 = _el$12.firstChild,
+    _el$18 = _el$13.nextSibling,
+    _el$14 = _el$18.nextSibling,
+    _el$19 = _el$14.nextSibling,
+    _el$15 = _el$19.nextSibling,
+    _el$20 = _el$15.nextSibling,
+    _el$16 = _el$20.nextSibling,
+    _el$21 = _el$16.nextSibling,
+    _el$17 = _el$21.nextSibling;
+
+  _$insert(
+    _el$12,
+    _$createComponent(Link, {
+      children: "new"
+    }),
+    _el$13
+  );
+
+  _$insert(
+    _el$12,
+    _$createComponent(Link, {
+      children: "comments"
+    }),
+    _el$18
+  );
+
+  _$insert(
+    _el$12,
+    _$createComponent(Link, {
+      children: "show"
+    }),
+    _el$19
+  );
+
+  _$insert(
+    _el$12,
+    _$createComponent(Link, {
+      children: "ask"
+    }),
+    _el$20
+  );
+
+  _$insert(
+    _el$12,
+    _$createComponent(Link, {
+      children: "jobs"
+    }),
+    _el$21
+  );
+
+  _$insert(
+    _el$12,
+    _$createComponent(Link, {
+      children: "submit"
+    }),
+    null
+  );
+
+  return _el$12;
+})();
+
+const template11 = (() => {
+  const _el$22 = _tmpl$5.cloneNode(true),
+    _el$23 = _el$22.firstChild,
+    _el$26 = _el$23.nextSibling,
+    _el$24 = _el$26.nextSibling,
+    _el$27 = _el$24.nextSibling,
+    _el$25 = _el$27.nextSibling;
+
+  _$insert(
+    _el$22,
+    _$createComponent(Link, {
+      children: "new"
+    }),
+    _el$23
+  );
+
+  _$insert(
+    _el$22,
+    _$createComponent(Link, {
+      children: "comments"
+    }),
+    _el$26
+  );
+
+  _$insert(
+    _el$22,
+    _$createComponent(Link, {
+      children: "show"
+    }),
+    _el$26
+  );
+
+  _$insert(
+    _el$22,
+    _$createComponent(Link, {
+      children: "ask"
+    }),
+    _el$27
+  );
+
+  _$insert(
+    _el$22,
+    _$createComponent(Link, {
+      children: "jobs"
+    }),
+    _el$27
+  );
+
+  _$insert(
+    _el$22,
+    _$createComponent(Link, {
+      children: "submit"
+    }),
+    null
+  );
+
+  return _el$22;
+})();
+
+const template12 = (() => {
+  const _el$28 = _tmpl$6.cloneNode(true),
+    _el$29 = _el$28.firstChild,
+    _el$34 = _el$29.nextSibling,
+    _el$30 = _el$34.nextSibling,
+    _el$35 = _el$30.nextSibling,
+    _el$33 = _el$35.nextSibling;
+
+  _$insert(
+    _el$28,
+    _$createComponent(Link, {
+      children: "comments"
+    }),
+    _el$34
+  );
+
+  _$insert(
+    _el$28,
+    _$createComponent(Link, {
+      children: "show"
+    }),
+    _el$35
+  );
+
+  return _el$28;
+})();
+
+class Template13 {
+  render() {
+    const _self$ = this;
+
+    _$createComponent(Component, {
+      get prop() {
+        return _self$.something;
+      },
+
+      get children() {
+        return _$createComponent(Nested, {
+          get prop() {
+            return _self$.data;
+          },
+
+          get children() {
+            return _self$.content;
+          }
+        });
+      }
+    });
+  }
+}
+
+const Template14 = _$createComponent(Component, {
+  get children() {
+    return data();
+  }
+});

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/conditionalExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/conditionalExpressions/code.js
@@ -1,0 +1,47 @@
+const template1 = <div>{simple}</div>;
+
+const template2 = <div>{state.dynamic}</div>;
+
+const template3 = <div>{simple ? good : bad}</div>;
+
+const template4 = <div>{simple ? good() : bad}</div>
+
+const template5 = <div>{state.dynamic ? good() : bad}</div>;
+
+const template6 = <div>{state.dynamic && good()}</div>;
+
+const template7 = (
+  <div>{state.count > 5 ? (state.dynamic ? best : good()) : bad}</div>
+);
+
+const template8 = <div>{state.dynamic && state.something && good()}</div>;
+
+const template9 = <div>{(state.dynamic && good()) || bad}</div>;
+
+const template10 = (
+  <div>{state.a ? "a" : state.b ? "b" : state.c ? "c" : "fallback"}</div>
+);
+
+const template11 = (
+  <div>{state.a ? a() : state.b ? b() : state.c ? "c" : "fallback"}</div>
+);
+
+const template12 = <Comp render={state.dynamic ? good() : bad} />;
+
+// no dynamic predicate
+const template13 = <Comp render={state.dynamic ? good : bad} />;
+
+const template14 = <Comp render={state.dynamic && good()} />;
+
+// no dynamic predicate
+const template15 = <Comp render={state.dynamic && good} />;
+
+const template16 = <Comp render={state.dynamic || good()} />;
+
+const template17 = <Comp render={state.dynamic ? <Comp/> : <Comp/>} />;
+
+const template18 = <Comp>{state.dynamic ? <Comp/> : <Comp/>}</Comp>;
+
+const template19 = <div innerHTML={state.dynamic ? <Comp/> : <Comp/>} />;
+
+const template20 = <div>{state.dynamic ? <Comp/> : <Comp/>}</div>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/conditionalExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/conditionalExpressions/output.js
@@ -1,0 +1,152 @@
+import { template as _$template } from "r-dom";
+import { createComponent as _$createComponent } from "r-dom";
+import { insert as _$insert } from "r-dom";
+
+const _tmpl$ = _$template(`<div></div>`, 2);
+
+const template1 = (() => {
+  const _el$ = _tmpl$.cloneNode(true);
+
+  _$insert(_el$, simple);
+
+  return _el$;
+})();
+
+const template2 = (() => {
+  const _el$2 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$2, () => state.dynamic);
+
+  return _el$2;
+})();
+
+const template3 = (() => {
+  const _el$3 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$3, simple ? good : bad);
+
+  return _el$3;
+})();
+
+const template4 = (() => {
+  const _el$4 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$4, () => (simple ? good() : bad));
+
+  return _el$4;
+})();
+
+const template5 = (() => {
+  const _el$5 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$5, () => (state.dynamic ? good() : bad));
+
+  return _el$5;
+})();
+
+const template6 = (() => {
+  const _el$6 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$6, () => state.dynamic && good());
+
+  return _el$6;
+})();
+
+const template7 = (() => {
+  const _el$7 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$7, () => (state.count > 5 ? (state.dynamic ? best : good()) : bad));
+
+  return _el$7;
+})();
+
+const template8 = (() => {
+  const _el$8 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$8, () => state.dynamic && state.something && good());
+
+  return _el$8;
+})();
+
+const template9 = (() => {
+  const _el$9 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$9, () => (state.dynamic && good()) || bad);
+
+  return _el$9;
+})();
+
+const template10 = (() => {
+  const _el$10 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$10, () => (state.a ? "a" : state.b ? "b" : state.c ? "c" : "fallback"));
+
+  return _el$10;
+})();
+
+const template11 = (() => {
+  const _el$11 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$11, () => (state.a ? a() : state.b ? b() : state.c ? "c" : "fallback"));
+
+  return _el$11;
+})();
+
+const template12 = _$createComponent(Comp, {
+  get render() {
+    return state.dynamic ? good() : bad;
+  }
+}); // no dynamic predicate
+
+const template13 = _$createComponent(Comp, {
+  get render() {
+    return state.dynamic ? good : bad;
+  }
+});
+
+const template14 = _$createComponent(Comp, {
+  get render() {
+    return state.dynamic && good();
+  }
+}); // no dynamic predicate
+
+const template15 = _$createComponent(Comp, {
+  get render() {
+    return state.dynamic && good;
+  }
+});
+
+const template16 = _$createComponent(Comp, {
+  get render() {
+    return state.dynamic || good();
+  }
+});
+
+const template17 = _$createComponent(Comp, {
+  get render() {
+    return state.dynamic ? _$createComponent(Comp, {}) : _$createComponent(Comp, {});
+  }
+});
+
+const template18 = _$createComponent(Comp, {
+  get children() {
+    return state.dynamic ? _$createComponent(Comp, {}) : _$createComponent(Comp, {});
+  }
+});
+
+const template19 = (() => {
+  const _el$12 = _tmpl$.cloneNode(true);
+
+  _el$12.innerHTML = state.dynamic ? _$createComponent(Comp, {}) : _$createComponent(Comp, {});
+  return _el$12;
+})();
+
+const template20 = (() => {
+  const _el$13 = _tmpl$.cloneNode(true);
+
+  _$insert(_el$13, () =>
+    state.dynamic ? _$createComponent(Comp, {}) : _$createComponent(Comp, {})
+  );
+
+  return _el$13;
+})();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/fragments/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/fragments/code.js
@@ -1,0 +1,70 @@
+const multiStatic = (
+  <>
+    <div>First</div>
+    <div>Last</div>
+  </>
+);
+
+const multiExpression = (
+  <>
+    <div>First</div>
+    {inserted}
+    <div>Last</div>
+    After
+  </>
+);
+
+const multiDynamic = (
+  <>
+    <div id={state.first}>First</div>
+    {state.inserted}
+    <div id={state.last}>Last</div>
+    After
+  </>
+);
+
+const singleExpression = <>{inserted}</>;
+
+const singleDynamic = <>{inserted()}</>;
+
+const firstStatic = (
+  <>
+    {inserted}
+    <div />
+  </>
+);
+
+const firstDynamic = (
+  <>
+    {inserted()}
+    <div />
+  </>
+);
+
+const firstComponent = (
+  <>
+    <Component />
+    <div />
+  </>
+);
+
+const lastStatic = (
+  <>
+    <div />
+    {inserted}
+  </>
+);
+
+const lastDynamic = (
+  <>
+    <div />
+    {inserted()}
+  </>
+);
+
+const lastComponent = (
+  <>
+    <div />
+    <Component />
+  </>
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/fragments/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/fragments/output.js
@@ -1,0 +1,36 @@
+import { template as _$template } from "r-dom";
+import { createComponent as _$createComponent } from "r-dom";
+import { setAttribute as _$setAttribute } from "r-dom";
+
+const _tmpl$ = _$template(`<div>First</div>`, 2),
+  _tmpl$2 = _$template(`<div>Last</div>`, 2),
+  _tmpl$3 = _$template(`<div></div>`, 2);
+
+const multiStatic = [_tmpl$.cloneNode(true), _tmpl$2.cloneNode(true)];
+const multiExpression = [_tmpl$.cloneNode(true), inserted, _tmpl$2.cloneNode(true), "After"];
+const multiDynamic = [
+  (() => {
+    const _el$5 = _tmpl$.cloneNode(true);
+
+    _$setAttribute(_el$5, "id", state.first);
+
+    return _el$5;
+  })(),
+  () => state.inserted,
+  (() => {
+    const _el$6 = _tmpl$2.cloneNode(true);
+
+    _$setAttribute(_el$6, "id", state.last);
+
+    return _el$6;
+  })(),
+  "After"
+];
+const singleExpression = inserted;
+const singleDynamic = inserted;
+const firstStatic = [inserted, _tmpl$3.cloneNode(true)];
+const firstDynamic = [inserted, _tmpl$3.cloneNode(true)];
+const firstComponent = [_$createComponent(Component, {}), _tmpl$3.cloneNode(true)];
+const lastStatic = [_tmpl$3.cloneNode(true), inserted];
+const lastDynamic = [_tmpl$3.cloneNode(true), inserted];
+const lastComponent = [_tmpl$3.cloneNode(true), _$createComponent(Component, {})];

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-wrapperless.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-wrapperless.spec.js
@@ -1,0 +1,19 @@
+const path = require('path')
+const pluginTester = require('babel-plugin-tester').default;
+const plugin = require('../index');
+
+pluginTester({
+  plugin,
+  pluginOptions: {
+    moduleName: 'r-dom',
+    builtIns: ['For', 'Show'],
+    generate: "dom",
+    wrapConditionals: false,
+    delegateEvents: false,
+    setAttributesWrapper: false,
+    dynamicExpressionWrapper: false,
+  },
+  title: 'Convert JSX',
+  fixtures: path.join(__dirname, '__dom_wrapperless_fixtures__'),
+  snapshot: true
+});


### PR DESCRIPTION
This generalizes babel-plugin-jsx-dom-expressions generated calls to `effect()` and `memo()`. The function names are now configurable with new options `setAttributesWrapper` (effect) and `dynamicExpressionWrapper` (memo). The plugin behavior is unchanged when the default options are used. Additionally, either option can be set to `false`, which will essentially treat expressions as if they were static and won't wrap them. 

The use case for setting the new options to `false` is to use babel-plugin-jsx-dom-expressions with a wrapperless non-reactive runtime.

I've copied a subset of relevant tests from `dom.spec.js` to `dom-wrapperless.spec.js` with the new options set to false.