### PR TITLE
add missing "meter" role

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1958,6 +1958,7 @@ export namespace JSX {
       | "menuitem"
       | "menuitemcheckbox"
       | "menuitemradio"
+      | "meter"
       | "navigation"
       | "none"
       | "note"


### PR DESCRIPTION
The `role="meter"` is woefully underused, for example for amplitude visualization or password strength - and even missing here. More under: https://w3c.github.io/aria-practices/examples/meter/meter.html