### PR TITLE
Add missing `onToggle` event to the `<details>` event

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -2085,6 +2085,8 @@ export namespace JSX {
   }
   interface DetailsHtmlAttributes<T> extends HTMLAttributes<T> {
     open?: boolean;
+    onToggle?: EventHandlerUnion<T, Event>;
+    ontoggle?: EventHandlerUnion<T, Event>;
   }
   interface DialogHtmlAttributes<T> extends HTMLAttributes<T> {
     open?: boolean;


### PR DESCRIPTION
The event information is found here: https://developer.mozilla.org/en-US/docs/Web/API/HTMLDetailsElement/toggle_event

It seems like react added it in a similar fashion: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L2079-L2081