### PR TITLE
Add full functionality of `classnames` package to classList

### DIFF
--- a/packages/dom-expressions/src/client.d.ts
+++ b/packages/dom-expressions/src/client.d.ts
@@ -30,12 +30,16 @@ export function spread<T>(
 export function assign(node: Element, props: any, isSVG?: Boolean, skipChildren?: Boolean): void;
 export function setAttribute(node: Element, name: string, value: string): void;
 export function setAttributeNS(node: Element, namespace: string, name: string, value: string): void;
-export function addEventListener(node: Element, name: string, handler: () => void, delegate: boolean): void;
-export function classList(
+export function addEventListener(
   node: Element,
-  value: { [k: string]: boolean },
-  prev?: { [k: string]: boolean }
+  name: string,
+  handler: () => void,
+  delegate: boolean
 ): void;
+type ClassList =
+  | { [k: string]: boolean }
+  | (ClassList | string | number | boolean | null | undefined)[];
+export function classList(node: Element, value: ClassList, prev?: { [k: string]: boolean }): void;
 export function style(
   node: Element,
   value: { [k: string]: string },


### PR DESCRIPTION
This allows classList to accept an array of classNames, omitting falsey values (except for 0, reasoning described in comment). 

This will allow users to put optional classNames in className, and not have to worry about omitting an unset value. The following shows the common usecase of passing through a classname:
```jsx
// BEFORE
function Component({ className }) {
  return <div className={`component-class-name ${className || ""}`}> // nit: this will have an extra space and removing it is much more verbose
    ...
  </div>;
}

// AFTER
function Component({ className }) {
  return <div classList={['component-class-name', className]}>
    ...
  </div>
}
```

This is fully backwards compatible and accepts objects & nested arrays:
```jsx
function Collapsible({ className, classList }) {
  const [collapse, setCollapse] = createSignal(false);

  return <div classList={['collapsible', { collapse: collapse() }, className, classList]}>
    ...
  </div>;
}