### PR TITLE
Lazy template creation

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -58,15 +58,30 @@ export function render(code, element, init, options = {}) {
   };
 }
 
-export function template(html, check, isSVG) {
-  const t = document.createElement("template");
-  t.innerHTML = html;
-  if ("_DX_DEV_" && check && t.innerHTML.split("<").length - 1 !== check)
-    throw `The browser resolved template HTML does not match JSX input:\n${t.innerHTML}\n\n${html}. Is your HTML properly formed?`;
-  let node = t.content.firstChild;
-  if (isSVG) node = node.firstChild;
-  return node;
-}
+export const template = function template(
+  templates,
+  html,
+  check,
+  isSVG,
+) {
+  return {
+    cloneNode: e => {
+      if (!templates.has(html)) {
+        const t = document.createElement('template')
+        t.innerHTML = html
+        if ('_DX_DEV_' && check && t.innerHTML.split('<').length - 1 !== check)
+          throw `The browser resolved template HTML does not match JSX input:\n${t.innerHTML}\n\n${html}. Is your HTML properly formed?`
+        templates.set(
+          html,
+          isSVG
+            ? t.content.firstChild.firstChild
+            : t.content.firstChild,
+        )
+      }
+      return templates.get(html).cloneNode(e)
+    },
+  }
+}.bind(null, new Map())
 
 export function delegateEvents(eventNames, document = window.document) {
   const e = document[$$EVENTS] || (document[$$EVENTS] = new Set());

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -58,30 +58,22 @@ export function render(code, element, init, options = {}) {
   };
 }
 
-export const template = function template(
-  templates,
-  html,
-  check,
-  isSVG,
-) {
+export function template(html, check, isSVG) {
   return {
-    cloneNode: e => {
-      if (!templates.has(html)) {
-        const t = document.createElement('template')
-        t.innerHTML = html
-        if ('_DX_DEV_' && check && t.innerHTML.split('<').length - 1 !== check)
-          throw `The browser resolved template HTML does not match JSX input:\n${t.innerHTML}\n\n${html}. Is your HTML properly formed?`
-        templates.set(
-          html,
-          isSVG
-            ? t.content.firstChild.firstChild
-            : t.content.firstChild,
-        )
-      }
-      return templates.get(html).cloneNode(e)
+    cloneNode: function (e) {
+      const t = document.createElement('template')
+      t.innerHTML = html
+      if ('_DX_DEV_' && check && t.innerHTML.split('<').length - 1 !== check)
+        throw `The browser resolved template HTML does not match JSX input:\n${t.innerHTML}\n\n${html}. Is your HTML properly formed?`
+      const node = isSVG
+        ? t.content.firstChild.firstChild
+        : t.content.firstChild
+
+      this.cloneNode = node.cloneNode.bind(node)
+      return this.cloneNode(e)
     },
   }
-}.bind(null, new Map())
+}
 
 export function delegateEvents(eventNames, document = window.document) {
   const e = document[$$EVENTS] || (document[$$EVENTS] = new Set());


### PR DESCRIPTION
From time to time, one questions if templates should be created when used, instead of at start-up.  Currently, solid creates all the templates at startup, regardless if these are going to be used or not.

In my opinion, templates should be created when used.

Pros:
- pushes time spent in creation to the pages on which the nodes are used, giving a measurable faster startup (in the range of milliseconds).
- from a purist point of view, it doesn't spend time working on things it may not use
- this is specially beneficial for SPA with a lot of components

Cons:
- If pushing the node creation to the pages makes the landing page faster, then that means that switching pages requires creating the nodes, so it will make the navigation slightly slower. The thing is, that _usually_ components are distributed on the pages, so any possible slow down caused by this change will be also distributed and won't be as bad as the _slowdown_ generated by creating all the components at once.  

Alternatives:
- make this configurable? Seems not worthy on my opinion.

~~Please note that this change also includes caching, which means that any template that has the exact same shape will be reused and not regenerated.~~

Real life testing:

| function          | templates created | time  |
| ----------------- | ------------------ | ----- |
| current template  | 153                | 3ms   |
| improved template | 23                 | 0.5ms |