### PR TITLE
Mark `template` as `#__PURE__` in generated code.

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
@@ -42,12 +42,16 @@ export function appendTemplates(path, templates) {
     };
     return t.variableDeclarator(
       template.id,
-      t.callExpression(
-        registerImportMethod(path, "template"),
-        [
-          t.templateLiteral([t.templateElement(tmpl, true)], []),
-          t.numericLiteral(template.elementCount)
-        ].concat(template.isSVG ? t.booleanLiteral(template.isSVG) : [])
+      t.addComment(
+        t.callExpression(
+          registerImportMethod(path, "template"),
+          [
+            t.templateLiteral([t.templateElement(tmpl, true)], []),
+            t.numericLiteral(template.elementCount)
+          ].concat(template.isSVG ? t.booleanLiteral(template.isSVG) : [])
+        ),
+        'leading',
+        '#__PURE__'
       )
     );
   });

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
@@ -5,21 +5,25 @@ import { spread as _$spread } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 import { effect as _$effect } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
     `<svg width="400" height="180"><rect stroke-width="2" x="50" y="20" rx="20" ry="20" width="150" height="150" style="fill:red;stroke:black;stroke-width:5;opacity:0.5"></rect><linearGradient gradientTransform="rotate(25)"><stop offset="0%"></stop></linearGradient></svg>`,
     8
   ),
-  _tmpl$2 = _$template(
+  _tmpl$2 = /*#__PURE__*/ _$template(
     `<svg width="400" height="180"><rect rx="20" ry="20" width="150" height="150"></rect></svg>`,
     4
   ),
-  _tmpl$3 = _$template(`<svg width="400" height="180"><rect></rect></svg>`, 4),
-  _tmpl$4 = _$template(`<svg><rect x="50" y="20" width="150" height="150"></rect></svg>`, 4, true),
-  _tmpl$5 = _$template(
+  _tmpl$3 = /*#__PURE__*/ _$template(`<svg width="400" height="180"><rect></rect></svg>`, 4),
+  _tmpl$4 = /*#__PURE__*/ _$template(
+    `<svg><rect x="50" y="20" width="150" height="150"></rect></svg>`,
+    4,
+    true
+  ),
+  _tmpl$5 = /*#__PURE__*/ _$template(
     `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><a><text x="10" y="25">MDN Web Docs</text></a></svg>`,
     6
   ),
-  _tmpl$6 = _$template(
+  _tmpl$6 = /*#__PURE__*/ _$template(
     `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><text x="10" y="25"></text></svg>`,
     4
   );

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -5,15 +5,15 @@ import { effect as _$effect } from "r-dom";
 import { classList as _$classList } from "r-dom";
 import { spread as _$spread } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
     `<div id="main"><h1 class="base selected" id="my-h1" disabled readonly=""><a href="/">Welcome</a></h1></div>`,
     6
   ),
-  _tmpl$2 = _$template(`<div><div></div><div> </div><div></div></div>`, 8),
-  _tmpl$3 = _$template(`<div></div>`, 2),
-  _tmpl$4 = _$template(`<div class="a b"></div>`, 2),
-  _tmpl$5 = _$template(`<input type="checkbox">`, 1),
-  _tmpl$6 = _$template(`<div class="\`a">\`$\`</div>`, 2);
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div></div></div>`, 8),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div class="a b"></div>`, 2),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<input type="checkbox">`, 1),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\`</div>`, 2);
 
 const selected = true;
 let id = "my-h1";

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -5,15 +5,15 @@ import { createComponent as _$createComponent } from "r-dom";
 import { mergeProps as _$mergeProps } from "r-dom";
 import { insert as _$insert } from "r-dom";
 
