### PR TITLE
fix: add href attribute to GradientElementSVGAttributes interface

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1291,6 +1291,7 @@ export namespace JSX {
     gradientUnits?: FunctionMaybe<SVGUnits>;
     gradientTransform?: FunctionMaybe<string>;
     spreadMethod?: FunctionMaybe<"pad" | "reflect" | "repeat">;
+    href?: FunctionMaybe<string>
   }
   interface GraphicsElementSVGAttributes<T>
     extends CoreSVGAttributes<T>,

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1301,6 +1301,7 @@ export namespace JSX {
     gradientUnits?: SVGUnits;
     gradientTransform?: string;
     spreadMethod?: "pad" | "reflect" | "repeat";
+    href?: string
   }
   interface GraphicsElementSVGAttributes<T>
     extends CoreSVGAttributes<T>,


### PR DESCRIPTION
There might be other types missing, I just stumbled on this in my project. See [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href)

I am uncertain about the implications of `FunctionMaybe` type but I followed example of similar attribute typing.