### PR TITLE
Fix inaccurate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ function memo(fn, equal) {
   return s;
 }
 
-function createComponent(Comp, props, dynamicKeys) {
+function createComponent(Comp, props) {
   return sample(() => Comp(props));
 }
 

--- a/packages/dom-expressions/README.md
+++ b/packages/dom-expressions/README.md
@@ -55,7 +55,7 @@ function memo(fn, equal) {
   return s;
 }
 
-function createComponent(Comp, props, dynamicKeys) {
+function createComponent(Comp, props) {
   return sample(() => Comp(props));
 }
 


### PR DESCRIPTION
The `createComponent()` examples in the documentation have an unused argument `dynamicKeys`. `babel-plugin-jsx-dom-expressions` doesn't generate any calls to createComponent with this argument. I'm assuming this is from an old version.