### PR TITLE
Declare @babel/core as peer dependency

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/package-lock.json
+++ b/packages/babel-plugin-jsx-dom-expressions/package-lock.json
@@ -6,13 +6,16 @@
 	"packages": {
 		"": {
 			"name": "babel-plugin-jsx-dom-expressions",
-			"version": "0.32.11",
+			"version": "0.33.11",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "7.16.0",
 				"@babel/plugin-syntax-jsx": "^7.16.5",
 				"@babel/types": "^7.16.0",
 				"html-entities": "2.3.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/packages/babel-plugin-jsx-dom-expressions/package.json
+++ b/packages/babel-plugin-jsx-dom-expressions/package.json
@@ -22,5 +22,8 @@
     "@babel/plugin-syntax-jsx": "^7.16.5",
     "@babel/types": "^7.16.0",
     "html-entities": "2.3.2"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   }
 }


### PR DESCRIPTION
This avoids issues with yarn 2 complaining about package not providing @babel/core.

```
➤ YN0002: │ babel-plugin-jsx-dom-expressions@npm:0.33.8 doesn't provide @babel/core (p9ac8d), requested by @babel/plugin-syntax-jsx
```

See https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0 for more details.