### PR TITLE
Make TS user friendly with custom tags and attributes

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -75,7 +75,7 @@ export namespace JSX {
   type OnCaptureAttributes<T> = {
     [Key in keyof CustomEvents as `oncapture:${Key}`]?: EventHandler<T, CustomEvents[Key]>;
   }
-  interface DOMAttributes<T> extends CustomAttributes<T>, ActionAttributes, PropAttributes, AttrAttributes, OnAttributes<T>, OnCaptureAttributes<T>, Record<string, any> {
+  interface DOMAttributes<T> extends CustomAttributes<T>, DirectiveAttributes, PropAttributes, AttrAttributes, OnAttributes<T>, OnCaptureAttributes<T>, Record<string, any> {
     children?: Element;
     innerHTML?: string;
     innerText?: string;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -75,7 +75,7 @@ export namespace JSX {
   type OnCaptureAttributes<T> = {
     [Key in keyof CustomEvents as `oncapture:${Key}`]?: EventHandler<T, CustomEvents[Key]>;
   }
-  interface DOMAttributes<T> extends CustomAttributes<T>, DirectiveAttributes, PropAttributes, AttrAttributes, OnAttributes<T>, OnCaptureAttributes<T> {
+  interface DOMAttributes<T> extends CustomAttributes<T>, ActionAttributes, PropAttributes, AttrAttributes, OnAttributes<T>, OnCaptureAttributes<T>, Record<string, any> {
     children?: Element;
     innerHTML?: string;
     innerText?: string;
@@ -256,7 +256,7 @@ export namespace JSX {
   type CSSWideKeyword = "initial" | "inherit" | "unset";
   type CSSPercentage = string;
   type CSSLength = number | string;
-  interface CSSProperties {
+  interface CSSProperties extends Record<string, any> {
     /**
      * Aligns a flex container's lines within the flex container when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.
      */
@@ -1895,7 +1895,7 @@ export namespace JSX {
     "aria-valuetext"?: string;
   }
 
-  interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+  interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T>, Record<string, any> {
     accessKey?: string;
     className?: string;
     class?: string;
@@ -2601,7 +2601,8 @@ export namespace JSX {
   interface AnimationElementSVGAttributes<T>
     extends CoreSVGAttributes<T>,
       ExternalResourceSVGAttributes,
-      ConditionalProcessingSVGAttributes {}
+      ConditionalProcessingSVGAttributes,
+      Record<string, any> {}
   interface ContainerElementSVGAttributes<T>
     extends CoreSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
@@ -3187,7 +3188,7 @@ export namespace JSX {
       ZoomAndPanSVGAttributes {
     viewTarget?: string;
   }
-  interface IntrinsicElements {
+  interface IntrinsicElements extends Record<string, HTMLAttributes<any>> {
     a: AnchorHTMLAttributes<HTMLAnchorElement>;
     abbr: HTMLAttributes<HTMLElement>;
     address: HTMLAttributes<HTMLElement>;


### PR DESCRIPTION
This PR aims to make typescript way less in the way.

Instead of having to maintain a bazillion of different use case, this allows us to use what already exist and default to `any` for the rest (custom attributes, tags, etc..)

Before merging it could be interesting to have @trusktr opinion, but from my POV, this would allow us to have a break with TS when 1.0 launch.

---

The origin of this is the recent release of windicss 3.0, which added custom attributes to style your markup https://windicss.org/posts/attributify.html. I expect people bumping into using `tsx` files and wondering why TS is all over them because they use custom attributes such as `div text="green-500`.

This also allows for custom element to at least not yield an error. It won't be typed but at least they will be usable.