-const _tmpl$ = _$template(`<div>Hello </div>`, 2),
-  _tmpl$2 = _$template(`<div></div>`, 2),
-  _tmpl$3 = _$template(`<div>From Parent</div>`, 2),
-  _tmpl$4 = _$template(`<div> | <!> | <!> | <!> | <!> | </div>`, 6),
-  _tmpl$5 = _$template(`<div> | <!> | <!> | </div>`, 4),
-  _tmpl$6 = _$template(`<div> | <!> |  |  | <!> | </div>`, 4),
-  _tmpl$7 = _$template(`<span>1</span>`, 2),
-  _tmpl$8 = _$template(`<span>2</span>`, 2),
-  _tmpl$9 = _$template(`<span>3</span>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<div>Hello </div>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div>From Parent</div>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div> | <!> | <!> | <!> | <!> | </div>`, 6),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<div> | <!> | <!> | </div>`, 4),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<div> | <!> |  |  | <!> | </div>`, 4),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<span>1</span>`, 2),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<span>2</span>`, 2),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<span>3</span>`, 2);
 
 import { Show } from "somewhere";
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/conditionalExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/conditionalExpressions/output.js
@@ -4,7 +4,7 @@ import { createComponent as _$createComponent } from "r-dom";
 import { memo as _$memo } from "r-dom";
 import { insert as _$insert } from "r-dom";
 
-const _tmpl$ = _$template(`<div></div>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
 const template1 = (() => {
   const _el$ = _tmpl$.cloneNode(true);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -3,9 +3,12 @@ import { effect as _$effect } from "r-dom";
 import { getOwner as _$getOwner } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 
-const _tmpl$ = _$template(`<my-element></my-element>`, 2),
-  _tmpl$2 = _$template(`<my-element><header slot="head">Title</header></my-element>`, 4),
-  _tmpl$3 = _$template(`<slot name="head"></slot>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<my-element></my-element>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(
+    `<my-element><header slot="head">Title</header></my-element>`,
+    4
+  ),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<slot name="head"></slot>`, 2);
 
 const template = (() => {
   const _el$ = _tmpl$.cloneNode(true);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/eventExpressions/output.js
@@ -2,7 +2,7 @@ import { template as _$template } from "r-dom";
 import { delegateEvents as _$delegateEvents } from "r-dom";
 import { addEventListener as _$addEventListener } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
   `<div id="main"><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture</button></div>`,
   26
 );

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/fragments/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/fragments/output.js
@@ -4,12 +4,12 @@ import { memo as _$memo } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 import { effect as _$effect } from "r-dom";
 
-const _tmpl$ = _$template(`<div>First</div>`, 2),
-  _tmpl$2 = _$template(`<div>Last</div>`, 2),
-  _tmpl$3 = _$template(`<div></div>`, 2),
-  _tmpl$4 = _$template(`<span>1</span>`, 2),
-  _tmpl$5 = _$template(`<span>2</span>`, 2),
-  _tmpl$6 = _$template(`<span>3</span>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<div>First</div>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div>Last</div>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<span>1</span>`, 2),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<span>2</span>`, 2),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<span>3</span>`, 2);
 
 const multiStatic = [_tmpl$.cloneNode(true), _tmpl$2.cloneNode(true)];
 const multiExpression = [_tmpl$.cloneNode(true), inserted, _tmpl$2.cloneNode(true), "After"];

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/insertChildren/output.js
@@ -4,11 +4,11 @@ import { spread as _$spread } from "r-dom";
 import { insert as _$insert } from "r-dom";
 import { createComponent as _$createComponent } from "r-dom";
 
-const _tmpl$ = _$template(`<div></div>`, 2),
-  _tmpl$2 = _$template(`<module></module>`, 2),
-  _tmpl$3 = _$template(`<module>Hello</module>`, 2),
-  _tmpl$4 = _$template(`<module>Hi </module>`, 2),
-  _tmpl$5 = _$template(`<div>Test 1</div>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<module></module>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<module>Hello</module>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<module>Hi </module>`, 2),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<div>Test 1</div>`, 2);
 
 const children = _tmpl$.cloneNode(true);
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/namespaceElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/namespaceElements/output.js
@@ -1,7 +1,7 @@
 import { template as _$template } from "r-dom";
 import { createComponent as _$createComponent } from "r-dom";
 
-const _tmpl$ = _$template(`<namespace:tag></namespace:tag>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<namespace:tag></namespace:tag>`, 2);
 
 const template = _$createComponent(module.A, {});
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/simpleElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/simpleElements/output.js
@@ -1,6 +1,6 @@
 import { template as _$template } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
   `<div id="main"><style>div { color: red; }</style><h1>Welcome</h1><label for="entry">Edit:</label><input id="entry" type="text"></div>`,
   9
 );

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
@@ -2,23 +2,23 @@ import { template as _$template } from "r-dom";
 import { createComponent as _$createComponent } from "r-dom";
 import { insert as _$insert } from "r-dom";
 
-const _tmpl$ = _$template(`<span>Hello </span>`, 2),
-  _tmpl$2 = _$template(`<span> John</span>`, 2),
-  _tmpl$3 = _$template(`<span>Hello John</span>`, 2),
-  _tmpl$4 = _$template(`<span> </span>`, 2),
-  _tmpl$5 = _$template(`<span> <!> <!> </span>`, 4),
-  _tmpl$6 = _$template(`<span> <!> </span>`, 3),
-  _tmpl$7 = _$template(`<span>Hello</span>`, 2),
-  _tmpl$8 = _$template(`<span>&nbsp;&lt;Hi&gt;&nbsp;</span>`, 2),
-  _tmpl$9 = _$template(`<span>Hi&lt;script>alert();&lt;/script></span>`, 2),
-  _tmpl$10 = _$template(`<span>Hello World!</span>`, 2),
-  _tmpl$11 = _$template(`<span>4 + 5 = 9</span>`, 2),
-  _tmpl$12 = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(`<span>Hello </span>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<span> John</span>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<span>Hello John</span>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<span> </span>`, 2),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<span> <!> <!> </span>`, 4),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<span> <!> </span>`, 3),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<span>Hello</span>`, 2),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<span>&nbsp;&lt;Hi&gt;&nbsp;</span>`, 2),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<span>Hi&lt;script>alert();&lt;/script></span>`, 2),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<span>Hello World!</span>`, 2),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<span>4 + 5 = 9</span>`, 2),
+  _tmpl$12 = /*#__PURE__*/ _$template(
     `<div>
 d</div>`,
     2
   ),
