### PR TITLE
Make `elementtiming` and  `fetchpriority` optional properties

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -876,8 +876,8 @@ export namespace JSX {
     useMap?: string;
     width?: number | string;
     crossOrigin?: HTMLCrossorigin;
-    elementtiming: string;
-    fetchpriority: "high" | "low" | "auto";
+    elementtiming?: string;
+    fetchpriority?: "high" | "low" | "auto";
   }
   interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
     accept?: string;


### PR DESCRIPTION
I see there was an [Issue](https://github.com/solidjs/solid/issues/1690) about missing properties, but I suppose they should be optional, because if I do 

```ts
import type { JSX } from 'solid-js';

type ImgAttrs = JSX.ImgHTMLAttributes<HTMLImageElement>;

const defaultProps = {
  src: 'http://'
} satisfies ImgAttrs;
```

I get a error that `elementtiming` and  `fetchpriority` is required