### PR TITLE
feat: ungroup dynamics for universal renderer

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
@@ -41,28 +41,30 @@ const template = (() => {
 
   _$setProp(_el$3, "readonly", value);
 
-  _$effect(
-    _p$ => {
-      const _v$ = welcoming(),
-        _v$2 = {
-          "background-color": color(),
-          "margin-right": "40px"
-        },
-        _v$3 = {
-          dynamic: dynamic(),
-          selected
-        };
+  _$effect(_$p => _$setProp(_el$2, "title", welcoming(), _$p));
 
-      _v$ !== _p$._v$ && (_p$._v$ = _$setProp(_el$2, "title", _v$, _p$._v$));
-      _v$2 !== _p$._v$2 && (_p$._v$2 = _$setProp(_el$2, "style", _v$2, _p$._v$2));
-      _v$3 !== _p$._v$3 && (_p$._v$3 = _$setProp(_el$2, "classList", _v$3, _p$._v$3));
-      return _p$;
-    },
-    {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined
-    }
+  _$effect(_$p =>
+    _$setProp(
+      _el$2,
+      "style",
+      {
+        "background-color": color(),
+        "margin-right": "40px"
+      },
+      _$p
+    )
+  );
+
+  _$effect(_$p =>
+    _$setProp(
+      _el$2,
+      "classList",
+      {
+        dynamic: dynamic(),
+        selected
+      },
+      _$p
+    )
   );
 
   return _el$;
@@ -144,26 +146,22 @@ const template6 = (() => {
 const template7 = (() => {
   const _el$13 = _$createElement("div");
 
-  _$effect(
-    _p$ => {
-      const _v$4 = {
-          "background-color": color(),
-          "margin-right": "40px",
-          ...props.style
-        },
-        _v$5 = props.top,
-        _v$6 = props.active;
-      _v$4 !== _p$._v$4 && (_p$._v$4 = _$setProp(_el$13, "style", _v$4, _p$._v$4));
-      _v$5 !== _p$._v$5 && (_p$._v$5 = _$setProp(_el$13, "style:padding-top", _v$5, _p$._v$5));
-      _v$6 !== _p$._v$6 && (_p$._v$6 = _$setProp(_el$13, "class:my-class", _v$6, _p$._v$6));
-      return _p$;
-    },
-    {
-      _v$4: undefined,
-      _v$5: undefined,
-      _v$6: undefined
-    }
+  _$effect(_$p =>
+    _$setProp(
+      _el$13,
+      "style",
+      {
+        "background-color": color(),
+        "margin-right": "40px",
+        ...props.style
+      },
+      _$p
+    )
   );
+
+  _$effect(_$p => _$setProp(_el$13, "style:padding-top", props.top, _$p));
+
+  _$effect(_$p => _$setProp(_el$13, "class:my-class", props.active, _$p));
 
   return _el$13;
 })();


### PR DESCRIPTION
### Summary

This PR removes the effect grouping for dynamics in the 'universal' generated code

### Description

A potential perf issue when complex objects that have reactive props inside them are passed as props in the template.

```ts
<element prop1={[ {x: 30}, { y: count() }]} prop2={{ key: anotherSignal() }} />
```

The transformer will group those 2 props into a single effect, which is neat, but because the values are complex, they will always fail an equality check:

```ts
_$effect(_p$ => {
  const _v$ = [{
    x: 30
  }, {
    y: count()
  }],
  _v$2 = {
    key: anotherSignal()
  };
  _v$ !== _p$._v$ && (_p$._v$ = _$setProp(_el$, "prop1", _v$, _p$._v$));
  _v$2 !== _p$._v$2 && (_p$._v$2 = _$setProp(_el$, "prop2", _v$2, _p$._v$2));
  return _p$;
}, {
  _v$: undefined,
  _v$2: undefined
});
```

Note that _v$ will be a new array on every effect run. _v$2 will be a new object on every effect run. Both will fail the equality check and reassign on any signal change of that effect, be it count() or another().

Removing grouping means you trade memory for execution speed because now dynamics only execute for the props they depend on. If you want this to be a configuration option let me know.

### Testing

Unit tests green