### PR TITLE
bump html-parse-string version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ types/
 test/runtime.js
 packages/babel-plugin-jsx-dom-expressions/index.js
 !packages/babel-plugin-jsx-dom-expressions/types/
+package-lock.json

--- a/packages/babel-plugin-jsx-dom-expressions/package.json
+++ b/packages/babel-plugin-jsx-dom-expressions/package.json
@@ -15,7 +15,8 @@
     "build": "rollup -c",
     "test": "npm run build && jest --no-cache",
     "test:coverage": "npm run build && jest --coverage --no-cache",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@babel/helper-module-imports": "7.16.0",

--- a/packages/hyper-dom-expressions/package.json
+++ b/packages/hyper-dom-expressions/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "rollup -c && tsc",
     "test": "npm run build && jest",
-    "test:coverage": "npm run build && jest --coverage"
+    "test:coverage": "npm run build && jest --coverage",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "dom-expressions": "^0.33.13"

--- a/packages/lit-dom-expressions/package.json
+++ b/packages/lit-dom-expressions/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "dom-expressions": "^0.33.13",
-    "html-parse-string": "^0.0.7"
+    "html-parse-string": "0.0.8"
   }
 }

--- a/packages/lit-dom-expressions/package.json
+++ b/packages/lit-dom-expressions/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "rollup -c && tsc",
     "test": "npm run build && jest",
-    "test:coverage": "npm run build && jest --coverage"
+    "test:coverage": "npm run build && jest --coverage",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "dom-expressions": "^0.33.13",

--- a/packages/lit-dom-expressions/package.json
+++ b/packages/lit-dom-expressions/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "dom-expressions": "^0.33.13",
-    "html-parse-string": "0.0.6"
+    "html-parse-string": "trusktr/improve-attribute-parsing#d65d6a8aaa86321cc4d08c94d2fa055bc8792cfd"
   }
 }

--- a/packages/lit-dom-expressions/package.json
+++ b/packages/lit-dom-expressions/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "dom-expressions": "^0.33.13",
-    "html-parse-string": "trusktr/improve-attribute-parsing#d65d6a8aaa86321cc4d08c94d2fa055bc8792cfd"
+    "html-parse-string": "^0.0.7"
   }
 }

--- a/packages/lit-dom-expressions/src/index.ts
+++ b/packages/lit-dom-expressions/src/index.ts
@@ -1,4 +1,5 @@
 import { parse, stringify, IDom } from "html-parse-string";
