### PR TITLE
Fix events firing on disabled elements

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -297,7 +297,7 @@ function eventHandler(e) {
 
   while (node !== null) {
     const handler = node[key];
-    if (handler) {
+    if (handler && !node.disabled) {
       const data = node[`${key}Data`];
       data !== undefined ? handler(data, e) : handler(e);
       if (e.cancelBubble) return;


### PR DESCRIPTION
Makes it consistent with vanilla (without event delegation) and React

https://codesandbox.io/s/xenodochial-resonance-mz4hd