### PR TITLE
move ref call outside of the spread effect

### DIFF
--- a/packages/dom-expressions/src/universal.js
+++ b/packages/dom-expressions/src/universal.js
@@ -218,16 +218,14 @@ export function createRenderer({
         () => (prevProps.children = insertExpression(node, props.children, prevProps.children))
       );
     }
+    props.ref && props.ref(node);
     effect(() => {
       for (const prop in props) {
-        if (prop === "children") continue;
+        if (prop === "children" || prop === "ref") continue;
         const value = props[prop];
         if (value === prevProps[prop]) continue;
-        if (prop === "ref") value(node);
-        else {
-          setProperty(node, prop, value, prevProps[prop]);
-          prevProps[prop] = value;
-        }
+        setProperty(node, prop, value, prevProps[prop]);
+        prevProps[prop] = value;
       }
     });
     return prevProps;

--- a/packages/dom-expressions/test/dom/spread.spec.jsx
+++ b/packages/dom-expressions/test/dom/spread.spec.jsx
@@ -147,5 +147,100 @@ describe("create component with various spreads", () => {
     expect(span.textContent).toBe("Hi");
     expect(span.$$click).toBeDefined();
     expect(span.getAttribute("data-mode")).toBe("stealth");
+    disposer();
   });
+});
+
+describe("ref scope for cleanup in the spread for elements and components", () => {
+  it("should not crash when ref is no longer in props", () => {
+    let span, disposer;
+    const ref = el => { span = el; };
+
+    const p = S.data({
+      ref,
+      className: "class1"
+    });
+
+    S.root(dispose => {
+      disposer = dispose;
+      <span {...p()}>
+        Hi
+      </span>
+    });
+
+    expect(span).toBeDefined();
+    expect(span.className).toBe("class1");
+    expect(span.textContent).toBe("Hi");
+
+    p({
+      className: "class2"
+    });
+    expect(span.className).toBe("class2");
+    expect(span).toBeDefined();
+    disposer();
+  });
+
+  it("should call ref outside of the non-function spread effect (no ref cleanup)", () => {
+    let span, disposer, refCount = 0, refCleanupCount = 0;
+
+    const Component = props => <span {...props}/>;
+    const ref = el => { ++refCount; span = el; S.cleanup(() => { ++refCleanupCount; }); };
+    const c = S.data("class1");
+
+    S.root(dispose => {
+      disposer = dispose;
+      <Component className={c()} ref={ref}>
+        Hi
+      </Component>
+    });
+
+    expect(span).toBeDefined();
+    expect(span.className).toBe("class1");
+    expect(span.textContent).toBe("Hi");
+    expect(refCount).toBe(1);
+    expect(refCleanupCount).toBe(0);
+
+    c("class2");
+    expect(span.className).toBe("class2");
+    expect(refCount).toBe(1);
+    expect(refCleanupCount).toBe(0);
+
+    disposer();
+    expect(refCleanupCount).toBe(1);
+  });
+  
+  it("should call ref again after cleanup when used in a function spread", () => {
+    let span, disposer, refCount = 0, refCleanupCount = 0;
+
+    const ref = el => { ++refCount; span = el; S.cleanup(() => { ++refCleanupCount; }); };
+    const p = S.data({
+      ref,
+      className: "class1"
+    });
+
+    S.root(dispose => {
+      disposer = dispose;
+      <span {...p()}>
+        Hi
+      </span>
+    });
+
+    expect(span).toBeDefined();
+    expect(span.className).toBe("class1");
+    expect(span.textContent).toBe("Hi");
+    expect(refCount).toBe(1);
+    expect(refCleanupCount).toBe(0);
+
+    p({
+      ref,
+      className: "class2"
+    });
+    expect(span.className).toBe("class2");
+    expect(refCount).toBe(2);
+    expect(refCleanupCount).toBe(1);
+
+    disposer();
+    expect(refCleanupCount).toBe(2);
+  });
+
 });

--- a/packages/dom-expressions/test/universal/spread.spec.jsx
+++ b/packages/dom-expressions/test/universal/spread.spec.jsx
@@ -80,3 +80,96 @@ describe("create component with various spreads", () => {
     disposer();
   });
 });
