### PR TITLE
Fix prop mutation error on `attr:`

### DIFF
--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -581,7 +581,7 @@ export function ssrSpread(props, isSVG, skipChildren) {
   const keys = Object.keys(props);
   let classResolved;
   for (let i = 0; i < keys.length; i++) {
-    const prop = keys[i];
+    let prop = keys[i];
     if (prop === "children") {
       !skipChildren && console.warn(`SSR currently does not support spread children.`);
       continue;


### PR DESCRIPTION
- `prop` was declared as `const`, and it was being mutated in the `attr:` check of `ssrSpread`