### PR TITLE
Lazily create template DOM nodes

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
@@ -83,9 +83,7 @@ function registerTemplate(path, results) {
       results.id,
       hydratable
         ? t.callExpression(registerImportMethod(path, "getNextElement"), templateId ? [templateId] : [])
-        : t.callExpression(t.memberExpression(templateId, t.identifier("cloneNode")), [
-            t.booleanLiteral(true)
-          ])
+        : t.callExpression(templateId, [])
     );
   }
   results.decl.unshift(decl);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
@@ -28,10 +28,10 @@ const _tmpl$ = /*#__PURE__*/ _$template(
     4
   );
 
-const template = _tmpl$.cloneNode(true);
+const template = _tmpl$();
 
 const template2 = (() => {
-  const _el$2 = _tmpl$2.cloneNode(true),
+  const _el$2 = _tmpl$2(),
     _el$3 = _el$2.firstChild;
 
   _el$3.style.setProperty("fill", "red");
@@ -67,7 +67,7 @@ const template2 = (() => {
 })();
 
 const template3 = (() => {
-  const _el$4 = _tmpl$3.cloneNode(true),
+  const _el$4 = _tmpl$3(),
     _el$5 = _el$4.firstChild;
 
   _$spread(_el$5, props, true, false);
@@ -75,18 +75,18 @@ const template3 = (() => {
   return _el$4;
 })();
 
-const template4 = _tmpl$4.cloneNode(true);
+const template4 = _tmpl$4();
 
-const template5 = _tmpl$4.cloneNode(true);
+const template5 = _tmpl$4();
 
 const template6 = _$createComponent(Component, {
   get children() {
-    return _tmpl$4.cloneNode(true);
+    return _tmpl$4();
   }
 });
 
 const template7 = (() => {
-  const _el$9 = _tmpl$5.cloneNode(true),
+  const _el$9 = _tmpl$5(),
     _el$10 = _el$9.firstChild;
 
   _$setAttributeNS(_el$10, "http://www.w3.org/1999/xlink", "xlink:href", url);
@@ -95,7 +95,7 @@ const template7 = (() => {
 })();
 
 const template8 = (() => {
-  const _el$11 = _tmpl$6.cloneNode(true),
+  const _el$11 = _tmpl$6(),
     _el$12 = _el$11.firstChild;
 
   _el$12.textContent = text;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -20,7 +20,7 @@ let id = "my-h1";
 let link;
 
 const template = (() => {
-  const _el$ = _tmpl$.cloneNode(true),
+  const _el$ = _tmpl$(),
     _el$2 = _el$.firstChild,
     _el$3 = _el$2.firstChild;
 
@@ -65,7 +65,7 @@ const template = (() => {
 })();
 
 const template2 = (() => {
-  const _el$4 = _tmpl$2.cloneNode(true),
+  const _el$4 = _tmpl$2(),
     _el$5 = _el$4.firstChild,
     _el$6 = _el$5.nextSibling,
     _el$7 = _el$6.firstChild,
@@ -82,7 +82,7 @@ const template2 = (() => {
 })();
 
 const template3 = (() => {
-  const _el$9 = _tmpl$3.cloneNode(true);
+  const _el$9 = _tmpl$3();
 
   _$setAttribute(_el$9, "id", state.id);
 
@@ -96,7 +96,7 @@ const template3 = (() => {
 })();
 
 const template4 = (() => {
-  const _el$10 = _tmpl$3.cloneNode(true);
+  const _el$10 = _tmpl$3();
 
   _$classList(_el$10, {
     "ccc:ddd": true
@@ -107,10 +107,10 @@ const template4 = (() => {
   return _el$10;
 })();
 
-const template5 = _tmpl$4.cloneNode(true);
+const template5 = _tmpl$4();
 
 const template6 = (() => {
-  const _el$12 = _tmpl$3.cloneNode(true);
+  const _el$12 = _tmpl$3();
 
   _el$12.textContent = "Hi";
 
@@ -120,7 +120,7 @@ const template6 = (() => {
 })();
 
 const template7 = (() => {
-  const _el$13 = _tmpl$3.cloneNode(true);
+  const _el$13 = _tmpl$3();
 
   _$effect(
     _p$ => {
@@ -149,7 +149,7 @@ const template7 = (() => {
 let refTarget;
 
 const template8 = (() => {
-  const _el$14 = _tmpl$3.cloneNode(true);
+  const _el$14 = _tmpl$3();
 
   const _ref$2 = refTarget;
   typeof _ref$2 === "function" ? _ref$2(_el$14) : (refTarget = _el$14);
@@ -157,7 +157,7 @@ const template8 = (() => {
 })();
 
 const template9 = (() => {
-  const _el$15 = _tmpl$3.cloneNode(true);
+  const _el$15 = _tmpl$3();
 
   (e => console.log(e))(_el$15);
 
@@ -165,7 +165,7 @@ const template9 = (() => {
 })();
 
 const template10 = (() => {
-  const _el$16 = _tmpl$3.cloneNode(true);
+  const _el$16 = _tmpl$3();
 
   const _ref$3 = refFactory();
 
@@ -174,7 +174,7 @@ const template10 = (() => {
 })();
 
 const template11 = (() => {
-  const _el$17 = _tmpl$3.cloneNode(true);
+  const _el$17 = _tmpl$3();
 
   zero(_el$17, () => 0);
   another(_el$17, () => thing);
@@ -183,25 +183,25 @@ const template11 = (() => {
 })();
 
 const template12 = (() => {
-  const _el$18 = _tmpl$3.cloneNode(true);
+  const _el$18 = _tmpl$3();
 
   _el$18.htmlFor = thing;
   return _el$18;
 })();
 
 const template13 = (() => {
-  const _el$19 = _tmpl$5.cloneNode(true);
+  const _el$19 = _tmpl$5();
 
   _el$19.checked = true;
   return _el$19;
 })();
 
 const template14 = (() => {
-  const _el$20 = _tmpl$5.cloneNode(true);
+  const _el$20 = _tmpl$5();
 
   _$effect(() => (_el$20.checked = state.visible));
 
   return _el$20;
 })();
 
-const template15 = _tmpl$6.cloneNode(true);
+const template15 = _tmpl$6();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -21,7 +21,7 @@ const Child = props => {
   const [s, set] = createSignal();
   return [
     (() => {
-      const _el$ = _tmpl$.cloneNode(true),
+      const _el$ = _tmpl$(),
         _el$2 = _el$.firstChild;
 
       const _ref$ = props.ref;
@@ -32,7 +32,7 @@ const Child = props => {
       return _el$;
     })(),
     (() => {
-      const _el$3 = _tmpl$2.cloneNode(true);
+      const _el$3 = _tmpl$2();
 
       set(_el$3);
 
@@ -47,7 +47,7 @@ const template = props => {
   let childRef;
   const { content } = props;
   return (() => {
-    const _el$4 = _tmpl$2.cloneNode(true);
+    const _el$4 = _tmpl$2();
 
     _$insert(
       _el$4,
@@ -67,7 +67,7 @@ const template = props => {
             booleanProperty: true,
 
             get children() {
-              return _tmpl$3.cloneNode(true);
+              return _tmpl$3();
             }
           }
         )
@@ -91,7 +91,7 @@ const template = props => {
             },
 
             get children() {
-              const _el$6 = _tmpl$2.cloneNode(true);
+              const _el$6 = _tmpl$2();
 
               _$insert(_el$6, content);
 
@@ -140,7 +140,7 @@ const template2 = _$createComponent(Child, {
 
 const template3 = _$createComponent(Child, {
   get children() {
-    return [_tmpl$2.cloneNode(true), _tmpl$2.cloneNode(true), _tmpl$2.cloneNode(true), "After"];
+    return [_tmpl$2(), _tmpl$2(), _tmpl$2(), "After"];
   }
 });
 
@@ -150,7 +150,7 @@ const template4 = _$createComponent(Child, {
   ref: set,
 
   get children() {
-    return _tmpl$2.cloneNode(true);
+    return _tmpl$2();
   }
 });
 
@@ -185,7 +185,7 @@ const template6 = _$createComponent(_$For, {
 
 const template7 = _$createComponent(Child, {
   get children() {
-    return [_tmpl$2.cloneNode(true), _$memo(() => state.dynamic)];
+    return [_tmpl$2(), _$memo(() => state.dynamic)];
   }
 });
 
@@ -200,7 +200,7 @@ const template9 = _$createComponent(_garbage, {
 });
 
 const template10 = (() => {
-  const _el$12 = _tmpl$4.cloneNode(true),
+  const _el$12 = _tmpl$4(),
     _el$13 = _el$12.firstChild,
     _el$18 = _el$13.nextSibling,
     _el$14 = _el$18.nextSibling,
@@ -263,7 +263,7 @@ const template10 = (() => {
 })();
 
 const template11 = (() => {
-  const _el$22 = _tmpl$5.cloneNode(true),
+  const _el$22 = _tmpl$5(),
     _el$23 = _el$22.firstChild,
     _el$26 = _el$23.nextSibling,
     _el$24 = _el$26.nextSibling,
@@ -322,7 +322,7 @@ const template11 = (() => {
 })();
 
 const template12 = (() => {
-  const _el$28 = _tmpl$6.cloneNode(true),
+  const _el$28 = _tmpl$6(),
     _el$29 = _el$28.firstChild,
     _el$34 = _el$29.nextSibling,
     _el$30 = _el$34.nextSibling,
@@ -394,13 +394,13 @@ const Template16 = _$createComponent(
 
 const Template17 = _$createComponent(Pre, {
   get children() {
-    return [_tmpl$7.cloneNode(true), " ", _tmpl$8.cloneNode(true), " ", _tmpl$9.cloneNode(true)];
+    return [_tmpl$7(), " ", _tmpl$8(), " ", _tmpl$9()];
   }
 });
 
 const Template18 = _$createComponent(Pre, {
   get children() {
-    return [_tmpl$7.cloneNode(true), _tmpl$8.cloneNode(true), _tmpl$9.cloneNode(true)];
+    return [_tmpl$7(), _tmpl$8(), _tmpl$9()];
   }
 });
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/conditionalExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/conditionalExpressions/output.js
@@ -7,7 +7,7 @@ import { insert as _$insert } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
 const template1 = (() => {
-  const _el$ = _tmpl$.cloneNode(true);
+  const _el$ = _tmpl$();
 
   _$insert(_el$, simple);
 
@@ -15,7 +15,7 @@ const template1 = (() => {
 })();
 
 const template2 = (() => {
-  const _el$2 = _tmpl$.cloneNode(true);
+  const _el$2 = _tmpl$();
 
   _$insert(_el$2, () => state.dynamic);
 
@@ -23,7 +23,7 @@ const template2 = (() => {
 })();
 
 const template3 = (() => {
-  const _el$3 = _tmpl$.cloneNode(true);
+  const _el$3 = _tmpl$();
 
   _$insert(_el$3, simple ? good : bad);
 
@@ -31,7 +31,7 @@ const template3 = (() => {
 })();
 
 const template4 = (() => {
-  const _el$4 = _tmpl$.cloneNode(true);
+  const _el$4 = _tmpl$();
 
   _$insert(_el$4, () => (simple ? good() : bad));
 
@@ -39,7 +39,7 @@ const template4 = (() => {
 })();
 
 const template5 = (() => {
-  const _el$5 = _tmpl$.cloneNode(true);
+  const _el$5 = _tmpl$();
 
   _$insert(
     _el$5,
@@ -54,7 +54,7 @@ const template5 = (() => {
 })();
 
 const template6 = (() => {
-  const _el$6 = _tmpl$.cloneNode(true);
+  const _el$6 = _tmpl$();
 
   _$insert(
     _el$6,
@@ -69,7 +69,7 @@ const template6 = (() => {
 })();
 
 const template7 = (() => {
-  const _el$7 = _tmpl$.cloneNode(true);
+  const _el$7 = _tmpl$();
 
   _$insert(
     _el$7,
@@ -91,7 +91,7 @@ const template7 = (() => {
 })();
 
 const template8 = (() => {
-  const _el$8 = _tmpl$.cloneNode(true);
+  const _el$8 = _tmpl$();
 
   _$insert(
     _el$8,
@@ -106,7 +106,7 @@ const template8 = (() => {
 })();
 
 const template9 = (() => {
-  const _el$9 = _tmpl$.cloneNode(true);
+  const _el$9 = _tmpl$();
 
   _$insert(
     _el$9,
@@ -121,7 +121,7 @@ const template9 = (() => {
 })();
 
 const template10 = (() => {
-  const _el$10 = _tmpl$.cloneNode(true);
+  const _el$10 = _tmpl$();
 
   _$insert(_el$10, () => (state.a ? "a" : state.b ? "b" : state.c ? "c" : "fallback"));
 
@@ -129,7 +129,7 @@ const template10 = (() => {
 })();
 
 const template11 = (() => {
-  const _el$11 = _tmpl$.cloneNode(true);
+  const _el$11 = _tmpl$();
 
   _$insert(
     _el$11,
@@ -197,7 +197,7 @@ const template18 = _$createComponent(Comp, {
 });
 
 const template19 = (() => {
-  const _el$12 = _tmpl$.cloneNode(true);
+  const _el$12 = _tmpl$();
 
   _$effect(
     () =>
@@ -208,7 +208,7 @@ const template19 = (() => {
 })();
 
 const template20 = (() => {
-  const _el$13 = _tmpl$.cloneNode(true);
+  const _el$13 = _tmpl$();
 
   _$insert(
     _el$13,
@@ -235,7 +235,7 @@ const template22 = _$createComponent(Comp, {
 });
 
 const template23 = (() => {
-  const _el$14 = _tmpl$.cloneNode(true);
+  const _el$14 = _tmpl$();
 
   _$effect(() => (_el$14.innerHTML = state?.dynamic ? "a" : "b"));
 
@@ -243,7 +243,7 @@ const template23 = (() => {
 })();
 
 const template24 = (() => {
-  const _el$15 = _tmpl$.cloneNode(true);
+  const _el$15 = _tmpl$();
 
   _$insert(_el$15, () => (state?.dynamic ? "a" : "b"));
 
@@ -263,7 +263,7 @@ const template26 = _$createComponent(Comp, {
 });
 
 const template27 = (() => {
-  const _el$16 = _tmpl$.cloneNode(true);
+  const _el$16 = _tmpl$();
 
   _$effect(() => (_el$16.innerHTML = state.dynamic ?? _$createComponent(Comp, {})));
 
@@ -271,7 +271,7 @@ const template27 = (() => {
 })();
 
 const template28 = (() => {
-  const _el$17 = _tmpl$.cloneNode(true);
+  const _el$17 = _tmpl$();
 
   _$insert(_el$17, () => state.dynamic ?? _$createComponent(Comp, {}));
 
@@ -279,7 +279,7 @@ const template28 = (() => {
 })();
 
 const template29 = (() => {
-  const _el$18 = _tmpl$.cloneNode(true);
+  const _el$18 = _tmpl$();
 
   _$insert(
     _el$18,
@@ -294,7 +294,7 @@ const template29 = (() => {
 })();
 
 const template30 = (() => {
-  const _el$19 = _tmpl$.cloneNode(true);
+  const _el$19 = _tmpl$();
 
   _$insert(_el$19, () => thing() || thing1() || thing2());
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -11,7 +11,7 @@ const _tmpl$ = /*#__PURE__*/ _$template(`<my-element></my-element>`, 2),
   _tmpl$3 = /*#__PURE__*/ _$template(`<slot name="head"></slot>`, 2);
 
 const template = (() => {
-  const _el$ = _tmpl$.cloneNode(true);
+  const _el$ = _tmpl$();
 
   _el$.someAttr = name;
   _el$.notprop = data;
@@ -24,7 +24,7 @@ const template = (() => {
 })();
 
 const template2 = (() => {
-  const _el$2 = _tmpl$.cloneNode(true);
+  const _el$2 = _tmpl$();
 
   _el$2._$owner = _$getOwner();
 
@@ -52,14 +52,14 @@ const template2 = (() => {
 })();
 
 const template3 = (() => {
-  const _el$3 = _tmpl$2.cloneNode(true);
+  const _el$3 = _tmpl$2();
 
   _el$3._$owner = _$getOwner();
   return _el$3;
 })();
 
 const template4 = (() => {
-  const _el$4 = _tmpl$3.cloneNode(true);
+  const _el$4 = _tmpl$3();
 
   _el$4._$owner = _$getOwner();
   return _el$4;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/eventExpressions/output.js
@@ -14,7 +14,7 @@ function hoisted1() {
 const hoisted2 = () => console.log("hoisted delegated");
 
 const template = (() => {
-  const _el$ = _tmpl$.cloneNode(true),
+  const _el$ = _tmpl$(),
     _el$2 = _el$.firstChild,
     _el$3 = _el$2.nextSibling,
     _el$4 = _el$3.nextSibling,

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/fragments/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/fragments/output.js
@@ -11,11 +11,11 @@ const _tmpl$ = /*#__PURE__*/ _$template(`<div>First</div>`, 2),
   _tmpl$5 = /*#__PURE__*/ _$template(`<span>2</span>`, 2),
   _tmpl$6 = /*#__PURE__*/ _$template(`<span>3</span>`, 2);
 
-const multiStatic = [_tmpl$.cloneNode(true), _tmpl$2.cloneNode(true)];
-const multiExpression = [_tmpl$.cloneNode(true), inserted, _tmpl$2.cloneNode(true), "After"];
+const multiStatic = [_tmpl$(), _tmpl$2()];
+const multiExpression = [_tmpl$(), inserted, _tmpl$2(), "After"];
 const multiDynamic = [
   (() => {
-    const _el$5 = _tmpl$.cloneNode(true);
+    const _el$5 = _tmpl$();
 
     _$effect(() => _$setAttribute(_el$5, "id", state.first));
 
@@ -23,7 +23,7 @@ const multiDynamic = [
   })(),
   _$memo(() => state.inserted),
   (() => {
-    const _el$6 = _tmpl$2.cloneNode(true);
+    const _el$6 = _tmpl$2();
 
     _$effect(() => _$setAttribute(_el$6, "id", state.last));
 
@@ -35,21 +35,11 @@ const singleExpression = inserted;
 
 const singleDynamic = _$memo(inserted);
 
-const firstStatic = [inserted, _tmpl$3.cloneNode(true)];
-const firstDynamic = [_$memo(inserted), _tmpl$3.cloneNode(true)];
-const firstComponent = [_$createComponent(Component, {}), _tmpl$3.cloneNode(true)];
-const lastStatic = [_tmpl$3.cloneNode(true), inserted];
-const lastDynamic = [_tmpl$3.cloneNode(true), _$memo(inserted)];
-const lastComponent = [_tmpl$3.cloneNode(true), _$createComponent(Component, {})];
-const spaces = [
-  _tmpl$4.cloneNode(true),
-  " ",
-  _tmpl$5.cloneNode(true),
-  " ",
-  _tmpl$6.cloneNode(true)
-];
-const multiLineTrailing = [
-  _tmpl$4.cloneNode(true),
-  _tmpl$5.cloneNode(true),
-  _tmpl$6.cloneNode(true)
-];
+const firstStatic = [inserted, _tmpl$3()];
+const firstDynamic = [_$memo(inserted), _tmpl$3()];
+const firstComponent = [_$createComponent(Component, {}), _tmpl$3()];
+const lastStatic = [_tmpl$3(), inserted];
+const lastDynamic = [_tmpl$3(), _$memo(inserted)];
+const lastComponent = [_tmpl$3(), _$createComponent(Component, {})];
+const spaces = [_tmpl$4(), " ", _tmpl$5(), " ", _tmpl$6()];
+const multiLineTrailing = [_tmpl$4(), _tmpl$5(), _tmpl$6()];

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/insertChildren/output.js
@@ -10,7 +10,7 @@ const _tmpl$ = /*#__PURE__*/ _$template(`<div></div>`, 2),
   _tmpl$4 = /*#__PURE__*/ _$template(`<module>Hi </module>`, 2),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div>Test 1</div>`, 2);
 
-const children = _tmpl$.cloneNode(true);
+const children = _tmpl$();
 
 const dynamic = {
   children
@@ -21,17 +21,17 @@ const template = _$createComponent(Module, {
 });
 
 const template2 = (() => {
-  const _el$2 = _tmpl$2.cloneNode(true);
+  const _el$2 = _tmpl$2();
 
   _$insert(_el$2, children);
 
   return _el$2;
 })();
 
-const template3 = _tmpl$3.cloneNode(true);
+const template3 = _tmpl$3();
 
 const template4 = (() => {
-  const _el$4 = _tmpl$2.cloneNode(true);
+  const _el$4 = _tmpl$2();
 
   _$insert(_el$4, _$createComponent(Hello, {}));
 
@@ -39,7 +39,7 @@ const template4 = (() => {
 })();
 
 const template5 = (() => {
-  const _el$5 = _tmpl$2.cloneNode(true);
+  const _el$5 = _tmpl$2();
 
   _$insert(_el$5, () => dynamic.children);
 
@@ -53,7 +53,7 @@ const template6 = _$createComponent(Module, {
 });
 
 const template7 = (() => {
-  const _el$6 = _tmpl$2.cloneNode(true);
+  const _el$6 = _tmpl$2();
 
   _$spread(_el$6, dynamic, false, false);
 
@@ -61,7 +61,7 @@ const template7 = (() => {
 })();
 
 const template8 = (() => {
-  const _el$7 = _tmpl$3.cloneNode(true);
+  const _el$7 = _tmpl$3();
 
   _$spread(_el$7, dynamic, false, true);
 
@@ -69,7 +69,7 @@ const template8 = (() => {
 })();
 
 const template9 = (() => {
-  const _el$8 = _tmpl$2.cloneNode(true);
+  const _el$8 = _tmpl$2();
 
   _$spread(_el$8, dynamic, false, true);
 
@@ -86,7 +86,7 @@ const template10 = _$createComponent(
 );
 
 const template11 = (() => {
-  const _el$9 = _tmpl$2.cloneNode(true);
+  const _el$9 = _tmpl$2();
 
   _$insert(_el$9, state.children);
 
@@ -98,7 +98,7 @@ const template12 = _$createComponent(Module, {
 });
 
 const template13 = (() => {
-  const _el$10 = _tmpl$2.cloneNode(true);
+  const _el$10 = _tmpl$2();
 
   _$insert(_el$10, children);
 
@@ -110,7 +110,7 @@ const template14 = _$createComponent(Module, {
 });
 
 const template15 = (() => {
-  const _el$11 = _tmpl$2.cloneNode(true);
+  const _el$11 = _tmpl$2();
 
   _$insert(_el$11, () => dynamic.children);
 
@@ -124,7 +124,7 @@ const template16 = _$createComponent(Module, {
 });
 
 const template18 = (() => {
-  const _el$12 = _tmpl$4.cloneNode(true);
+  const _el$12 = _tmpl$4();
 
   _$insert(_el$12, children, null);
 
@@ -138,7 +138,7 @@ const template19 = _$createComponent(Module, {
 });
 
 const template20 = (() => {
-  const _el$13 = _tmpl$2.cloneNode(true);
+  const _el$13 = _tmpl$2();
 
   _$insert(_el$13, children);
 
@@ -152,7 +152,7 @@ const template21 = _$createComponent(Module, {
 });
 
 const template22 = (() => {
-  const _el$14 = _tmpl$2.cloneNode(true);
+  const _el$14 = _tmpl$2();
 
   _$insert(_el$14, () => state.children());
 
@@ -166,10 +166,10 @@ const template23 = _$createComponent(Module, {
 });
 
 const tiles = [];
-tiles.push(_tmpl$5.cloneNode(true));
+tiles.push(_tmpl$5());
 
 const template24 = (() => {
-  const _el$16 = _tmpl$.cloneNode(true);
+  const _el$16 = _tmpl$();
 
   _$insert(_el$16, tiles);
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/namespaceElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/namespaceElements/output.js
@@ -13,4 +13,4 @@ const template4 = _$createComponent(module["a-b"], {});
 
 const template5 = _$createComponent(module["a-b"]["c-d"], {});
 
-const template6 = _tmpl$.cloneNode(true);
+const template6 = _tmpl$();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/simpleElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/simpleElements/output.js
@@ -5,4 +5,4 @@ const _tmpl$ = /*#__PURE__*/ _$template(
   9
 );
 
-const template = _tmpl$.cloneNode(true);
+const template = _tmpl$();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
@@ -20,15 +20,15 @@ d</div>`,
   ),
   _tmpl$13 = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
-const trailing = _tmpl$.cloneNode(true);
+const trailing = _tmpl$();
 
-const leading = _tmpl$2.cloneNode(true);
+const leading = _tmpl$2();
 /* prettier-ignore */
 
-const extraSpaces = _tmpl$3.cloneNode(true);
+const extraSpaces = _tmpl$3();
 
 const trailingExpr = (() => {
-  const _el$4 = _tmpl$.cloneNode(true),
+  const _el$4 = _tmpl$(),
     _el$5 = _el$4.firstChild;
 
   _$insert(_el$4, name, null);
@@ -37,7 +37,7 @@ const trailingExpr = (() => {
 })();
 
 const leadingExpr = (() => {
-  const _el$6 = _tmpl$2.cloneNode(true),
+  const _el$6 = _tmpl$2(),
     _el$7 = _el$6.firstChild;
 
   _$insert(_el$6, greeting, _el$7);
@@ -47,7 +47,7 @@ const leadingExpr = (() => {
 /* prettier-ignore */
 
 const multiExpr = (() => {
-  const _el$8 = _tmpl$4.cloneNode(true),
+  const _el$8 = _tmpl$4(),
         _el$9 = _el$8.firstChild;
 
   _$insert(_el$8, greeting, _el$9);
@@ -59,7 +59,7 @@ const multiExpr = (() => {
 /* prettier-ignore */
 
 const multiExprSpaced = (() => {
-  const _el$10 = _tmpl$5.cloneNode(true),
+  const _el$10 = _tmpl$5(),
         _el$11 = _el$10.firstChild,
         _el$14 = _el$11.nextSibling,
         _el$12 = _el$14.nextSibling,
@@ -75,7 +75,7 @@ const multiExprSpaced = (() => {
 /* prettier-ignore */
 
 const multiExprTogether = (() => {
-  const _el$16 = _tmpl$6.cloneNode(true),
+  const _el$16 = _tmpl$6(),
         _el$17 = _el$16.firstChild,
         _el$19 = _el$17.nextSibling,
         _el$18 = _el$19.nextSibling;
@@ -88,16 +88,16 @@ const multiExprTogether = (() => {
 })();
 /* prettier-ignore */
 
-const multiLine = _tmpl$7.cloneNode(true);
+const multiLine = _tmpl$7();
 /* prettier-ignore */
 
-const multiLineTrailingSpace = _tmpl$3.cloneNode(true);
+const multiLineTrailingSpace = _tmpl$3();
 /* prettier-ignore */
 
-const multiLineNoTrailingSpace = _tmpl$3.cloneNode(true);
+const multiLineNoTrailingSpace = _tmpl$3();
 /* prettier-ignore */
 
-const escape = _tmpl$8.cloneNode(true);
+const escape = _tmpl$8();
 /* prettier-ignore */
 
 const escape2 = _$createComponent(Comp, {
@@ -107,18 +107,18 @@ const escape2 = _$createComponent(Comp, {
 
 const escape3 = "\xA0<Hi>\xA0";
 
-const injection = _tmpl$9.cloneNode(true);
+const injection = _tmpl$9();
 
 let value = "World";
 
-const evaluated = _tmpl$10.cloneNode(true);
+const evaluated = _tmpl$10();
 
 let number = 4 + 5;
 
-const evaluatedNonString = _tmpl$11.cloneNode(true);
+const evaluatedNonString = _tmpl$11();
 
 const newLineLiteral = (() => {
-  const _el$27 = _tmpl$12.cloneNode(true),
+  const _el$27 = _tmpl$12(),
     _el$28 = _el$27.firstChild;
 
   _$insert(_el$27, s, _el$28);
@@ -127,7 +127,7 @@ const newLineLiteral = (() => {
 })();
 
 const trailingSpace = (() => {
-  const _el$29 = _tmpl$13.cloneNode(true);
+  const _el$29 = _tmpl$13();
 
   _$insert(_el$29, expr);
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/attributeExpressions/output.js
@@ -16,7 +16,7 @@ const _tmpl$ = /*#__PURE__*/ _$template(
 const selected = true;
 
 const template = (() => {
-  const _el$ = _tmpl$.cloneNode(true),
+  const _el$ = _tmpl$(),
     _el$2 = _el$.firstChild,
     _el$3 = _el$2.firstChild;
 
@@ -48,7 +48,7 @@ const template = (() => {
 })();
 
 const template2 = (() => {
-  const _el$4 = _tmpl$2.cloneNode(true),
+  const _el$4 = _tmpl$2(),
     _el$5 = _el$4.firstChild,
     _el$6 = _el$5.nextSibling,
     _el$7 = _el$6.nextSibling;
@@ -60,7 +60,7 @@ const template2 = (() => {
 })();
 
 const template3 = (() => {
-  const _el$8 = _tmpl$3.cloneNode(true);
+  const _el$8 = _tmpl$3();
 
   _$setAttribute(
     _el$8,
@@ -84,7 +84,7 @@ const template3 = (() => {
 })();
 
 const template4 = (() => {
-  const _el$9 = _tmpl$3.cloneNode(true);
+  const _el$9 = _tmpl$3();
 
   _el$9.className = `hi ${state.class || ""}`;
 
@@ -95,10 +95,10 @@ const template4 = (() => {
   return _el$9;
 })();
 
-const template5 = _tmpl$4.cloneNode(true);
+const template5 = _tmpl$4();
 
 const template6 = (() => {
-  const _el$11 = _tmpl$3.cloneNode(true);
+  const _el$11 = _tmpl$3();
 
   _$style(_el$11, someStyle());
 
@@ -107,7 +107,7 @@ const template6 = (() => {
 })();
 
 const template7 = (() => {
-  const _el$12 = _tmpl$3.cloneNode(true);
+  const _el$12 = _tmpl$3();
 
   _$style(_el$12, {
     "background-color": color(),
@@ -125,7 +125,7 @@ const template7 = (() => {
 let refTarget;
 
 const template8 = (() => {
-  const _el$13 = _tmpl$3.cloneNode(true);
+  const _el$13 = _tmpl$3();
 
   const _ref$2 = refTarget;
   typeof _ref$2 === "function" ? _ref$2(_el$13) : (refTarget = _el$13);
@@ -133,7 +133,7 @@ const template8 = (() => {
 })();
 
 const template9 = (() => {
-  const _el$14 = _tmpl$3.cloneNode(true);
+  const _el$14 = _tmpl$3();
 
   (e => console.log(e))(_el$14);
 
@@ -141,7 +141,7 @@ const template9 = (() => {
 })();
 
 const template10 = (() => {
-  const _el$15 = _tmpl$3.cloneNode(true);
+  const _el$15 = _tmpl$3();
 
   const _ref$3 = refFactory();
 
@@ -150,7 +150,7 @@ const template10 = (() => {
 })();
 
 const template11 = (() => {
-  const _el$16 = _tmpl$3.cloneNode(true);
+  const _el$16 = _tmpl$3();
 
   another(_el$16, () => thing);
   something(_el$16, () => true);
@@ -158,21 +158,21 @@ const template11 = (() => {
 })();
 
 const template12 = (() => {
-  const _el$17 = _tmpl$3.cloneNode(true);
+  const _el$17 = _tmpl$3();
 
   _el$17.htmlFor = thing;
   return _el$17;
 })();
 
 const template13 = (() => {
-  const _el$18 = _tmpl$5.cloneNode(true);
+  const _el$18 = _tmpl$5();
 
   _el$18.checked = true;
   return _el$18;
 })();
 
 const template14 = (() => {
-  const _el$19 = _tmpl$5.cloneNode(true);
+  const _el$19 = _tmpl$5();
 
   _el$19.checked = state.visible;
   return _el$19;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
@@ -18,7 +18,7 @@ import { Show } from "somewhere";
 
 const Child = props => [
   (() => {
-    const _el$ = _tmpl$.cloneNode(true),
+    const _el$ = _tmpl$(),
       _el$2 = _el$.firstChild;
 
     const _ref$ = props.ref;
@@ -29,7 +29,7 @@ const Child = props => [
     return _el$;
   })(),
   (() => {
-    const _el$3 = _tmpl$2.cloneNode(true);
+    const _el$3 = _tmpl$2();
 
     _$insert(_el$3, () => props.children);
 
@@ -41,7 +41,7 @@ const template = props => {
   let childRef;
   const { content } = props;
   return (() => {
-    const _el$4 = _tmpl$2.cloneNode(true);
+    const _el$4 = _tmpl$2();
 
     _$insert(
       _el$4,
@@ -61,7 +61,7 @@ const template = props => {
             booleanProperty: true,
 
             get children() {
-              return _tmpl$3.cloneNode(true);
+              return _tmpl$3();
             }
           }
         )
@@ -85,7 +85,7 @@ const template = props => {
             },
 
             get children() {
-              const _el$6 = _tmpl$2.cloneNode(true);
+              const _el$6 = _tmpl$2();
 
               _$insert(_el$6, content);
 
@@ -134,13 +134,13 @@ const template2 = _$createComponent(Child, {
 
 const template3 = _$createComponent(Child, {
   get children() {
-    return [_tmpl$2.cloneNode(true), _tmpl$2.cloneNode(true), _tmpl$2.cloneNode(true), "After"];
+    return [_tmpl$2(), _tmpl$2(), _tmpl$2(), "After"];
   }
 });
 
 const template4 = _$createComponent(Child, {
   get children() {
-    return _tmpl$2.cloneNode(true);
+    return _tmpl$2();
   }
 });
 
@@ -175,7 +175,7 @@ const template6 = _$createComponent(_$For, {
 
 const template7 = _$createComponent(Child, {
   get children() {
-    return [_tmpl$2.cloneNode(true), () => state.dynamic];
+    return [_tmpl$2(), () => state.dynamic];
   }
 });
 
@@ -190,7 +190,7 @@ const template9 = _$createComponent(_garbage, {
 });
 
 const template10 = (() => {
-  const _el$12 = _tmpl$4.cloneNode(true),
+  const _el$12 = _tmpl$4(),
     _el$13 = _el$12.firstChild,
     _el$18 = _el$13.nextSibling,
     _el$14 = _el$18.nextSibling,
@@ -253,7 +253,7 @@ const template10 = (() => {
 })();
 
 const template11 = (() => {
-  const _el$22 = _tmpl$5.cloneNode(true),
+  const _el$22 = _tmpl$5(),
     _el$23 = _el$22.firstChild,
     _el$26 = _el$23.nextSibling,
     _el$24 = _el$26.nextSibling,
@@ -312,7 +312,7 @@ const template11 = (() => {
 })();
 
 const template12 = (() => {
-  const _el$28 = _tmpl$6.cloneNode(true),
+  const _el$28 = _tmpl$6(),
     _el$29 = _el$28.firstChild,
     _el$34 = _el$29.nextSibling,
     _el$30 = _el$34.nextSibling,
@@ -384,12 +384,12 @@ const Template16 = _$createComponent(
 
 const Template17 = _$createComponent(Pre, {
   get children() {
-    return [_tmpl$7.cloneNode(true), " ", _tmpl$8.cloneNode(true), " ", _tmpl$9.cloneNode(true)];
+    return [_tmpl$7(), " ", _tmpl$8(), " ", _tmpl$9()];
   }
 });
 
 const Template18 = _$createComponent(Pre, {
   get children() {
-    return [_tmpl$7.cloneNode(true), _tmpl$8.cloneNode(true), _tmpl$9.cloneNode(true)];
+    return [_tmpl$7(), _tmpl$8(), _tmpl$9()];
   }
 });

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/conditionalExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/conditionalExpressions/output.js
@@ -5,7 +5,7 @@ import { insert as _$insert } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
 const template1 = (() => {
-  const _el$ = _tmpl$.cloneNode(true);
+  const _el$ = _tmpl$();
 
   _$insert(_el$, simple);
 
@@ -13,7 +13,7 @@ const template1 = (() => {
 })();
 
 const template2 = (() => {
-  const _el$2 = _tmpl$.cloneNode(true);
+  const _el$2 = _tmpl$();
 
   _$insert(_el$2, () => state.dynamic);
 
@@ -21,7 +21,7 @@ const template2 = (() => {
 })();
 
 const template3 = (() => {
-  const _el$3 = _tmpl$.cloneNode(true);
+  const _el$3 = _tmpl$();
 
   _$insert(_el$3, simple ? good : bad);
 
@@ -29,7 +29,7 @@ const template3 = (() => {
 })();
 
 const template4 = (() => {
-  const _el$4 = _tmpl$.cloneNode(true);
+  const _el$4 = _tmpl$();
 
   _$insert(_el$4, () => (simple ? good() : bad));
 
@@ -37,7 +37,7 @@ const template4 = (() => {
 })();
 
 const template5 = (() => {
-  const _el$5 = _tmpl$.cloneNode(true);
+  const _el$5 = _tmpl$();
 
   _$insert(_el$5, () => (state.dynamic ? good() : bad));
 
@@ -45,7 +45,7 @@ const template5 = (() => {
 })();
 
 const template6 = (() => {
-  const _el$6 = _tmpl$.cloneNode(true);
+  const _el$6 = _tmpl$();
 
   _$insert(_el$6, () => state.dynamic && good());
 
@@ -53,7 +53,7 @@ const template6 = (() => {
 })();
 
 const template7 = (() => {
-  const _el$7 = _tmpl$.cloneNode(true);
+  const _el$7 = _tmpl$();
 
   _$insert(_el$7, () => (state.count > 5 ? (state.dynamic ? best : good()) : bad));
 
@@ -61,7 +61,7 @@ const template7 = (() => {
 })();
 
 const template8 = (() => {
-  const _el$8 = _tmpl$.cloneNode(true);
+  const _el$8 = _tmpl$();
 
   _$insert(_el$8, () => state.dynamic && state.something && good());
 
@@ -69,7 +69,7 @@ const template8 = (() => {
 })();
 
 const template9 = (() => {
-  const _el$9 = _tmpl$.cloneNode(true);
+  const _el$9 = _tmpl$();
 
   _$insert(_el$9, () => (state.dynamic && good()) || bad);
 
@@ -77,7 +77,7 @@ const template9 = (() => {
 })();
 
 const template10 = (() => {
-  const _el$10 = _tmpl$.cloneNode(true);
+  const _el$10 = _tmpl$();
 
   _$insert(_el$10, () => (state.a ? "a" : state.b ? "b" : state.c ? "c" : "fallback"));
 
@@ -85,7 +85,7 @@ const template10 = (() => {
 })();
 
 const template11 = (() => {
-  const _el$11 = _tmpl$.cloneNode(true);
+  const _el$11 = _tmpl$();
 
   _$insert(_el$11, () => (state.a ? a() : state.b ? b() : state.c ? "c" : "fallback"));
 
@@ -135,14 +135,14 @@ const template18 = _$createComponent(Comp, {
 });
 
 const template19 = (() => {
-  const _el$12 = _tmpl$.cloneNode(true);
+  const _el$12 = _tmpl$();
 
   _el$12.innerHTML = state.dynamic ? _$createComponent(Comp, {}) : _$createComponent(Comp, {});
   return _el$12;
 })();
 
 const template20 = (() => {
-  const _el$13 = _tmpl$.cloneNode(true);
+  const _el$13 = _tmpl$();
 
   _$insert(_el$13, () =>
     state.dynamic ? _$createComponent(Comp, {}) : _$createComponent(Comp, {})
@@ -164,14 +164,14 @@ const template22 = _$createComponent(Comp, {
 });
 
 const template23 = (() => {
-  const _el$14 = _tmpl$.cloneNode(true);
+  const _el$14 = _tmpl$();
 
   _el$14.innerHTML = state?.dynamic ? "a" : "b";
   return _el$14;
 })();
 
 const template24 = (() => {
-  const _el$15 = _tmpl$.cloneNode(true);
+  const _el$15 = _tmpl$();
 
   _$insert(_el$15, () => (state?.dynamic ? "a" : "b"));
 
@@ -191,14 +191,14 @@ const template26 = _$createComponent(Comp, {
 });
 
 const template27 = (() => {
-  const _el$16 = _tmpl$.cloneNode(true);
+  const _el$16 = _tmpl$();
 
   _el$16.innerHTML = state.dynamic ?? _$createComponent(Comp, {});
   return _el$16;
 })();
 
 const template28 = (() => {
-  const _el$17 = _tmpl$.cloneNode(true);
+  const _el$17 = _tmpl$();
 
   _$insert(_el$17, () => state.dynamic ?? _$createComponent(Comp, {}));
 
@@ -206,7 +206,7 @@ const template28 = (() => {
 })();
 
 const template29 = (() => {
-  const _el$18 = _tmpl$.cloneNode(true);
+  const _el$18 = _tmpl$();
 
   _$insert(_el$18, () => (thing() && thing1()) ?? thing2() ?? thing3());
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/fragments/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/fragments/output.js
@@ -6,11 +6,11 @@ const _tmpl$ = /*#__PURE__*/ _$template(`<div>First</div>`, 2),
   _tmpl$2 = /*#__PURE__*/ _$template(`<div>Last</div>`, 2),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div></div>`, 2);
 
-const multiStatic = [_tmpl$.cloneNode(true), _tmpl$2.cloneNode(true)];
-const multiExpression = [_tmpl$.cloneNode(true), inserted, _tmpl$2.cloneNode(true), "After"];
+const multiStatic = [_tmpl$(), _tmpl$2()];
+const multiExpression = [_tmpl$(), inserted, _tmpl$2(), "After"];
 const multiDynamic = [
   (() => {
-    const _el$5 = _tmpl$.cloneNode(true);
+    const _el$5 = _tmpl$();
 
     _$setAttribute(_el$5, "id", state.first);
 
@@ -18,7 +18,7 @@ const multiDynamic = [
   })(),
   () => state.inserted,
   (() => {
-    const _el$6 = _tmpl$2.cloneNode(true);
+    const _el$6 = _tmpl$2();
 
     _$setAttribute(_el$6, "id", state.last);
 
@@ -28,9 +28,9 @@ const multiDynamic = [
 ];
 const singleExpression = inserted;
 const singleDynamic = inserted;
-const firstStatic = [inserted, _tmpl$3.cloneNode(true)];
-const firstDynamic = [inserted, _tmpl$3.cloneNode(true)];
-const firstComponent = [_$createComponent(Component, {}), _tmpl$3.cloneNode(true)];
-const lastStatic = [_tmpl$3.cloneNode(true), inserted];
-const lastDynamic = [_tmpl$3.cloneNode(true), inserted];
-const lastComponent = [_tmpl$3.cloneNode(true), _$createComponent(Component, {})];
+const firstStatic = [inserted, _tmpl$3()];
+const firstDynamic = [inserted, _tmpl$3()];
+const firstComponent = [_$createComponent(Component, {}), _tmpl$3()];
+const lastStatic = [_tmpl$3(), inserted];
+const lastDynamic = [_tmpl$3(), inserted];
+const lastComponent = [_tmpl$3(), _$createComponent(Component, {})];

--- a/packages/dom-expressions/src/client.d.ts
+++ b/packages/dom-expressions/src/client.d.ts
@@ -9,7 +9,7 @@ export const SVGNamespace: Record<string, string>;
 
 type MountableElement = Element | Document | ShadowRoot | DocumentFragment | Node;
 export function render(code: () => JSX.Element, element: MountableElement): () => void;
-export function template(html: string, count: number, isSVG?: boolean): Element;
+export function template(html: string, count: number, isSVG?: boolean): () => Element;
 export function effect<T>(fn: (prev?: T) => T, init?: T): void;
 export function memo<T>(fn: () => T, equal: boolean): () => T;
 export function insert<T>(
@@ -57,7 +57,7 @@ export function hydrate(
   options?: { renderId?: string }
 ): () => void;
 export function getHydrationKey(): string;
-export function getNextElement(template?: HTMLTemplateElement): Element;
+export function getNextElement(template?: () => HTMLTemplateElement): Element;
 export function getNextMatch(start: Node, elementName: string): Element;
 export function getNextMarker(start: Node): [Node, Array<Node>];
 export function Assets(props: { children?: JSX.Element }): JSX.Element;

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -37,13 +37,17 @@ export function render(code, element, init) {
 }
 
 export function template(html, check, isSVG) {
-  const t = document.createElement("template");
-  t.innerHTML = html;
-  if ("_DX_DEV_" && check && t.innerHTML.split("<").length - 1 !== check)
-    throw `The browser resolved template HTML does not match JSX input:\n${t.innerHTML}\n\n${html}. Is your HTML properly formed?`;
-  let node = t.content.firstChild;
-  if (isSVG) node = node.firstChild;
-  return node;
+  var setup = () => {
+    const t = document.createElement("template");
+    t.innerHTML = html;
+    if ("_DX_DEV_" && check && t.innerHTML.split("<").length - 1 !== check)
+      throw `The browser resolved template HTML does not match JSX input:\n${t.innerHTML}\n\n${html}. Is your HTML properly formed?`;
+    let node = t.content.firstChild;
+    if (isSVG) node = node.firstChild;
+    setup = () => node.cloneNode(true);
+    return setup();
+  }
+  return function() { return setup(); }
 }
 
 export function delegateEvents(eventNames, document = window.document) {
@@ -199,7 +203,7 @@ export function hydrate(code, element, options = {}) {
 export function getNextElement(template) {
   let node, key;
   if (!sharedConfig.context || !(node = sharedConfig.registry.get((key = getHydrationKey())))) {
-    return template.cloneNode(true);
+    return template();
   }
   if (sharedConfig.completed) sharedConfig.completed.add(node);
   sharedConfig.registry.delete(key);


### PR DESCRIPTION
This slightly changes the codegen and how `template` works to defer DOM template node creation until the first invocation.

This *should* improve startup times for large applications by avoiding `document.createElement` calls on yet-unused templates until they're actually needed, which for many large applications is dynamic and varying. We have to dip into the DOM to clone the template nodes anyway, so creating the template at the same time shouldn't interrupt flow too much.

After the node has been created, it replaces the function to return a clone of the node for regular usage, so subsequent calls should be quite cheap/zero-cost.

This was talked about some on Discord, but I figure a draft PR would be a better place.