### PR TITLE
refactor: keep persistent type

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -40,7 +40,7 @@ export function transformElement(path, info) {
     isCustomElement = tagName.indexOf("-") > -1,
     results = {
       template: `<${tagName}`,
-      decl: [],
+      declarations: [],
       exprs: [],
       dynamics: [],
       postExprs: [],
@@ -612,7 +612,7 @@ function transformAttributes(path, results) {
             nextElem = attribute.scope.generateUidIdentifier("el$");
             children = t.JSXText(" ");
             children.extra = { raw: " ", rawValue: " " };
-            results.decl.push(
+            results.declarations.push(
               t.variableDeclarator(nextElem, t.memberExpression(elem, t.identifier("firstChild")))
             );
           }
@@ -713,7 +713,7 @@ function transformChildren(path, results, config) {
         t.identifier(tempPath),
         t.identifier(i === 0 ? "firstChild" : "nextSibling")
       );
-      results.decl.push(
+      results.declarations.push(
         t.variableDeclarator(
           child.id,
           config.hydratable && tagName === "html"
@@ -721,7 +721,7 @@ function transformChildren(path, results, config) {
             : walk
         )
       );
-      results.decl.push(...child.decl);
+      results.declarations.push(...child.declarations);
       results.exprs.push(...child.exprs);
       results.dynamics.push(...child.dynamics);
       results.postExprs.push(...child.postExprs);
@@ -781,7 +781,7 @@ function createPlaceholder(path, results, tempPath, i, char) {
   results.template += `<!${char}>`;
   if (config.hydratable && char === "/") {
     contentId = path.scope.generateUidIdentifier("co$");
-    results.decl.push(
+    results.declarations.push(
       t.variableDeclarator(
         t.arrayPattern([exprId, contentId]),
         t.callExpression(
@@ -791,7 +791,7 @@ function createPlaceholder(path, results, tempPath, i, char) {
       )
     );
   } else
-    results.decl.push(
+    results.declarations.push(
       t.variableDeclarator(
         exprId,
         t.memberExpression(

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
@@ -105,8 +105,8 @@ function registerTemplate(path, results) {
           ])
     );
   }
-  results.decl.unshift(decl);
-  results.decl = t.variableDeclaration("const", results.decl);
+  results.declarations.unshift(decl);
+  results.decl = t.variableDeclaration("const", results.declarations);
 }
 
 function wrapDynamics(path, dynamics) {
@@ -142,7 +142,7 @@ function wrapDynamics(path, dynamics) {
       ])
     );
   }
-  const decls = [],
+  const declarations = [],
     statements = [],
     identifiers = [],
     prevId = t.identifier("_p$");
@@ -152,7 +152,7 @@ function wrapDynamics(path, dynamics) {
       value = t.unaryExpression("!", t.unaryExpression("!", value));
     }
     identifiers.push(identifier);
-    decls.push(t.variableDeclarator(identifier, value));
+    declarations.push(t.variableDeclarator(identifier, value));
     if (key === "classList" || key === "style") {
       const prev = t.memberExpression(prevId, identifier);
       statements.push(
@@ -188,7 +188,7 @@ function wrapDynamics(path, dynamics) {
       t.arrowFunctionExpression(
         [prevId],
         t.blockStatement([
-          t.variableDeclaration("const", decls),
+          t.variableDeclaration("const", declarations),
           ...statements,
           t.returnStatement(prevId)
         ])

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
@@ -63,7 +63,7 @@ export function transformNode(path, info = {}) {
   if (t.isJSXElement(node)) {
     return transformElement(config, path, info);
   } else if (t.isJSXFragment(node)) {
-    let results = { template: "", decl: [], exprs: [], dynamics: [] };
+    let results = { template: "", declarations: [], exprs: [], dynamics: [] };
     // <><div /><Component /></>
     transformFragmentChildren(path.get("children"), results, config);
     return results;
@@ -77,7 +77,7 @@ export function transformNode(path, info = {}) {
     if (!text.length) return null;
     const results = {
       template: config.generate === "ssr" ? text : escapeBackticks(text),
-      decl: [],
+      declarations: [],
       exprs: [],
       dynamics: [],
       postExprs: [],

--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
@@ -43,7 +43,7 @@ export function transformElement(path, info) {
     results = {
       template: [`<${tagName}`],
       templateValues: [],
-      decl: [],
+      declarations: [],
       exprs: [],
       dynamics: [],
       tagName,

--- a/packages/babel-plugin-jsx-dom-expressions/src/universal/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/universal/element.js
@@ -16,7 +16,7 @@ export function transformElement(path, info) {
   let tagName = getTagName(path.node),
     results = {
       id: path.scope.generateUidIdentifier("el$"),
-      decl: [],
+      declarations: [],
       exprs: [],
       dynamics: [],
       postExprs: [],
@@ -24,7 +24,7 @@ export function transformElement(path, info) {
       renderer: "universal"
     };
 
-  results.decl.push(
+  results.declarations.push(
     t.variableDeclarator(
       results.id,
       t.callExpression(
@@ -240,7 +240,7 @@ function transformChildren(path, results) {
           getRendererConfig(path, "universal").moduleName
         );
         if (multi) {
-          results.decl.push(
+          results.declarations.push(
             t.variableDeclarator(
               child.id,
               t.callExpression(createTextNode, [
@@ -254,7 +254,7 @@ function transformChildren(path, results) {
           ]);
       }
       appends.push(t.expressionStatement(t.callExpression(insertNode, [results.id, insert])));
-      results.decl.push(...child.decl);
+      results.declarations.push(...child.declarations);
       results.exprs.push(...child.exprs);
       results.dynamics.push(...child.dynamics);
     } else if (child.exprs.length) {

--- a/packages/babel-plugin-jsx-dom-expressions/src/universal/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/universal/template.js
@@ -5,7 +5,7 @@ import { setAttr } from "./element";
 export function createTemplate(path, result, wrap) {
   const config = getConfig(path);
   if (result.id) {
-    result.decl = t.variableDeclaration("const", result.decl);
+    result.decl = t.variableDeclaration("const", result.declarations);
     if (
       !(result.exprs.length || result.dynamics.length || result.postExprs.length) &&
       result.decl.declarations.length === 1
@@ -55,14 +55,14 @@ function wrapDynamics(path, dynamics) {
       ])
     );
   }
-  const decls = [],
+  const declarations = [],
     statements = [],
     identifiers = [],
     prevId = t.identifier("_p$");
   dynamics.forEach(({ elem, key, value }) => {
     const identifier = path.scope.generateUidIdentifier("v$");
     identifiers.push(identifier);
-    decls.push(t.variableDeclarator(identifier, value));
+    declarations.push(t.variableDeclarator(identifier, value));
     const prev = t.memberExpression(prevId, identifier);
     statements.push(
       t.expressionStatement(
@@ -86,7 +86,7 @@ function wrapDynamics(path, dynamics) {
       t.arrowFunctionExpression(
         [prevId],
         t.blockStatement([
-          t.variableDeclaration("const", decls),
+          t.variableDeclaration("const", declarations),
           ...statements,
           t.returnStatement(prevId)
         ])


### PR DESCRIPTION
# Motivation

We should not modify the type of a variable at runtime, this can be error prone and misleading:

```ts
results.decl.unshift(decl);
results.decl = t.variableDeclaration("const", results.decl); // decl's type changed from `array` to `t.VariableDeclaration`
```

To fix this, we can create another property to save the original declarations.