### PR TITLE
reliable quick start command to initialize this project

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,9 @@
         "rollup-plugin-cleanup": "^3.2.1",
         "s-js": "0.4.9",
         "typescript": "~4.5.4"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "build": "lerna run build --concurrency=1 --stream",
     "publish:release": "lerna run build && lerna publish",
     "report:coverage": "lerna run report:coverage --parallel",
-    "bootstrap": "lerna bootstrap"
+    "bootstrap": "lerna bootstrap",
+    "init": "npm install && npm run bootstrap"
+  },
+  "engines": {
+    "npm": ">=7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",


### PR DESCRIPTION
# Summary

This PR implements thoughts at https://github.com/ryansolid/dom-expressions/issues/172:

1. Introducing a new npm script to finish all initialization task.
2. Once the NPM version is not matched, `npm install` will get following error:

```bash
➜  dom-expressions git:(main) ✗ npm run init

> dom-expressions-build@0.31.0 init ~/dom-expressions
> npm install && npm run bootstrap

npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for dom-expressions-build@0.31.0: wanted: {"npm":">=7.0.0"} (current: {"node":"14.19.3","npm":"6.14.17"})
npm ERR! notsup Not compatible with your version of node/npm: dom-expressions-build@0.31.0
npm ERR! notsup Not compatible with your version of node/npm: dom-expressions-build@0.31.0
npm ERR! notsup Required: {"npm":">=7.0.0"}
npm ERR! notsup Actual:   {"npm":"6.14.17","node":"14.19.3"}

npm ERR! A complete log of this run can be found in:
npm ERR!     ~/.npm/_logs/2022-10-21T17_30_34_285Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! dom-expressions-build@0.31.0 init: `npm install && npm run bootstrap`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the dom-expressions-build@0.31.0 init script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     ~/.npm/_logs/2022-10-21T17_30_34_319Z-debug.log
```


close: #172