### PR TITLE
Handle white-space-only text correctly, fixes solidjs issue #571

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -138,6 +138,9 @@ export function checkLength(children) {
 }
 
 export function trimWhitespace(text) {
+  if (/^[\r\n\s]+$/.test(text)) {
+    return " ";
+  }
   text = text.replace(/\r/g, "");
   if (/\n/g.test(text)) {
     text = text


### PR DESCRIPTION
If a text consists only of white-space characters (worst case: `"\n"`), the return value may be an empty string, which may cause issues like in SolidJS #571 and unneccessary filtering of non-data. Detecting this case and returning a simple space character fixes both.