+import { r } from "regexr";
 
 type MountableElement = Element | Document | ShadowRoot | DocumentFragment | Node;
 interface Runtime {
@@ -32,19 +33,15 @@ export type HTMLTag = {
 const cache = new Map<TemplateStringsArray, HTMLTemplateElement[]>();
 // Based on https://github.com/WebReflection/domtagger/blob/master/esm/sanitizer.js
 const VOID_ELEMENTS = /^(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr)$/i;
-const spaces = " \\f\\n\\r\\t";
-const almostEverything = "[^ " + spaces + "\\/>\"'=]+";
-const attrName = "[ " + spaces + "]+" + almostEverything;
-const tagName = "<([A-Za-z$#]+[A-Za-z0-9:_-]*)((?:";
-const attrPartials =
-  "(?:\\s*=\\s*(?:'[^']*?'|\"[^\"]*?\"|\\([^)]*?\\)|<[^>]*?>|" + almostEverything + "))?)";
+const spaces = r` \f\n\r\t`;
+const almostEverything = r`[^ ${spaces}\/>"'=]+`;
+const attrName = r`[ ${spaces}]+${almostEverything}`;
+const tagName = `<([A-Za-z$#]+[A-Za-z0-9:_-]*)`;
+const attrPartials = r`(?:\s*=\s*(?:'[^']*?'|"[^"]*?"|\([^)]*?\)|<[^>]*?>|${almostEverything}))?`;
 
-const attrSeeker = new RegExp(tagName + attrName + attrPartials + "+)([ " + spaces + "]*/?>)", "g");
-const findAttributes = new RegExp(
-  "(" + attrName + "\\s*=\\s*)(<!--#-->|['\"(]([\\w\\s]*<!--#-->[\\w\\s]*)*['\")])",
-  "gi"
-);
-const selfClosing = new RegExp(tagName + attrName + attrPartials + "*)([ " + spaces + "]*/>)", "g");
+const attrSeeker = r`/${tagName}((?:${attrName}${attrPartials})+)([ ${spaces}]*\/?>)/g`;
+const findAttributes = r`/(${attrName}\s*=\s*)(<!--#-->|['"(]([\w\s]*<!--#-->[\w\s]*)*['")])/gi`;
+const selfClosing = r`/${tagName}((?:${attrName}${attrPartials})*)([ ${spaces}]*\/>)/g`;
 const marker = "<!--#-->";
 const reservedNameSpaces = new Set(["class", "on", "oncapture", "style", "use", "prop", "attr"]);
 

--- a/packages/lit-dom-expressions/src/index.ts
+++ b/packages/lit-dom-expressions/src/index.ts
@@ -1,5 +1,4 @@
 import { parse, stringify, IDom } from "html-parse-string";
-import { r } from "regexr";
 
 type MountableElement = Element | Document | ShadowRoot | DocumentFragment | Node;
 interface Runtime {
@@ -33,15 +32,19 @@ export type HTMLTag = {
 const cache = new Map<TemplateStringsArray, HTMLTemplateElement[]>();
 // Based on https://github.com/WebReflection/domtagger/blob/master/esm/sanitizer.js
 const VOID_ELEMENTS = /^(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr)$/i;
-const spaces = r` \f\n\r\t`;
-const almostEverything = r`[^ ${spaces}\/>"'=]+`;
-const attrName = r`[ ${spaces}]+${almostEverything}`;
-const tagName = `<([A-Za-z$#]+[A-Za-z0-9:_-]*)`;
-const attrPartials = r`(?:\s*=\s*(?:'[^']*?'|"[^"]*?"|\([^)]*?\)|<[^>]*?>|${almostEverything}))?`;
+const spaces = " \\f\\n\\r\\t";
+const almostEverything = "[^ " + spaces + "\\/>\"'=]+";
+const attrName = "[ " + spaces + "]+" + almostEverything;
+const tagName = "<([A-Za-z$#]+[A-Za-z0-9:_-]*)((?:";
+const attrPartials =
+  "(?:\\s*=\\s*(?:'[^']*?'|\"[^\"]*?\"|\\([^)]*?\\)|<[^>]*?>|" + almostEverything + "))?)";
 
-const attrSeeker = r`/${tagName}((?:${attrName}${attrPartials})+)([ ${spaces}]*\/?>)/g`;
-const findAttributes = r`/(${attrName}\s*=\s*)(<!--#-->|['"(]([\w\s]*<!--#-->[\w\s]*)*['")])/gi`;
-const selfClosing = r`/${tagName}((?:${attrName}${attrPartials})*)([ ${spaces}]*\/>)/g`;
+const attrSeeker = new RegExp(tagName + attrName + attrPartials + "+)([ " + spaces + "]*/?>)", "g");
+const findAttributes = new RegExp(
+  "(" + attrName + "\\s*=\\s*)(<!--#-->|['\"(]([\\w\\s]*<!--#-->[\\w\\s]*)*['\")])",
+  "gi"
+);
+const selfClosing = new RegExp(tagName + attrName + attrPartials + "*)([ " + spaces + "]*/>)", "g");
 const marker = "<!--#-->";
 const reservedNameSpaces = new Set(["class", "on", "oncapture", "style", "use", "prop", "attr"]);
 

--- a/packages/lit-dom-expressions/test/html.spec.js
+++ b/packages/lit-dom-expressions/test/html.spec.js
@@ -241,6 +241,12 @@ describe("Test HTML", () => {
     // expect(div.attributes.getNamedItem('beep"boop')?.value).toBe("");
     // expect(div.attributes.getNamedItem("y-o")?.value).toBe('123"456=#$%');
     // expect(div.attributes.getNamedItem("#$%'123-")?.value).toBe("");
+
+    // ensure it handles `"` chars correctly
+    const el = html`<lume-box uniforms='{ "iTime": { "value": 0 } }'></lume-box>`;
+
+    expect(el.attributes.length).toBe(1);
+    expect(el.attributes.uniforms?.value).toBe('{ "iTime": { "value": 0 } }');
   });
 
   test("Test style tag", () => {

--- a/packages/lit-dom-expressions/test/html.spec.js
+++ b/packages/lit-dom-expressions/test/html.spec.js
@@ -44,9 +44,13 @@ describe("Test HTML", () => {
           ref=${el => {
             el.setAttribute("refset", "true");
           }}
-          ...${() => ({title: "hi"})}
+          ...${() => ({ title: "hi" })}
         >
-          <h1 class=${welcoming} title="${welcoming} John ${"Smith"}" style=${() => ({ "background-color": "red" })}>
+          <h1
+            class=${welcoming}
+            title="${welcoming} John ${"Smith"}"
+            style=${() => ({ "background-color": "red" })}
+          >
             <a href="/" ref=${r => (link = r)}>Welcome</a>
           </h1>
         </div>
@@ -109,7 +113,7 @@ describe("Test HTML", () => {
       html` <div>${() => props.name + " " + props.middle}${props.children}</div> `;
     S.root(() => {
       const template = html`
-        <div id="main" ...${() => ({title: "hi"})}>
+        <div id="main" ...${() => ({ title: "hi" })}>
           <${Comp} name=${() => "John"} middle="R."><span>Smith</span><//>
           <div>After</div>
         </div>
@@ -146,18 +150,18 @@ describe("Test HTML", () => {
     const Match = props => props;
     S.root(() => {
       const template = html`<div>
-      <${Switch}>
-        <${Match} when=${1}>
-          <div>Hi</div>
+        <${Switch}>
+          <${Match} when=${1}>
+            <div>Hi</div>
+          <//>
+          <${Match} when=${2}>
+            <div>Morris</div>
+          <//>
+          <${Match} when=${3}>
+            <p>Jamie</p>
+          <//>
         <//>
-        <${Match} when=${2}>
-          <div>Morris</div>
-        <//>
-        <${Match} when=${3}>
-          <p>Jamie</p>
-        <//>
-      <//>
-    </div>`;
+      </div>`;
       const div = document.createElement("div");
       div.appendChild(template);
       expect(div.innerHTML.replace(/<!--#-->/g, "")).toBe(FIXTURES[6]);
@@ -175,26 +179,89 @@ describe("Test HTML", () => {
     div.appendChild(template);
     expect(div.innerHTML.replace(/<!--#-->/g, "")).toBe(FIXTURES[7]);
   });
-});
 
-test("Test style tag", () => {
-  const color = "red";
-  // prettier-ignore
-  const template = html`
-    <style>.something{color:${color}}</style>
-  `;
-  const div = document.createElement("div");
-  div.appendChild(template);
-  expect(div.innerHTML.replace(/<!--#-->/g, "")).toBe(FIXTURES[8]);
-});
+  test("multi-line, strange-but-valid, and edge-case attributes", () => {
+    // This tests some attributes that previously did not work (but not all of
+    // them, because html template tag still stumbles on the uncommon ones
+    // (TODO)), detailed in
+    // https://github.com/ryansolid/dom-expressions/issues/143 and
+    // https://github.com/ryansolid/html-parse-string/issues/3
 
-test("Test double toggle classList", () => {
-  S.root(() => {
-    const d = S.data("first");
-    const template = html` <div classList=${() => ({ [d()]: true })} /> `;
+    /** @type {HTMLDivElement} */
+    // prettier-ignore
+    // We need to not format this HTML code otherwise prettier changes or even breaks the special cases we're testing.
+    const div = html`
+      <div
+        multiline="
+          foo
+          bar
+        "
+        multi-line="
+          foo
+          bar
+        "
+        lorem ipsum these-all-need-to-be-on-the-same-line
+        baz=123=456
+        #$%=123
+      ></div>
+    `;
+
+    // TODO these attributes are parsed correctly by html-parse-string now, but
+    // html template tag doesn't handle them well yet.
+    // beep"boop
+    // y-o=123"456=#$%
+    // #$%'123-
+
+    // It was previously creating attributes from each new line.
+    expect(div.attributes.getNamedItem("foo")).toBe(null);
+    expect(div.attributes.getNamedItem("bar")).toBe(null);
+
+    // Such attributes should now be preserved.
+    expect(div.attributes.getNamedItem("multiline")?.value).toBe(
+      `
+          foo
+          bar
+        `
+    );
+
+    expect(div.attributes.getNamedItem("multi-line")?.value).toBe(
+      `
+          foo
+          bar
+        `
+    );
+
+    expect(div.attributes.getNamedItem("lorem")?.value).toBe("");
+    expect(div.attributes.getNamedItem("ipsum")?.value).toBe("");
+    expect(div.attributes.getNamedItem("these-all-need-to-be-on-the-same-line")?.value).toBe("");
+    expect(div.attributes.getNamedItem("baz")?.value).toBe("123=456");
+    expect(div.attributes.getNamedItem("#$%")?.value).toBe("123");
+
+    // TODO
+    // expect(div.attributes.getNamedItem('beep"boop')?.value).toBe("");
+    // expect(div.attributes.getNamedItem("y-o")?.value).toBe('123"456=#$%');
+    // expect(div.attributes.getNamedItem("#$%'123-")?.value).toBe("");
+  });
+
+  test("Test style tag", () => {
+    const color = "red";
+    // prettier-ignore
+    const template = html`
+      <style>.something{color:${color}}</style>
+    `;
     const div = document.createElement("div");
     div.appendChild(template);
-    d("second");
-    expect(div.innerHTML.replace(/<!--#-->/g, "")).toBe(FIXTURES[9]);
+    expect(div.innerHTML.replace(/<!--#-->/g, "")).toBe(FIXTURES[8]);
+  });
+
+  test("Test double toggle classList", () => {
+    S.root(() => {
+      const d = S.data("first");
+      const template = html` <div classList=${() => ({ [d()]: true })} /> `;
+      const div = document.createElement("div");
+      div.appendChild(template);
+      d("second");
+      expect(div.innerHTML.replace(/<!--#-->/g, "")).toBe(FIXTURES[9]);
+    });
   });
 });


### PR DESCRIPTION
Note, we wouldn't need to bump the version for every non-breaking html-parse-string release if we bump it to `0.1.x` or higher.