### PR TITLE
Fix `normalizeIncomingArray` for non-string items

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -453,7 +453,8 @@ function normalizeIncomingArray(normalized, array, current, unwrap) {
         dynamic = true;
       }
     } else {
-      const value = t === "string" ? item : item.string();
+      // NOTE: is String better than `item + ''`, ``${item}``, `item.toString()` and `item.valueOf()`?
+      const value = String(item);
       if (prev && prev.nodeType === 3 && prev.data === value) {
         normalized.push(prev);
       } else normalized.push(document.createTextNode(value));


### PR DESCRIPTION
The previous code uses `item.string()` which I believe is a typo. This change uses `String(item)` **directly** so it also skips checking if the type is `"string"`.

Fixes https://github.com/solidjs/solid/issues/1093