### PR TITLE
Fix universal renderer types

### DIFF
--- a/packages/dom-expressions/src/universal.d.ts
+++ b/packages/dom-expressions/src/universal.d.ts
@@ -6,9 +6,9 @@ export interface RendererOptions<NodeType> {
   setProperty<T>(node: NodeType, name: string, value: T, prev?: T): void;
   insertNode(parent: NodeType, node: NodeType, anchor?: NodeType): void;
   removeNode(parent: NodeType, node: NodeType): void;
-  getParentNode(node: NodeType): NodeType;
-  getFirstChild(node: NodeType): NodeType;
-  getNextSibling(node: NodeType): NodeType;
+  getParentNode(node: NodeType): NodeType | undefined;
+  getFirstChild(node: NodeType): NodeType | undefined;
+  getNextSibling(node: NodeType): NodeType | undefined;
 }
 
 export interface Renderer<NodeType> {


### PR DESCRIPTION
This PR changes the return types of `getFirstChild`, `getParentNode` and `getNextSibling` to allow `undefined` to be returned.

`undefined` is a valid case, for example, when the element being queried is the parent node, has no children, is the only child or is the last child. Solid already handles those cases properly with the right checks AFAIK.