### PR TITLE
Add type definition for Universal Renderer use function

### DIFF
--- a/packages/dom-expressions/src/universal.d.ts
+++ b/packages/dom-expressions/src/universal.d.ts
@@ -23,6 +23,7 @@ export interface Renderer<NodeType> {
   spread<T>(node: any, accessor: (() => T) | T, skipChildren?: Boolean): void;
   setProp<T>(node: NodeType, name: string, value: T, prev?: T): T;
   mergeProps(...sources: unknown[]): unknown;
+  use<A, T>(fn: (element: NodeType, arg: A) => T, element: NodeType, arg: A): T;
 }
 
 export function createRenderer<NodeType>(options: RendererOptions<NodeType>): Renderer<NodeType>;


### PR DESCRIPTION
The use function needs to be exported by universal renderers, but was not defined in the Renderer type definition. This causes type errors when building a universal renderer in Typescript.

Here I added a type-definition based on the definition of the use function in universal.js