-  _tmpl$13 = _$template(`<div></div>`, 2);
+  _tmpl$13 = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
 const trailing = _tmpl$.cloneNode(true);
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
@@ -7,21 +7,25 @@ import { setAttribute as _$setAttribute } from "r-dom";
 import { effect as _$effect } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
     `<svg width="400" height="180"><rect stroke-width="2" x="50" y="20" rx="20" ry="20" width="150" height="150" style="fill:red;stroke:black;stroke-width:5;opacity:0.5"></rect><linearGradient gradientTransform="rotate(25)"><stop offset="0%"></stop></linearGradient></svg>`,
     8
   ),
-  _tmpl$2 = _$template(
+  _tmpl$2 = /*#__PURE__*/ _$template(
     `<svg width="400" height="180"><rect rx="20" ry="20" width="150" height="150"></rect></svg>`,
     4
   ),
-  _tmpl$3 = _$template(`<svg width="400" height="180"><rect></rect></svg>`, 4),
-  _tmpl$4 = _$template(`<svg><rect x="50" y="20" width="150" height="150"></rect></svg>`, 4, true),
-  _tmpl$5 = _$template(
+  _tmpl$3 = /*#__PURE__*/ _$template(`<svg width="400" height="180"><rect></rect></svg>`, 4),
+  _tmpl$4 = /*#__PURE__*/ _$template(
+    `<svg><rect x="50" y="20" width="150" height="150"></rect></svg>`,
+    4,
+    true
+  ),
+  _tmpl$5 = /*#__PURE__*/ _$template(
     `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><a><text x="10" y="25">MDN Web Docs</text></a></svg>`,
     6
   ),
-  _tmpl$6 = _$template(
+  _tmpl$6 = /*#__PURE__*/ _$template(
     `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><text x="10" y="25"></text></svg>`,
     4
   );

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -8,15 +8,15 @@ import { runHydrationEvents as _$runHydrationEvents } from "r-dom";
 import { classList as _$classList } from "r-dom";
 import { spread as _$spread } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
     `<div id="main"><h1 class="base selected" id="my-h1" disabled readonly=""><a href="/">Welcome</a></h1></div>`,
     6
   ),
-  _tmpl$2 = _$template(`<div><div></div><div> </div><div></div></div>`, 8),
-  _tmpl$3 = _$template(`<div></div>`, 2),
-  _tmpl$4 = _$template(`<div class="a b"></div>`, 2),
-  _tmpl$5 = _$template(`<input type="checkbox">`, 1),
-  _tmpl$6 = _$template(`<div class="\`a">\`$\`</div>`, 2);
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div></div></div>`, 8),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div class="a b"></div>`, 2),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<input type="checkbox">`, 1),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\`</div>`, 2);
 
 const selected = true;
 let id = "my-h1";

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/output.js
@@ -7,19 +7,22 @@ import { getNextElement as _$getNextElement } from "r-dom";
 import { getNextMarker as _$getNextMarker } from "r-dom";
 import { insert as _$insert } from "r-dom";
 
