### PR TITLE
Add types for onAuxClick

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -161,6 +161,7 @@ export namespace JSX {
     onVolumeChange?: EventHandlerUnion<T, Event>;
     onWaiting?: EventHandlerUnion<T, Event>;
     onClick?: EventHandlerUnion<T, MouseEvent>;
+    onAuxClick?: EventHandlerUnion<T, MouseEvent>;
     onContextMenu?: EventHandlerUnion<T, MouseEvent>;
     onDblClick?: EventHandlerUnion<T, MouseEvent>;
     onDrag?: EventHandlerUnion<T, DragEvent>;
@@ -250,6 +251,7 @@ export namespace JSX {
     onvolumechange?: EventHandlerUnion<T, Event>;
     onwaiting?: EventHandlerUnion<T, Event>;
     onclick?: EventHandlerUnion<T, MouseEvent>;
+    onauxclick?: EventHandlerUnion<T, MouseEvent>;
     oncontextmenu?: EventHandlerUnion<T, MouseEvent>;
     ondblclick?: EventHandlerUnion<T, MouseEvent>;
     ondrag?: EventHandlerUnion<T, DragEvent>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -160,6 +160,7 @@ export namespace JSX {
     onVolumeChange?: EventHandlerUnion<T, Event>;
     onWaiting?: EventHandlerUnion<T, Event>;
     onClick?: EventHandlerUnion<T, MouseEvent>;
+    onAuxClick?: EventHandlerUnion<T, MouseEvent>;
     onContextMenu?: EventHandlerUnion<T, MouseEvent>;
     onDblClick?: EventHandlerUnion<T, MouseEvent>;
     onDrag?: EventHandlerUnion<T, DragEvent>;
@@ -249,6 +250,7 @@ export namespace JSX {
     onvolumechange?: EventHandlerUnion<T, Event>;
     onwaiting?: EventHandlerUnion<T, Event>;
     onclick?: EventHandlerUnion<T, MouseEvent>;
+    onauxclick?: EventHandlerUnion<T, MouseEvent>;
     oncontextmenu?: EventHandlerUnion<T, MouseEvent>;
     ondblclick?: EventHandlerUnion<T, MouseEvent>;
     ondrag?: EventHandlerUnion<T, DragEvent>;


### PR DESCRIPTION
As reported by @fabiospampinato, the types for `onAuxClick` were missing, despite the existence of [auxclick event](https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event). He wrote in #typescript:

> I don't know why, but the middle click seems to fire an "auxclick" for me, not a "click", so this feels pretty much essential. A convenience onMiddleClick might be worth exploring too.