### PR TITLE
Fix `ref` property to normalize `TsNonNullExpression` and `TsAsExpression`

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -335,7 +335,6 @@ function transformAttributes(path, results) {
       ) {
         if (key === "ref") {
           // Normalize expressions for non-null and type-as
-          console.log(value.expression);
           while (t.isTSNonNullExpression(value.expression) || t.isTSAsExpression(value.expression)) {
             value.expression = value.expression.expression;
           }

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -334,6 +334,11 @@ function transformAttributes(path, results) {
           !(t.isStringLiteral(value.expression) || t.isNumericLiteral(value.expression)))
       ) {
         if (key === "ref") {
+          // Normalize expressions for non-null and type-as
+          console.log(value.expression);
+          while (t.isTSNonNullExpression(value.expression) || t.isTSAsExpression(value.expression)) {
+            value.expression = value.expression.expression;
+          }
           if (t.isLVal(value.expression)) {
             const refIdentifier = path.scope.generateUidIdentifier("_ref$");
             results.exprs.unshift(

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -45,7 +45,7 @@ export default function transformComponent(path) {
           if (key === "ref") {
             if (config.generate === "ssr") return;
             // Normalize expressions for non-null and type-as
-            while (t.isTSNonNullExpression(value.expession) || t.isTSAsExpression(value.expression)) {
+            while (t.isTSNonNullExpression(value.expression) || t.isTSAsExpression(value.expression)) {
               value.expression = value.expression.expression;
             }
             if (t.isLVal(value.expression)) {

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -44,6 +44,10 @@ export default function transformComponent(path) {
         if (t.isJSXExpressionContainer(value))
           if (key === "ref") {
             if (config.generate === "ssr") return;
+            // Normalize expressions for non-null and type-as
+            while (t.isTSNonNullExpression(value.expession) || t.isTSAsExpression(value.expression)) {
+              value.expression = value.expression.expression;
+            }
             if (t.isLVal(value.expression)) {
               const refIdentifier = path.scope.generateUidIdentifier("_ref$");
               runningObject.push(


### PR DESCRIPTION
This PR fixes a known issue for `dom-expressions` where using non-null and type-as expressions causes `ref` property to get stripped out of the output code.

TODO
- Should I add fixtures/snapshots for the TS expressions?