### PR TITLE
Shave bytes by removing quotes and spacing from attributes

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -413,6 +413,8 @@ function transformAttributes(path, results) {
     attributes.map(a => a.node)
   );
 
+  let needsSpacing = true;
+
   path
     .get("openingElement")
     .get("attributes")
@@ -710,7 +712,7 @@ function transformAttributes(path, results) {
           );
         } else {
           !isSVG && (key = key.toLowerCase());
-          results.template += ` ${key}`;
+          results.template += `${needsSpacing ? ' ' : ''}${key}`;
           if (!value) return;
           
           let text = value.value;
@@ -760,8 +762,10 @@ function transformAttributes(path, results) {
               wrapper = '"';
             }
 
+            needsSpacing = false;
             results.template += `=${wrapper}${text}${wrapper}`;
           } else {
+            needsSpacing = true;
             results.template += `=${text}`;
           }
         }

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -763,10 +763,10 @@ function transformAttributes(path, results) {
             }
 
             needsSpacing = false;
-            results.template += `=${wrapper}${text}${wrapper}`;
+            results.template += `=${wrapper}${escapeBackticks(escapeHTML(text, true))}${wrapper}`;
           } else {
             needsSpacing = true;
-            results.template += `=${text}`;
+            results.template += `=${escapeBackticks(escapeHTML(text, true))}`;
           }
         }
       }

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
@@ -5,22 +5,22 @@ import { spread as _$spread } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 import { effect as _$effect } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-    `<svg width="400" height="180"><rect stroke-width="2" x="50" y="20" rx="20" ry="20" width="150" height="150" style="fill:red;stroke:black;stroke-width:5;opacity:0.5"></rect><linearGradient gradientTransform="rotate(25)"><stop offset="0%">`
+    `<svg width=400 height=180><rect stroke-width=2 x=50 y=20 rx=20 ry=20 width=150 height=150 style=fill:red;stroke:black;stroke-width:5;opacity:0.5></rect><linearGradient gradientTransform=rotate(25)><stop offset=0%>`
   ),
   _tmpl$2 = /*#__PURE__*/ _$template(
-    `<svg width="400" height="180"><rect rx="20" ry="20" width="150" height="150">`
+    `<svg width=400 height=180><rect rx=20 ry=20 width=150 height=150>`
   ),
-  _tmpl$3 = /*#__PURE__*/ _$template(`<svg width="400" height="180"><rect>`),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<svg width=400 height=180><rect>`),
   _tmpl$4 = /*#__PURE__*/ _$template(
-    `<svg><rect x="50" y="20" width="150" height="150"></svg>`,
+    `<svg><rect x=50 y=20 width=150 height=150></svg>`,
     false,
     true
   ),
   _tmpl$5 = /*#__PURE__*/ _$template(
-    `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><a><text x="10" y="25">MDN Web Docs`
+    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
   ),
   _tmpl$6 = /*#__PURE__*/ _$template(
-    `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><text x="10" y="25">`
+    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
   );
 const template = _tmpl$();
 const template2 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
@@ -17,10 +17,10 @@ const _tmpl$ = /*#__PURE__*/ _$template(
     true
   ),
   _tmpl$5 = /*#__PURE__*/ _$template(
-    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
+    `<svg viewBox='0 0 160 40'xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
   ),
   _tmpl$6 = /*#__PURE__*/ _$template(
-    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
+    `<svg viewBox='0 0 160 40'xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
   );
 const template = _tmpl$();
 const template2 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -11,27 +11,25 @@ import { classList as _$classList } from "r-dom";
 import { use as _$use } from "r-dom";
 import { spread as _$spread } from "r-dom";
 import { mergeProps as _$mergeProps } from "r-dom";
-const _tmpl$ = /*#__PURE__*/ _$template(
-    `<div id="main"><h1 class="base" id="my-h1"><a href="/">Welcome`
-  ),
+const _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a href=/>Welcome`),
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div>`),
-  _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type="checkbox">`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi" type="button">Write`),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly=""><input>`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;" data2="&quot;">`),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<div class='a b'>`),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<div class='\`a'>\`$\``),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<button class='static hi'type=button>Write`),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class='a b c'>Hi`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<div class='bg-red-500 flex flex-col'>`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly=><input>`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div data='&quot;hi&quot;'data2='&quot;'>`),
   _tmpl$13 = /*#__PURE__*/ _$template(`<a>`),
   _tmpl$14 = /*#__PURE__*/ _$template(`<div><a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div start="Hi">Hi`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
   _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div>`),
   _tmpl$17 =
