### PR TITLE
Added missing events for dialog element

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -727,6 +727,8 @@ export namespace JSX {
   }
   interface DialogHtmlAttributes<T> extends HTMLAttributes<T> {
     open?: boolean;
+    onClose?: EventHandlerUnion<T, Event>;
+    onCancel?: EventHandlerUnion<T, Event>;
   }
   interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
     height?: number | string;


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog dialog element also supports `cancel` and `close` events
