### PR TITLE
Improve some typings

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1715,17 +1715,17 @@ export namespace JSX {
      * Defines the total number of columns in a table, grid, or treegrid.
      * @see aria-colindex.
      */
-    "aria-colcount"?: number;
+    "aria-colcount"?: number | string;
     /**
      * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
      * @see aria-colcount @see aria-colspan.
      */
-    "aria-colindex"?: number;
+    "aria-colindex"?: number | string;
     /**
      * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-colindex @see aria-rowspan.
      */
-    "aria-colspan"?: number;
+    "aria-colspan"?: number | string;
     /**
      * Identifies the element (or elements) whose contents or presence are controlled by the current element.
      * @see aria-owns.
@@ -1795,7 +1795,7 @@ export namespace JSX {
      */
     "aria-labelledby"?: string;
     /** Defines the hierarchical level of an element within a structure. */
-    "aria-level"?: number;
+    "aria-level"?: number | string;
     /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
     "aria-live"?: "off" | "assertive" | "polite";
     /** Indicates whether an element is modal when displayed. */
@@ -1821,7 +1821,7 @@ export namespace JSX {
      * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-setsize.
      */
-    "aria-posinset"?: number;
+    "aria-posinset"?: number | string;
     /**
      * Indicates the current "pressed" state of toggle buttons.
      * @see aria-checked @see aria-selected.
@@ -1855,17 +1855,17 @@ export namespace JSX {
      * Defines the total number of rows in a table, grid, or treegrid.
      * @see aria-rowindex.
      */
-    "aria-rowcount"?: number;
+    "aria-rowcount"?: number | string;
     /**
      * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
      * @see aria-rowcount @see aria-rowspan.
      */
-    "aria-rowindex"?: number;
+    "aria-rowindex"?: number | string;
     /**
      * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-rowindex @see aria-colspan.
      */
-    "aria-rowspan"?: number;
+    "aria-rowspan"?: number | string;
     /**
      * Indicates the current "selected" state of various widgets.
      * @see aria-checked @see aria-pressed.
@@ -1875,18 +1875,18 @@ export namespace JSX {
      * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-posinset.
      */
-    "aria-setsize"?: number;
+    "aria-setsize"?: number | string;
     /** Indicates if items in a table or grid are sorted in ascending or descending order. */
     "aria-sort"?: "none" | "ascending" | "descending" | "other";
     /** Defines the maximum allowed value for a range widget. */
-    "aria-valuemax"?: number;
+    "aria-valuemax"?: number | string;
     /** Defines the minimum allowed value for a range widget. */
-    "aria-valuemin"?: number;
+    "aria-valuemin"?: number | string;
     /**
      * Defines the current value for a range widget.
      * @see aria-valuetext.
      */
-    "aria-valuenow"?: number;
+    "aria-valuenow"?: number | string;
     /** Defines the human readable text alternative of aria-valuenow for a range widget. */
     "aria-valuetext"?: string;
   }
@@ -2363,6 +2363,7 @@ export namespace JSX {
     rowspan?: number | string;
     colSpan?: number | string;
     rowSpan?: number | string;
+    scope?: 'col' | 'row' | 'rowgroup' | 'colgroup';
   }
   interface TimeHTMLAttributes<T> extends HTMLAttributes<T> {
     datetime?: string;


### PR DESCRIPTION
- All the `aria-*` should accept string as they are HTML attributes and HTML attributes only accept strings.
- Adding `scope` attribute for `th` as per [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)