### PR TITLE
fix(type): style use variable type error

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -283,9 +283,10 @@ export namespace JSX {
     onanimationiteration?: EventHandlerUnion<T, AnimationEvent>;
     ontransitionend?: EventHandlerUnion<T, TransitionEvent>;
   }
-  
+
   interface CSSProperties extends csstype.PropertiesHyphen {
     // Override
+    [key: string]: string | number | undefined;
   }
 
   type HTMLAutocapitalize = "off" | "none" | "on" | "sentences" | "words" | "characters";

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -285,6 +285,7 @@ export namespace JSX {
 
   interface CSSProperties extends csstype.PropertiesHyphen {
     // Override
+    [key: string]: string | number | undefined;
   }
 
   type HTMLAutocapitalize = "off" | "none" | "on" | "sentences" | "words" | "characters";


### PR DESCRIPTION
- fix: https://github.com/solidjs/solid/issues/1184 

can also use more strict 
```{ [key: `—${string}`]: string | number | undefined }```