### PR TITLE
fix runtime error on empty style/script tags

### DIFF
--- a/packages/lit-dom-expressions/src/index.ts
+++ b/packages/lit-dom-expressions/src/index.ts
@@ -100,7 +100,7 @@ export function createHTML(r: Runtime, { delegateEvents = true } = {}): HTMLTag 
       templates[i].innerHTML = html[i];
       const nomarkers = templates[i].content.querySelectorAll("script,style");
       for (let j = 0; j < nomarkers.length; j++) {
-        const d = (nomarkers[j].firstChild as Text)!.data || "";
+        const d = (nomarkers[j].firstChild as Text | null)?.data || "";
         if (d.indexOf(marker) > -1) {
           const parts = d.split(marker).reduce((memo, p, i) => {
             i && memo.push("");


### PR DESCRIPTION
There was previously a runtime error on empty script/style tags here, because `firstChild` was `null` in those cases, but the type cast assumed it to be non-null and a non-null assertion was being used on a null value. Now the type is casted to nullable, and an optional-chaining operator is used instead of non-null assertion to catch the `null` case.