### PR TITLE
Allow Element to be type void

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -15,7 +15,8 @@ export namespace JSX {
     | number
     | boolean
     | null
-    | undefined;
+    | undefined
+    | void;
   interface ArrayElement extends Array<Element> {}
   interface FunctionElement {
     (): Element;


### PR DESCRIPTION
I noticed many times I found components returning explicitly `undefined` to satisfy Element  type:
```jsx
export function MyComponent() {
  // ....
  return undefined;
}
```

I'm wondering if we could allow on `void` type as well, allowing components to not return anything and still be treated as `undefined`.