### PR TITLE
DirectiveFunctions alternative for typing directives

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -57,12 +57,25 @@ export namespace JSX {
     $ServerOnly?: boolean;
   }
   interface Directives {}
+  interface DirectiveFunctions {}
   interface ExplicitProperties {}
   interface ExplicitAttributes {}
   interface CustomEvents {}
   interface CustomCaptureEvents {}
   type DirectiveAttributes = {
     [Key in keyof Directives as `use:${Key}`]?: Directives[Key];
+  };
+  type DirectiveFunctionAttributes<T> = {
+    [Key in keyof DirectiveFunctions as `use:${Key}`]?:
+      // If function has no arguments, value is arbitrary
+      Parameters<DirectiveFunctions[Key]>['length'] extends 0 ? any :
+      // Otherwise (at least one argument), check its type matches element type
+      T extends Parameters<DirectiveFunctions[Key]>[0] ? (
+        // If function has only one argument, value is arbitrary
+        Parameters<DirectiveFunctions[Key]>['length'] extends 1 ? any :
+        // Otherwise (at least two arguments), value must match second argument
+        Parameters<DirectiveFunctions[Key]>[1]
+      ) : never;
   };
   type PropAttributes = {
     [Key in keyof ExplicitProperties as `prop:${Key}`]?: ExplicitProperties[Key];
@@ -76,7 +89,7 @@ export namespace JSX {
   type OnCaptureAttributes<T> = {
     [Key in keyof CustomCaptureEvents as `oncapture:${Key}`]?: EventHandler<T, CustomCaptureEvents[Key]>;
   }
-  interface DOMAttributes<T> extends CustomAttributes<T>, DirectiveAttributes, PropAttributes, AttrAttributes, OnAttributes<T>, OnCaptureAttributes<T> {
+  interface DOMAttributes<T> extends CustomAttributes<T>, DirectiveAttributes, DirectiveFunctionAttributes<T>, PropAttributes, AttrAttributes, OnAttributes<T>, OnCaptureAttributes<T> {
     children?: Element;
     innerHTML?: string;
     innerText?: string | number;


### PR DESCRIPTION
Directives (`use:___`) normally have two arguments, first the element/component and second the value passed in as a JSX attribute. The existing `Directives` overloadable interface only allows checks the value / second argument.  This PR provides a new overloadable interface `DirectiveFunctions` checks both (when present), by specifying the entire function type.

Example usage:

```ts
function model(element: HTMLInputElement, value: Accessor<Signal<string>>) {
  const [field, setField] = value();
  createRenderEffect(() => (element.value = field()));
  element.addEventListener("input", (e) => setField(e.target.value));
}

function log(element: DOMElement) {
  console.log(element);
}

let num = 0;
function count() {
  num++;
}

function foo(comp: number, ...args: string[]) {
}

declare module "solid-js" {
  namespace JSX {
    interface DirectiveFunctions {
      model: typeof model;
      log: typeof log;
      count: typeof count;
      foo: typeof foo;
    }
  }
}

{/*good:*/}
<input use:model={createSignal('')}/>
{/*bad:*/}
<input use:model/>
<input use:model={7}/>
<div use:model={createSignal('')}/>
{/*good:*/}
<div use:count use:log/>
{/*bad:*/}
<div use:foo/>
```

Testing tips would be appreciated. My best success was `npm link`ing `dom-expressions` into itself (`npm link; npm link dom-expressions`), creating a `tsconfig.json` and `jsx-runtime.d.ts`. I eventually got roughly the above file (without SolidJS imports and replacing `module "solid-js"` with `module "dom-expressions"`) to work and succeed/fail as intended, although the error for `<div use:model={'hi'}/>` is a bit weird (it says `use:model` can only take value `undefined` in this case, corresponding to an absent optional attribute, instead of complaining about the element type).

(I also tried `npm link`ing this into `solid` and putting tests into `src/web/test`, but I got all sorts of errors when trying to run `tsc` there... )