-    /*#__PURE__*/ _$template(`<div class="class1 class2 class3 class4 class5 class6" style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;" random="random1 random2
-    random3 random4">`);
+    /*#__PURE__*/ _$template(`<div class='class1 class2 class3 class4 class5 class6'style='color:red;background-color:blue !important;border:1px solid black;font-size:12px;'random='random1 random2
+    random3 random4'>`);
 const selected = true;
 let id = "my-h1";
 let link;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -3,8 +3,8 @@ import { effect as _$effect } from "r-dom";
 import { getOwner as _$getOwner } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(`<my-element>`, true, false),
-  _tmpl$2 = /*#__PURE__*/ _$template(`<my-element><header slot="head">Title`, true, false),
-  _tmpl$3 = /*#__PURE__*/ _$template(`<slot name="head">`);
+  _tmpl$2 = /*#__PURE__*/ _$template(`<my-element><header slot=head>Title`, true, false),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<slot name=head>`);
 const template = (() => {
   const _el$ = _tmpl$();
   _el$.someAttr = name;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/eventExpressions/output.js
@@ -2,7 +2,7 @@ import { template as _$template } from "r-dom";
 import { delegateEvents as _$delegateEvents } from "r-dom";
 import { addEventListener as _$addEventListener } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-  `<div id="main"><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture`
+  `<div id=main><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture`
 );
 function hoisted1() {
   console.log("hoisted");

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/simpleElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/simpleElements/output.js
@@ -1,6 +1,6 @@
 import { template as _$template } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-    `<div id="main"><style>div { color: red; }</style><h1>Welcome</h1><label for="entry">Edit:</label><input id="entry" type="text">`
+    `<div id=main><style>div { color: red; }</style><h1>Welcome</h1><label for=entry>Edit:</label><input id=entry type=text>`
   ),
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><span><a></a></span><span>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div><div><table><tbody></tbody></table></div><div>`),

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
@@ -15,7 +15,7 @@ const _tmpl$ = /*#__PURE__*/ _$template(`<span>Hello `),
   _tmpl$12 = /*#__PURE__*/ _$template(`<div>
 d`),
   _tmpl$13 = /*#__PURE__*/ _$template(`<div>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div normal="Search…" title="Search&amp;hellip;">`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&hellip;>`),
   _tmpl$15 = /*#__PURE__*/ _$template(`<div><div>`);
 const trailing = _tmpl$();
 const leading = _tmpl$2();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/textInterpolation/output.js
@@ -15,7 +15,7 @@ const _tmpl$ = /*#__PURE__*/ _$template(`<span>Hello `),
   _tmpl$12 = /*#__PURE__*/ _$template(`<div>
 d`),
   _tmpl$13 = /*#__PURE__*/ _$template(`<div>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&hellip;>`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&amp;hellip;>`),
   _tmpl$15 = /*#__PURE__*/ _$template(`<div><div>`);
 const trailing = _tmpl$();
 const leading = _tmpl$2();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
@@ -7,22 +7,22 @@ import { setAttribute as _$setAttribute } from "r-dom";
 import { effect as _$effect } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-    `<svg width="400" height="180"><rect stroke-width="2" x="50" y="20" rx="20" ry="20" width="150" height="150" style="fill:red;stroke:black;stroke-width:5;opacity:0.5"></rect><linearGradient gradientTransform="rotate(25)"><stop offset="0%">`
+    `<svg width=400 height=180><rect stroke-width=2 x=50 y=20 rx=20 ry=20 width=150 height=150 style=fill:red;stroke:black;stroke-width:5;opacity:0.5></rect><linearGradient gradientTransform=rotate(25)><stop offset=0%>`
   ),
   _tmpl$2 = /*#__PURE__*/ _$template(
-    `<svg width="400" height="180"><rect rx="20" ry="20" width="150" height="150">`
+    `<svg width=400 height=180><rect rx=20 ry=20 width=150 height=150>`
   ),
