### PR TITLE
type(jsx): make input events' target type more specific

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -31,7 +31,7 @@ export namespace JSX {
     (
       e: E & {
         currentTarget: T;
-        target: DOMElement;
+        target: E extends InputEvent ? HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement : DOMElement;
       }
     ): void;
   }
@@ -40,7 +40,7 @@ export namespace JSX {
       data: any,
       e: E & {
         currentTarget: T;
-        target: DOMElement;
+        target: E extends InputEvent ? HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement : DOMElement;
       }
     ) => void;
     1: any;


### PR DESCRIPTION
This PR changes the type of `target` in JSX EventHandlers for input events to `HTML(Input|Select|TextArea)Element` as described in https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event

On further reading, elements with `contenteditable` or all elements when `designMode` is enabled can also be targets of an input event, which might be enough reason to close this PR. 