### PR TITLE
(feat) augmentable JSX-Element-type

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -10,15 +10,16 @@ type DOMElement = Element;
 
 export namespace JSX {
   type FunctionMaybe<T = unknown> = ({ (): T }) | T;
-  type Element =
-    | Node
-    | ArrayElement
-    | FunctionElement
-    | (string & {})
-    | number
-    | boolean
-    | null
-    | undefined;
+  interface ElementRegistry {
+    Node: Node;
+    ArrayElement: ArrayElement;
+    FunctionElement: FunctionElement;
+    "(string & {})": string & {};
+    number: number;
+    boolean: boolean;
+    null: null;
+    undefined: undefined;
+  }
   interface ArrayElement extends Array<Element> {}
   interface FunctionElement {
     (): Element;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -9,15 +9,16 @@ import * as csstype from 'csstype';
 type DOMElement = Element;
 
 export namespace JSX {
-  type Element =
-    | Node
-    | ArrayElement
-    | FunctionElement
-    | (string & {})
-    | number
-    | boolean
-    | null
-    | undefined;
+  interface ElementRegistry {
+    Node: Node;
+    ArrayElement: ArrayElement;
+    FunctionElement: FunctionElement;
+    "(string & {})": string & {};
+    number: number;
+    boolean: boolean;
+    null: null;
+    undefined: undefined;
+  }
   interface ArrayElement extends Array<Element> {}
   interface FunctionElement {
     (): Element;


### PR DESCRIPTION
I have been having a lot of fun lately with custom JSX-elements ([for example with this little side-project](https://github.com/vincentvandijck/plasticinecms)) : JSX are functions and functions can return more then dom-elements or any of the allowed JSXElement-types. Solidjs itself allows this approach, but it is impossible right now to properly type these components as types can not be augmented through declaration. 

My proposal is to follow a pattern described [here](https://github.com/microsoft/TypeScript/issues/28078)
`interface XRegistry {
  A:A
  B:B
  C:C
}`
`type X= XRegistry[keyof XRegistry];`
//... And in the other file
`declare module "someModule" {
  interface XRegistry { D:D }
}`

This way JSXElements could be augmented through a declaration-file as follows
`declare module 'solid-js/jsx-runtime' {
	namespace JSX {
		interface CustomElement {
			test: string
		}
		interface ElementRegistry {
			CustomElement: CustomElement
		}
	}
}`

It creates identical code if not augmented, and works perfectly as is right now. If you want an example of it in action: ([this repo](https://github.com/vincentvandijck/plasticinecms)) contains a patch with it working.

(I thought first to make the pull request with Solid, but the tests and builds kept on overwriting my changes, so I realized it was importing the types from here)