### PR TITLE
refactor: do not use deprecated `t.cloneDeep`

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -44,7 +44,7 @@ export function registerImportMethod(path, name, moduleName) {
     // the cloning is required to play well with babel-preset-env which is
     // transpiling import as we add them and using the same identifier causes
     // problems with the multiple identifiers of the same thing
-    return t.cloneDeep(iden);
+    return t.cloneNode(iden);
   }
 }
 


### PR DESCRIPTION
`t.cloneDeep` was deprecated at `@babel/types` <sup>[1]</sup>

[1] https://github.com/babel/babel/pull/7149/files#diff-485c64b2cca1542ce531c88388b1d12cabbc7a0ae5846be94c68d3fc81e057d7