### PR TITLE
Fix typings for <details>

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -19,7 +19,7 @@ export namespace JSX {
   interface ArrayElement extends Array<Element> {}
   interface FunctionElement {
     (): Element;
-  }
+  
   interface ElementClass {
     render(props: any): Element;
   }
@@ -3215,7 +3215,7 @@ export namespace JSX {
     datalist: HTMLAttributes<HTMLDataListElement>;
     dd: HTMLAttributes<HTMLElement>;
     del: HTMLAttributes<HTMLElement>;
-    details: DetailsHtmlAttributes<HTMLElement>;
+    details: DetailsHtmlAttributes<HTMLDetailsElement>;
     dfn: HTMLAttributes<HTMLElement>;
     dialog: DialogHtmlAttributes<HTMLElement>;
     div: HTMLAttributes<HTMLDivElement>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -19,7 +19,7 @@ export namespace JSX {
   interface ArrayElement extends Array<Element> {}
   interface FunctionElement {
     (): Element;
-  
+  }
   interface ElementClass {
     render(props: any): Element;
   }


### PR DESCRIPTION
Typing details as DetailsHTMLAttributes<HTMLElement> will stop the open property from working correctly in typescript.