### PR TITLE
Adding missing `href` attribute to `UseSVGAttributes`

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -3173,6 +3173,7 @@ export namespace JSX {
     y?: number | string;
     width?: number | string;
     height?: number | string;
+    href?: string;
   }
   interface ViewSVGAttributes<T>
     extends CoreSVGAttributes<T>,


### PR DESCRIPTION
As per the list of attributes defined here: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#attributes