### PR TITLE
fix: pathLength added to ShapeElementSVGAttributes

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1209,6 +1209,7 @@ export namespace JSX {
     mask?: FunctionMaybe<string>;
     opacity?: FunctionMaybe<number | string | "inherit">;
     overflow?: FunctionMaybe<"visible" | "hidden" | "scroll" | "auto" | "inherit">;
+    pathLength?: FunctionMaybe<string | number>;
     "pointer-events"?: FunctionMaybe<
       | "bounding-box"
       | "visiblePainted"
@@ -1331,6 +1332,7 @@ export namespace JSX {
         | "stroke-dashoffset"
         | "stroke-opacity"
         | "shape-rendering"
+        | "pathLength"
       > {}
   interface TextContentElementSVGAttributes<T>
     extends CoreSVGAttributes<T>,

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1219,6 +1219,7 @@ export namespace JSX {
     mask?: string;
     opacity?: number | string | "inherit";
     overflow?: "visible" | "hidden" | "scroll" | "auto" | "inherit";
+    pathLength?: string | number;
     "pointer-events"?:
       | "bounding-box"
       | "visiblePainted"
@@ -1341,6 +1342,7 @@ export namespace JSX {
         | "stroke-dashoffset"
         | "stroke-opacity"
         | "shape-rendering"
+        | "pathLength"
       > {}
   interface TextContentElementSVGAttributes<T>
     extends CoreSVGAttributes<T>,


### PR DESCRIPTION
**Summary:**

I've added the missing `pathLength` to the `ShapeElementSVGAttributes` interface

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength
