### PR TITLE
Delegate contextmenu events

### DIFF
--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -51,6 +51,7 @@ const DelegatedEvents = new Set([
   "beforeinput",
   "click",
   "dblclick",
+  "contextmenu",
   "focusin",
   "focusout",
   "input",


### PR DESCRIPTION
Add `contextmenu` to `DelegatedEvents`.

This is a useful event for passing through Portals when doing custom context menus. 