### PR TITLE
Supported non-standard input attributes

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -798,6 +798,7 @@ export namespace JSX {
     accept?: string;
     alt?: string;
     autocomplete?: string;
+    autocorrect?: "on" | "off";
     autofocus?: boolean;
     capture?: boolean | string;
     checked?: boolean;
@@ -811,6 +812,7 @@ export namespace JSX {
     formnovalidate?: boolean;
     formtarget?: string;
     height?: number | string;
+    incremental?: boolean;
     list?: string;
     max?: number | string;
     maxlength?: number | string;
@@ -821,6 +823,7 @@ export namespace JSX {
     pattern?: string;
     placeholder?: string;
     readonly?: boolean;
+    results?: number;
     required?: boolean;
     size?: number | string;
     src?: string;


### PR DESCRIPTION
Referring to this issue https://github.com/solidjs/solid/issues/1642 I added non-standard attributes (see this https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search#non-standard_attributes).