### PR TITLE
fix: add enterkeyhint attribute to InputHTMLAttributes interface

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -803,6 +803,7 @@ export namespace JSX {
     checked?: boolean;
     crossorigin?: HTMLCrossorigin;
     disabled?: boolean;
+    enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
     form?: string;
     formaction?: string;
     formenctype?: HTMLFormEncType;


### PR DESCRIPTION
Relevant [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint).
Inferno [has it](https://github.com/infernojs/inferno/blob/e7f9f4e902a4daaf69e61693b1265f2558f210a6/packages/inferno/src/core/types.ts#L1188) since [Feb last year](https://github.com/infernojs/inferno/commit/696006c3d817fc4f0af45d422eb78ad6deeb1caa)