-  _tmpl$3 = /*#__PURE__*/ _$template(`<svg width="400" height="180"><rect>`),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<svg width=400 height=180><rect>`),
   _tmpl$4 = /*#__PURE__*/ _$template(
-    `<svg><rect x="50" y="20" width="150" height="150"></svg>`,
+    `<svg><rect x=50 y=20 width=150 height=150></svg>`,
     false,
     true
   ),
   _tmpl$5 = /*#__PURE__*/ _$template(
-    `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><a><text x="10" y="25">MDN Web Docs`
+    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
   ),
   _tmpl$6 = /*#__PURE__*/ _$template(
-    `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><text x="10" y="25">`
+    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
   );
 const template = _$getNextElement(_tmpl$);
 const template2 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
@@ -19,10 +19,10 @@ const _tmpl$ = /*#__PURE__*/ _$template(
     true
   ),
   _tmpl$5 = /*#__PURE__*/ _$template(
-    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
+    `<svg viewBox='0 0 160 40'xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
   ),
   _tmpl$6 = /*#__PURE__*/ _$template(
-    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
+    `<svg viewBox='0 0 160 40'xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
   );
 const template = _$getNextElement(_tmpl$);
 const template2 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -15,27 +15,25 @@ import { classList as _$classList } from "r-dom";
 import { use as _$use } from "r-dom";
 import { spread as _$spread } from "r-dom";
 import { mergeProps as _$mergeProps } from "r-dom";
-const _tmpl$ = /*#__PURE__*/ _$template(
-    `<div id="main"><h1 class="base" id="my-h1"><a href="/">Welcome`
-  ),
+const _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a href=/>Welcome`),
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div>`),
-  _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type="checkbox">`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi" type="button">Write`),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly=""><input>`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;" data2="&quot;">`),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<div class='a b'>`),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<div class='\`a'>\`$\``),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<button class='static hi'type=button>Write`),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class='a b c'>Hi`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<div class='bg-red-500 flex flex-col'>`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly=><input>`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div data='&quot;hi&quot;'data2='&quot;'>`),
   _tmpl$13 = /*#__PURE__*/ _$template(`<a>`),
   _tmpl$14 = /*#__PURE__*/ _$template(`<div><!#><!/><a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div start="Hi">Hi`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
   _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is <!#><!/></span><input><div>`),
   _tmpl$17 =
-    /*#__PURE__*/ _$template(`<div class="class1 class2 class3 class4 class5 class6" style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;" random="random1 random2
-    random3 random4">`);
+    /*#__PURE__*/ _$template(`<div class='class1 class2 class3 class4 class5 class6'style='color:red;background-color:blue !important;border:1px solid black;font-size:12px;'random='random1 random2
+    random3 random4'>`);
 const selected = true;
 let id = "my-h1";
 let link;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
@@ -4,8 +4,8 @@ import { getNextElement as _$getNextElement } from "r-dom";
 import { getOwner as _$getOwner } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(`<my-element>`, true, false),
-  _tmpl$2 = /*#__PURE__*/ _$template(`<my-element><header slot="head">Title`, true, false),
-  _tmpl$3 = /*#__PURE__*/ _$template(`<slot name="head">`);
+  _tmpl$2 = /*#__PURE__*/ _$template(`<my-element><header slot=head>Title`, true, false),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<slot name=head>`);
 const template = (() => {
   const _el$ = _$getNextElement(_tmpl$);
   _el$.someAttr = name;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/eventExpressions/output.js
@@ -3,7 +3,7 @@ import { delegateEvents as _$delegateEvents } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 import { runHydrationEvents as _$runHydrationEvents } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-  `<div id="main"><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture`
+  `<div id=main><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture`
 );
 const template = (() => {
   const _el$ = _$getNextElement(_tmpl$),

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/simpleElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/simpleElements/output.js
@@ -1,7 +1,7 @@
 import { template as _$template } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-    `<div id="main"><style>div { color: red; }</style><h1>Welcome</h1><label for="entry">Edit:</label><input id="entry" type="text">`
+    `<div id=main><style>div { color: red; }</style><h1>Welcome</h1><label for=entry>Edit:</label><input id=entry type=text>`
   ),
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><span><a></a></span><span>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div><div><table><tbody></tbody></table></div><div>`),

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/textInterpolation/output.js
@@ -21,7 +21,7 @@ d`),
   _tmpl$15 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$16 = /*#__PURE__*/ _$template(`<span> <!#><!/>`),
   _tmpl$17 = /*#__PURE__*/ _$template(`<span><!#><!/> `),