-const _tmpl$ = _$template(`<div>Hello <!#><!/></div>`, 4),
-  _tmpl$2 = _$template(`<div></div>`, 2),
-  _tmpl$3 = _$template(`<div>From Parent</div>`, 2),
-  _tmpl$4 = _$template(`<div><!#><!/><!#><!/><!#><!/></div>`, 8),
-  _tmpl$5 = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(`<div>Hello <!#><!/></div>`, 4),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div>From Parent</div>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div><!#><!/><!#><!/><!#><!/></div>`, 8),
+  _tmpl$5 = /*#__PURE__*/ _$template(
     `<div><!#><!/> | <!#><!/> | <!#><!/> | <!#><!/> | <!#><!/> | <!#><!/></div>`,
     14
   ),
-  _tmpl$6 = _$template(`<div><!#><!/> | <!#><!/><!#><!/> | <!#><!/><!#><!/> | <!#><!/></div>`, 14),
-  _tmpl$7 = _$template(`<div> | <!#><!/> |  |  | <!#><!/> | </div>`, 6),
-  _tmpl$8 = _$template(`<span>1</span>`, 2),
-  _tmpl$9 = _$template(`<span>2</span>`, 2),
-  _tmpl$10 = _$template(`<span>3</span>`, 2);
+  _tmpl$6 = /*#__PURE__*/ _$template(
+    `<div><!#><!/> | <!#><!/><!#><!/> | <!#><!/><!#><!/> | <!#><!/></div>`,
+    14
+  ),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<div> | <!#><!/> |  |  | <!#><!/> | </div>`, 6),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<span>1</span>`, 2),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<span>2</span>`, 2),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<span>3</span>`, 2);
 
 import { Show } from "somewhere";
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
@@ -4,9 +4,12 @@ import { getNextElement as _$getNextElement } from "r-dom";
 import { getOwner as _$getOwner } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 
