### PR TITLE
fix-dom-function-children

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
@@ -115,7 +115,12 @@ function escapeExpression(path, expression, attr) {
   if (t.isStringLiteral(expression) || t.isNumericLiteral(expression)) {
     return expression;
   } else if (t.isFunction(expression)) {
-    expression.body = escapeExpression(path, expression.body, attr);
+    if (t.isBlockStatement(expression.body)) {
+      expression.body.body = expression.body.body.map(e => {
+        if (t.isReturnStatement(e)) e.argument = escapeExpression(path, e.argument, attr);
+        return e;
+      });
+    } else expression.body = escapeExpression(path, expression.body, attr);
     return expression;
   } else if (t.isTemplateLiteral(expression)) {
     expression.expressions = expression.expressions.map(e => escapeExpression(path, e, attr));

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/insertChildren/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/insertChildren/code.js
@@ -34,3 +34,19 @@ tiles.push(<div>Test 1</div>);
 const template24 = <div>{tiles}</div>;
 
 const comma = <div>{expression(), "static"}</div>
+
+const template25 = <div>{() => children}</div>
+
+const template26 = (
+  <div>{() => {
+    statement;
+    return children;
+  }}</div>
+)
+
+const template27 = (
+  <div>{(() => {
+    statement;
+    return children;
+  })()}</div>
+)

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/insertChildren/output.js
@@ -97,3 +97,18 @@ tiles.push(_$ssr(_tmpl$5));
 const template24 = _$ssr(_tmpl$6, _$escape(tiles));
 
 const comma = _$ssr(_tmpl$6, _$escape((expression(), "static")));
+
+const template25 = _$ssr(_tmpl$6, () => _$escape(children));
+
+const template26 = _$ssr(_tmpl$6, () => {
+  statement;
+  return _$escape(children);
+});
+
+const template27 = _$ssr(
+  _tmpl$6,
+  (() => {
+    statement;
+    return _$escape(children);
+  })()
+);


### PR DESCRIPTION
Fixes a problem where passing functions (either arrow functions or function expressions) with a block body would break compilation.
Fixes https://github.com/solidjs/solid/issues/1423