-  _tmpl$18 = /*#__PURE__*/ _$template(`<div normal="Search…" title="Search&amp;hellip;">`),
+  _tmpl$18 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&hellip;>`),
   _tmpl$19 = /*#__PURE__*/ _$template(`<div><div></div><!#><!/>`);
 const trailing = _$getNextElement(_tmpl$);
 const leading = _$getNextElement(_tmpl$2);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/textInterpolation/output.js
@@ -21,7 +21,7 @@ d`),
   _tmpl$15 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$16 = /*#__PURE__*/ _$template(`<span> <!#><!/>`),
   _tmpl$17 = /*#__PURE__*/ _$template(`<span><!#><!/> `),
-  _tmpl$18 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&hellip;>`),
+  _tmpl$18 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&amp;hellip;>`),
   _tmpl$19 = /*#__PURE__*/ _$template(`<div><div></div><!#><!/>`);
 const trailing = _$getNextElement(_tmpl$);
 const leading = _$getNextElement(_tmpl$2);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
@@ -17,10 +17,10 @@ const _tmpl$ = /*#__PURE__*/ _$template(
     true
   ),
   _tmpl$5 = /*#__PURE__*/ _$template(
-    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
+    `<svg viewBox='0 0 160 40'xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
   ),
   _tmpl$6 = /*#__PURE__*/ _$template(
-    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
+    `<svg viewBox='0 0 160 40'xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
   );
 const template = _tmpl$();
 const template2 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
@@ -5,22 +5,22 @@ import { spread as _$spread } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 import { effect as _$effect } from "r-custom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-    `<svg width="400" height="180"><rect stroke-width="2" x="50" y="20" rx="20" ry="20" width="150" height="150" style="fill:red;stroke:black;stroke-width:5;opacity:0.5"></rect><linearGradient gradientTransform="rotate(25)"><stop offset="0%">`
+    `<svg width=400 height=180><rect stroke-width=2 x=50 y=20 rx=20 ry=20 width=150 height=150 style=fill:red;stroke:black;stroke-width:5;opacity:0.5></rect><linearGradient gradientTransform=rotate(25)><stop offset=0%>`
   ),
   _tmpl$2 = /*#__PURE__*/ _$template(
-    `<svg width="400" height="180"><rect rx="20" ry="20" width="150" height="150">`
+    `<svg width=400 height=180><rect rx=20 ry=20 width=150 height=150>`
   ),
-  _tmpl$3 = /*#__PURE__*/ _$template(`<svg width="400" height="180"><rect>`),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<svg width=400 height=180><rect>`),
   _tmpl$4 = /*#__PURE__*/ _$template(
-    `<svg><rect x="50" y="20" width="150" height="150"></svg>`,
+    `<svg><rect x=50 y=20 width=150 height=150></svg>`,
     false,
     true
   ),
   _tmpl$5 = /*#__PURE__*/ _$template(
-    `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><a><text x="10" y="25">MDN Web Docs`
+    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><a><text x=10 y=25>MDN Web Docs`
   ),
   _tmpl$6 = /*#__PURE__*/ _$template(
-    `<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"><text x="10" y="25">`
+    `<svg viewBox='0 0 160 40' xmlns=http://www.w3.org/2000/svg><text x=10 y=25>`
   );
 const template = _tmpl$();
 const template2 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -9,14 +9,12 @@ import { classList as _$classList } from "r-dom";
 import { use as _$use } from "r-dom";
 import { spread as _$spread } from "r-dom";
 import { mergeProps as _$mergeProps } from "r-custom";
