### PR TITLE
Add `loading` JSX attribute type to `<iframe>`

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -767,6 +767,7 @@ export namespace JSX {
     allow?: string;
     allowfullscreen?: boolean;
     height?: number | string;
+    loading?: "eager" | "lazy";
     name?: string;
     referrerpolicy?: HTMLReferrerPolicy;
     sandbox?: HTMLIframeSandbox | string;


### PR DESCRIPTION
Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#loading

From https://github.com/solidjs/solid/pull/1652