### PR TITLE
Fix JSX missing type in webstorm

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1940,10 +1940,18 @@ export namespace JSX {
       ZoomAndPanSVGAttributes {
     viewTarget?: string;
   }
+
+  interface HTMLElementTags extends Pick<IntrinsicElements, keyof HTMLElementTagNameMap> {
+  }
+
+  interface SVGElementTags extends Pick<IntrinsicElements, keyof SVGElementTagNameMap> {
+  }
+
   /**
-   * @type {HTMLElementTagNameMap}
+   * @type {HTMLElementTagNameMap & HTMLElementDeprecatedTagNameMap & SVGElementTagNameMap}
    */
-  interface HTMLElementTags {
+  interface IntrinsicElements {
+    // HTMLElementTags
     a: AnchorHTMLAttributes<HTMLAnchorElement>;
     abbr: HTMLAttributes<HTMLElement>;
     address: HTMLAttributes<HTMLElement>;
@@ -2055,21 +2063,15 @@ export namespace JSX {
     var: HTMLAttributes<HTMLElement>;
     video: VideoHTMLAttributes<HTMLVideoElement>;
     wbr: HTMLAttributes<HTMLElement>;
-  }
-  /**
-   * @type {HTMLElementDeprecatedTagNameMap}
-   */
-  interface HTMLElementDeprecatedTags {
+
+    // HTMLElementDeprecatedTags
     big: HTMLAttributes<HTMLElement>;
     keygen: KeygenHTMLAttributes<HTMLElement>;
     menuitem: HTMLAttributes<HTMLElement>;
     noindex: HTMLAttributes<HTMLElement>;
     param: ParamHTMLAttributes<HTMLParamElement>;
-  }
-  /**
-   * @type {SVGElementTagNameMap}
-   */
-  interface SVGElementTags {
+
+    // SVGElementTags
     animate: AnimateSVGAttributes<SVGAnimateElement>;
     animateMotion: AnimateMotionSVGAttributes<SVGAnimateMotionElement>;
     animateTransform: AnimateTransformSVGAttributes<SVGAnimateTransformElement>;
@@ -2130,5 +2132,4 @@ export namespace JSX {
     use: UseSVGAttributes<SVGUseElement>;
     view: ViewSVGAttributes<SVGViewElement>;
   }
-  interface IntrinsicElements extends HTMLElementTags, HTMLElementDeprecatedTags, SVGElementTags {}
 }

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -406,7 +406,7 @@ export namespace JSX {
     | "allow-storage-access-by-user-activation"
     | "allow-top-navigation"
     | "allow-top-navigation-by-user-activation"
-    | "allow-top-navigation-to-custom-protocols;
+    | "allow-top-navigation-to-custom-protocols";
   type HTMLLinkAs =
     | "audio"
     | "document"
@@ -875,7 +875,7 @@ export namespace JSX {
     useMap?: string;
     width?: number | string;
     crossOrigin?: HTMLCrossorigin
-    elementtiming: string; 
+    elementtiming: string;
     fetchpriority: "high" | "low" | "auto";
   }
   interface InputHTMLAttributes<T> extends HTMLAttributes<T> {


### PR DESCRIPTION
The webstorm error: [JSX: Completion not triggered by JSX.IntrinsicElements declared by "extends"](https://youtrack.jetbrains.com/issue/WEB-56801/JSX-Completion-not-triggered-by-JSX.IntrinsicElements-declared-by-extends)

Reference: [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8507d1ec567df3fbac1e896ec97a260cccc5910d/types/react/index.d.ts#L3168)