+
+describe("ref scope for cleanup in the spread for elements and components", () => {
+  it("should not crash when ref is no longer in props", () => {
+    let span, disposer;
+    const ref = el => { span = el; };
+
+    const p = S.data({
+      ref,
+      className: "class1"
+    });
+
+    S.root(dispose => {
+      disposer = dispose;
+      <span {...p()}>
+        Hi
+      </span>
+    });
+
+    expect(span).toBeDefined();
+    expect(span.className).toBe("class1");
+    expect(span.textContent).toBe("Hi");
+
+    p({
+      className: "class2"
+    });
+    expect(span.className).toBe("class2");
+    expect(span).toBeDefined();
+    disposer();
+  });
+
+  it("should call ref outside of the non-function spread effect (no ref cleanup)", () => {
+    let span, disposer, refCount = 0, refCleanupCount = 0;
+
+    const Component = props => <span {...props}/>;
+    const ref = el => { ++refCount; span = el; S.cleanup(() => { ++refCleanupCount; }); };
+    const c = S.data("class1");
+
+    S.root(dispose => {
+      disposer = dispose;
+      <Component className={c()} ref={ref}>
+        Hi
+      </Component>
+    });
+
+    expect(span).toBeDefined();
+    expect(span.className).toBe("class1");
+    expect(span.textContent).toBe("Hi");
+    expect(refCount).toBe(1);
+    expect(refCleanupCount).toBe(0);
+
+    c("class2");
+    expect(span.className).toBe("class2");
+    expect(refCount).toBe(1);
+    expect(refCleanupCount).toBe(0);
+
+    disposer();
+    expect(refCleanupCount).toBe(1);
+  });
+  
+  it("should call ref again after cleanup when used in a function spread", () => {
+    let span, disposer, refCount = 0, refCleanupCount = 0;
+
+    const ref = el => { ++refCount; span = el; S.cleanup(() => { ++refCleanupCount; }); };
+    const p = S.data({
+      ref,
+      className: "class1"
+    });
+
+    S.root(dispose => {
+      disposer = dispose;
+      <span {...p()}>
+        Hi
+      </span>
+    });
+
+    expect(span).toBeDefined();
+    expect(span.className).toBe("class1");
+    expect(span.textContent).toBe("Hi");
+    expect(refCount).toBe(1);
+    expect(refCleanupCount).toBe(0);
+
+    p({
+      ref,
+      className: "class2"
+    });
+    expect(span.className).toBe("class2");
+    expect(refCount).toBe(2);
+    expect(refCleanupCount).toBe(1);
+
+    disposer();
+    expect(refCleanupCount).toBe(2);
+  });
+});

--- a/packages/hyper-dom-expressions/test/hyperscript.spec.js
+++ b/packages/hyper-dom-expressions/test/hyperscript.spec.js
@@ -6,7 +6,7 @@ const h = createHyperScript(r);
 
 const FIXTURES = [
   '<div id="main"><h1>Welcome</h1><span style="color: rgb(85, 85, 85);">555</span><label class="name" for="entry">Edit:</label><input id="entry" type="text" readonly=""></div>',
-  '<div id="main" class="selected" refset="true"><h1 title="hello" style="background-color: red;"><a href="/">Welcome</a></h1></div>',
+  '<div id="main" refset="true" class="selected"><h1 title="hello" style="background-color: red;"><a href="/">Welcome</a></h1></div>',
   '<div id="main"><button>Click Bound</button><button>Click Delegated</button><button>Click Listener</button></div>',
   "<div>First</div>middle<div>Last</div>",
   '<div id="main"><div>John R.<span>Smith</span></div></div>',


### PR DESCRIPTION
This fixes solid issue solidjs/solid#903

[Refs are not reactive](https://discord.com/channels/722131463138705510/722349143024205824/940407159999569970), so ref call does not need to be wrapped in the separate effect

The change I'm less confident with is that the ref now is called even if its value did not change - the ref call is moved above the `if (value === prev)` check, in both web (for spread only) and universal (always?) renderers. But this is necessary to have ref() called again after cleanup in the functional spread ( in `<span {...p()}>` in the last test )