### PR TITLE
Fix server.js error missing `r`

### DIFF
--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -24,7 +24,7 @@ export function renderToString(code, options = {}) {
     }
   };
   let html = root((d) => {
-    resolveSSRNode(escape(code()))
+    let r = resolveSSRNode(escape(code()));
     d();
     return r;
   });


### PR DESCRIPTION
Recent error caused all `renderToString` calls to be broken (this heavily affected Astro users)