### PR TITLE
WIP fix: untrack importNode calls for custom elements 

### DIFF
--- a/packages/lit-dom-expressions/src/index.ts
+++ b/packages/lit-dom-expressions/src/index.ts
@@ -3,6 +3,7 @@ import { parse, stringify, IDom } from "html-parse-string";
 type MountableElement = Element | Document | ShadowRoot | DocumentFragment | Node;
 interface Runtime {
   effect<T>(fn: (prev?: T) => T, init?: T): any;
+  untrack?(fn: () => void): void;
   insert(parent: MountableElement, accessor: any, marker?: Node | null, init?: any): any;
   spread<T>(node: Element, accessor: (() => T) | T, isSVG?: Boolean, skipChildren?: Boolean): void;
   createComponent(Comp: (props: any) => any, props: any): any;
@@ -400,7 +401,11 @@ export function createHTML(r: Runtime, { delegateEvents = true } = {}): HTMLTag 
       processChildren(node, options);
       if (topDecl) {
         options.decl[0] = options.hasCustomElement
-          ? `const ${tag} = document.importNode(tmpls[${templateId}].content.firstChild, true)`
+          ? `const ${tag} = ${
+              r.untrack ? "r.untrack(() => " : ""
+            }document.importNode(tmpls[${templateId}].content.firstChild, true)${
+              r.untrack ? ")" : ""
+            }`
           : `const ${tag} = tmpls[${templateId}].content.firstChild.cloneNode(true)`;
       }
     } else if (node.type === "text") {


### PR DESCRIPTION
This avoids accidental infinite loops caused by constructors creating
and using reactive variables. This issue did not previously happen when
all templates used `cloneNode`. `v0.33.7` introduced `importNode` for
custom elements, and some programs started having infinite loops.