### PR TITLE
make JSX.ElementClass empty so that libs can define requirements

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -21,7 +21,7 @@ export namespace JSX {
     (): Element;
   }
   interface ElementClass {
-    render(props: any): Element;
+    // empty, libs can define requirements downstream
   }
   type LibraryManagedAttributes<Component, Props> = Props;
   interface ElementChildrenAttribute {


### PR DESCRIPTION
This way, a downstream lib can add whatever methods their class lib should have. They might want, for example, to use `template` instead of `render`.

Conversation: https://discord.com/channels/722131463138705510/817960620736380928/960716685499850752