-const _tmpl$ = _$template(`<my-element></my-element>`, 2),
-  _tmpl$2 = _$template(`<my-element><header slot="head">Title</header></my-element>`, 4),
-  _tmpl$3 = _$template(`<slot name="head"></slot>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<my-element></my-element>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(
+    `<my-element><header slot="head">Title</header></my-element>`,
+    4
+  ),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<slot name="head"></slot>`, 2);
 
 const template = (() => {
   const _el$ = _$getNextElement(_tmpl$);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/eventExpressions/output.js
@@ -3,7 +3,7 @@ import { delegateEvents as _$delegateEvents } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 import { runHydrationEvents as _$runHydrationEvents } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
   `<div id="main"><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture</button></div>`,
   14
 );

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/fragments/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/fragments/output.js
@@ -5,12 +5,12 @@ import { setAttribute as _$setAttribute } from "r-dom";
 import { effect as _$effect } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 
-const _tmpl$ = _$template(`<div>First</div>`, 2),
-  _tmpl$2 = _$template(`<div>Last</div>`, 2),
-  _tmpl$3 = _$template(`<div></div>`, 2),
-  _tmpl$4 = _$template(`<span>1</span>`, 2),
-  _tmpl$5 = _$template(`<span>2</span>`, 2),
-  _tmpl$6 = _$template(`<span>3</span>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<div>First</div>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div>Last</div>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<span>1</span>`, 2),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<span>2</span>`, 2),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<span>3</span>`, 2);
 
 const multiStatic = [_$getNextElement(_tmpl$), _$getNextElement(_tmpl$2)];
 const multiExpression = [_$getNextElement(_tmpl$), inserted, _$getNextElement(_tmpl$2), "After"];

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/simpleElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/simpleElements/output.js
@@ -1,7 +1,7 @@
 import { template as _$template } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
   `<div id="main"><style>div { color: red; }</style><h1>Welcome</h1><label for="entry">Edit:</label><input id="entry" type="text"></div>`,
   9
 );

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/textInterpolation/output.js
@@ -4,25 +4,25 @@ import { getNextMarker as _$getNextMarker } from "r-dom";
 import { insert as _$insert } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 
-const _tmpl$ = _$template(`<span>Hello </span>`, 2),
-  _tmpl$2 = _$template(`<span> John</span>`, 2),
-  _tmpl$3 = _$template(`<span>Hello John</span>`, 2),
-  _tmpl$4 = _$template(`<span>Hello <!#><!/></span>`, 4),
-  _tmpl$5 = _$template(`<span><!#><!/> John</span>`, 4),
-  _tmpl$6 = _$template(`<span><!#><!/> <!#><!/></span>`, 6),
-  _tmpl$7 = _$template(`<span> <!#><!/> <!#><!/> </span>`, 6),
-  _tmpl$8 = _$template(`<span> <!#><!/><!#><!/> </span>`, 6),
-  _tmpl$9 = _$template(`<span>Hello</span>`, 2),
-  _tmpl$10 = _$template(`<span>&nbsp;&lt;Hi&gt;&nbsp;</span>`, 2),
-  _tmpl$11 = _$template(`<span>Hi&lt;script>alert();&lt;/script></span>`, 2),
-  _tmpl$12 = _$template(`<span>Hello World!</span>`, 2),
-  _tmpl$13 = _$template(`<span>4 + 5 = 9</span>`, 2),
-  _tmpl$14 = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(`<span>Hello </span>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<span> John</span>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<span>Hello John</span>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<span>Hello <!#><!/></span>`, 4),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<span><!#><!/> John</span>`, 4),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<span><!#><!/> <!#><!/></span>`, 6),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<span> <!#><!/> <!#><!/> </span>`, 6),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<span> <!#><!/><!#><!/> </span>`, 6),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<span>Hello</span>`, 2),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<span>&nbsp;&lt;Hi&gt;&nbsp;</span>`, 2),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<span>Hi&lt;script>alert();&lt;/script></span>`, 2),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<span>Hello World!</span>`, 2),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<span>4 + 5 = 9</span>`, 2),
+  _tmpl$14 = /*#__PURE__*/ _$template(
     `<div><!#><!/>
 d</div>`,
     4
   ),
-  _tmpl$15 = _$template(`<div></div>`, 2);
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
 const trailing = _$getNextElement(_tmpl$);
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/attributeExpressions/output.js
@@ -4,14 +4,14 @@ import { classList as _$classList } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 import { spread as _$spread } from "r-dom";
 
