### PR TITLE
fix *this* in events

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -87,7 +87,8 @@ export function addEventListener(node, name, handler, delegate) {
       node[`$$${name}Data`] = handler[1];
     } else node[`$$${name}`] = handler;
   } else if (Array.isArray(handler)) {
-    node.addEventListener(name, handler[0] = e => handler[0](handler[1], e));
+    const handlerFn = handler[0];
+    node.addEventListener(name, (handler[0] = e => handlerFn.call(node, handler[1], e)));
   } else node.addEventListener(name, handler);
 }
 
@@ -341,7 +342,7 @@ function eventHandler(e) {
     const handler = node[key];
     if (handler && !node.disabled) {
       const data = node[`${key}Data`];
-      data !== undefined ? handler(data, e) : handler(e);
+      data !== undefined ? handler.call(node, data, e) : handler.call(node, e);
       if (e.cancelBubble) return;
     }
     node =


### PR DESCRIPTION
- fixes a infinite recursion bug from [this commit](https://github.com/ryansolid/dom-expressions/commit/cc3437dd25a4bf9fb94381d2dacde0469a673a2e?diff=split#diff-da2a5911aa8defd1b1e3649a3b811b7e67a2a7cea695d42b24a5e4ffd2b68ebdR90)
- implements `this` value in event handlers as per  https://html.spec.whatwg.org/multipage/webappapis.html#the-event-handler-processing-algorithm