### PR TITLE
add trim on toggleClassKey to support trailing/leading spaces

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -271,7 +271,7 @@ function toPropertyName(name) {
 }
 
 function toggleClassKey(node, key, value) {
-  const classNames = key.split(/\s+/);
+  const classNames = key.trim().split(/\s+/);
   for (let i = 0, nameLen = classNames.length; i < nameLen; i++)
     node.classList.toggle(classNames[i], value);
 }

--- a/packages/dom-expressions/test/classList.spec.jsx
+++ b/packages/dom-expressions/test/classList.spec.jsx
@@ -38,4 +38,12 @@ describe("Test classList binding", () => {
       expect(div.className).toBe("");
     });
   });
+
+  test("With leading/trailing spaces", () => {
+    let div;
+    S.root(() => {
+      div = <div classList={{ " color ": S.data(true) }} />;
+      expect(div.className).toBe("color");
+    });
+  });
 });


### PR DESCRIPTION
This PR should fix #77 by triming classes before toggling in `toggleClassKey`