### PR TITLE
fix: add quotes around attribute names which are reserved words in js

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -29,7 +29,7 @@ function convertComponentIdentifier(node) {
 
 function convertJSXIdentifier(node) {
   if (t.isJSXIdentifier(node)) {
-    if (t.isValidIdentifier(node.name, false)) {
+    if (t.isValidIdentifier(node.name)) {
       node.type = "Identifier";
     } else {
       return t.stringLiteral(node.name);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
@@ -137,3 +137,5 @@ const Template18 = <Pre>
 </Pre>
 
 const Template19 = <Component {...s.dynamic()} />
+
+const Template20 = <Component class={prop.red ? "red" : "green"} />

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -405,3 +405,9 @@ const Template18 = _$createComponent(Pre, {
 });
 
 const Template19 = _$createComponent(Component, _$mergeProps(s.dynamic));
+
+const Template20 = _$createComponent(Component, {
+  get ["class"]() {
+    return prop.red ? "red" : "green";
+  }
+});


### PR DESCRIPTION
Not sure if it was intended or not, but [this commit](https://github.com/ryansolid/dom-expressions/pull/99/commits/2b0b44d05ba2847c57fab25d1fa5ae21e21b1922) removed quotes in compiled JSX output for attribute names which are reserved words in javascript, like "class".

`get [class]()` without quotes is invalid syntax in chrome, so I think the quotes are necessary at least for the web. 

If it's ok to have quotes for all targets (ssr, universal?), the fix is pretty simple - revert `t.isValidIdentifier` call to the form it was before that commit - without the second `false` parameter.