-const _tmpl$ = _$template(
+const _tmpl$ = /*#__PURE__*/ _$template(
     `<div id="main"><h1 class="base selected" disabled readonly=""><a href="/">Welcome</a></h1></div>`,
     6
   ),
-  _tmpl$2 = _$template(`<div><div></div><div></div><div></div></div>`, 8),
-  _tmpl$3 = _$template(`<div></div>`, 2),
-  _tmpl$4 = _$template(`<div class="a b"></div>`, 2),
-  _tmpl$5 = _$template(`<input type="checkbox">`, 1);
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div></div><div></div></div>`, 8),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div class="a b"></div>`, 2),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<input type="checkbox">`, 1);
 
 const selected = true;
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
@@ -4,15 +4,15 @@ import { createComponent as _$createComponent } from "r-dom";
 import { mergeProps as _$mergeProps } from "r-dom";
 import { insert as _$insert } from "r-dom";
 
-const _tmpl$ = _$template(`<div>Hello </div>`, 2),
-  _tmpl$2 = _$template(`<div></div>`, 2),
-  _tmpl$3 = _$template(`<div>From Parent</div>`, 2),
-  _tmpl$4 = _$template(`<div> | <!> | <!> | <!> | <!> | </div>`, 6),
-  _tmpl$5 = _$template(`<div> | <!> | <!> | </div>`, 4),
-  _tmpl$6 = _$template(`<div> | <!> |  |  | <!> | </div>`, 4),
-  _tmpl$7 = _$template(`<span>1</span>`, 2),
-  _tmpl$8 = _$template(`<span>2</span>`, 2),
-  _tmpl$9 = _$template(`<span>3</span>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<div>Hello </div>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div></div>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div>From Parent</div>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div> | <!> | <!> | <!> | <!> | </div>`, 6),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<div> | <!> | <!> | </div>`, 4),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<div> | <!> |  |  | <!> | </div>`, 4),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<span>1</span>`, 2),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<span>2</span>`, 2),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<span>3</span>`, 2);
 
 import { Show } from "somewhere";
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/conditionalExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/conditionalExpressions/output.js
@@ -2,7 +2,7 @@ import { template as _$template } from "r-dom";
 import { createComponent as _$createComponent } from "r-dom";
 import { insert as _$insert } from "r-dom";
 
-const _tmpl$ = _$template(`<div></div>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
 const template1 = (() => {
   const _el$ = _tmpl$.cloneNode(true);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/fragments/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/fragments/output.js
@@ -2,9 +2,9 @@ import { template as _$template } from "r-dom";
 import { createComponent as _$createComponent } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 
-const _tmpl$ = _$template(`<div>First</div>`, 2),
-  _tmpl$2 = _$template(`<div>Last</div>`, 2),
-  _tmpl$3 = _$template(`<div></div>`, 2);
+const _tmpl$ = /*#__PURE__*/ _$template(`<div>First</div>`, 2),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div>Last</div>`, 2),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
 const multiStatic = [_tmpl$.cloneNode(true), _tmpl$2.cloneNode(true)];
 const multiExpression = [_tmpl$.cloneNode(true), inserted, _tmpl$2.cloneNode(true), "After"];

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -51,6 +51,7 @@ const DelegatedEvents = new Set([
   "beforeinput",
   "click",
   "dblclick",
+  "contextmenu",
   "focusin",
   "focusout",
   "input",


### PR DESCRIPTION
When components are included in files but are unused, Terser of course removes those functions. However, the generated calls to `template` outside of that function are kept, leading to code like:
```js
template("<div></div>");
const _tmpl$2 = template('<button type="button"></button>');
```
Note the first template is not assigned to anything, but Terser preserves it just in case it has side-effects.

However, the only side-effect `template` has is creating an unparented DOM node, which is just wasteful if not removed.

Therefore, marking `template` with the leading comment `/*#__PURE__*/` allows Terser the freedom to remove calls to it if the results are unused.

Also, may want to squash this when merging.