### PR TITLE
add empty ElementAttributesProperty

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -24,6 +24,9 @@ export namespace JSX {
     // empty, libs can define requirements downstream
   }
   type LibraryManagedAttributes<Component, Props> = Props;
+  interface ElementAttributesProperty {
+    // empty, libs can define requirements downstream
+  }
   interface ElementChildrenAttribute {
     children: {};
   }


### PR DESCRIPTION
Similar to `ElementClass`, defines it, but empty so class libs can use it. Should we add this empty? Or delete `ElementClass` instead? Having them present but empty might serve as a hint.