-const _tmpl$ = /*#__PURE__*/ _$template(
-    `<div id="main"><h1 class="base" id="my-h1"><a href="/">Welcome`
-  ),
+const _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a href=/>Welcome`),
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div>`),
-  _tmpl$4 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$5 = /*#__PURE__*/ _$template(`<input type="checkbox" readonly="">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type="checkbox">`);
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div class='a b'>`),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<input type=checkbox readonly=>`),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`);
 const selected = true;
 let id = "my-h1";
 let link;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/customElements/output.js
@@ -3,8 +3,8 @@ import { effect as _$effect } from "r-custom";
 import { getOwner as _$getOwner } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(`<my-element>`, true, false),
-  _tmpl$2 = /*#__PURE__*/ _$template(`<my-element><header slot="head">Title`, true, false),
-  _tmpl$3 = /*#__PURE__*/ _$template(`<slot name="head">`);
+  _tmpl$2 = /*#__PURE__*/ _$template(`<my-element><header slot=head>Title`, true, false),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<slot name=head>`);
 const template = (() => {
   const _el$ = _tmpl$();
   _el$.someAttr = name;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/eventExpressions/output.js
@@ -2,7 +2,7 @@ import { template as _$template } from "r-dom";
 import { delegateEvents as _$delegateEvents } from "r-dom";
 import { addEventListener as _$addEventListener } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-  `<div id="main"><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture`
+  `<div id=main><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture`
 );
 function hoisted1() {
   console.log("hoisted");

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/simpleElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/simpleElements/output.js
@@ -1,6 +1,6 @@
 import { template as _$template } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
-    `<div id="main"><style>div { color: red; }</style><h1>Welcome</h1><label for="entry">Edit:</label><input id="entry" type="text">`
+    `<div id=main><style>div { color: red; }</style><h1>Welcome</h1><label for=entry>Edit:</label><input id=entry type=text>`
   ),
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><span><a></a></span><span>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div><div><table><tbody></tbody></table></div><div>`),

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/textInterpolation/output.js
@@ -15,7 +15,7 @@ const _tmpl$ = /*#__PURE__*/ _$template(`<span>Hello `),
   _tmpl$12 = /*#__PURE__*/ _$template(`<div>
 d`),
   _tmpl$13 = /*#__PURE__*/ _$template(`<div>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div normal="Search…" title="Search&amp;hellip;">`);
+  _tmpl$14 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&hellip;>`);
 const trailing = _tmpl$();
 const leading = _tmpl$2();
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/textInterpolation/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/textInterpolation/output.js
@@ -15,7 +15,7 @@ const _tmpl$ = /*#__PURE__*/ _$template(`<span>Hello `),
   _tmpl$12 = /*#__PURE__*/ _$template(`<div>
 d`),
   _tmpl$13 = /*#__PURE__*/ _$template(`<div>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&hellip;>`);
+  _tmpl$14 = /*#__PURE__*/ _$template(`<div normal=Search… title=Search&amp;hellip;>`);
 const trailing = _tmpl$();
 const leading = _tmpl$2();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
         version: 2.3.0
     devDependencies:
       babel-plugin-jsx-dom-expressions:
-        specifier: ^0.36.9
+        specifier: ^0.36.10
         version: link:../babel-plugin-jsx-dom-expressions
       csstype:
         specifier: ^3.1
@@ -115,13 +115,13 @@ importers:
   packages/hyper-dom-expressions:
     devDependencies:
       dom-expressions:
-        specifier: ^0.36.9
+        specifier: ^0.36.10
         version: link:../dom-expressions
 
   packages/lit-dom-expressions:
     devDependencies:
       dom-expressions:
-        specifier: ^0.36.9
+        specifier: ^0.36.10
         version: link:../dom-expressions
       html-parse-string:
         specifier: ^0.0.9


### PR DESCRIPTION
This PR attempts to shave more bytes off the template code by removing or replacing the quotes, along with removing the spacing between them when it's next to a quoted attribute value.

The code would eagerly use single quotes when it can't remove the quotes entirely, this is mostly because the template literals would usually be converted into regular string by the transformer/minifier, where they would normally be double quotes. I think by doing this, gzip compression would atleast see that there are more repetitions with `("`, but that's something that has yet to be tested.

The one thing I haven't done here is to adjust `escapeHTML` code, as it still assumes that it's being wrapped in a double quote. I wasn't sure how to deal with it, so I just kept it as is but it'd definitely have to be changed I think.

Alternatively we could just drop the code relating to switching between double and single quotes for now.