### PR TITLE
Treat `attribute={true}` like `attribute=""`

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -67,12 +67,12 @@ export function clearDelegatedEvents(document = window.document) {
 
 export function setAttribute(node, name, value) {
   if (value == null) node.removeAttribute(name);
-  else node.setAttribute(name, value);
+  else node.setAttribute(name, value === true ? '' : value);
 }
 
 export function setAttributeNS(node, namespace, name, value) {
   if (value == null) node.removeAttributeNS(namespace, name);
-  else node.setAttributeNS(namespace, name, value);
+  else node.setAttributeNS(namespace, name, value === true ? '' : value);
 }
 
 export function className(node, value) {


### PR DESCRIPTION
Fixes https://github.com/solidjs/solid/issues/1101 by making `<div foo={true}>` (and `<Div foo={true}>` behave like `<div foo>` and `<div foo="">` i.e. HTML Boolean attributes.

It would be good to add tests for this... but I could use help as I haven't touched the tests before.