### PR TITLE
fix: make img attributes optional

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -876,8 +876,8 @@ export namespace JSX {
     useMap?: string;
     width?: number | string;
     crossOrigin?: HTMLCrossorigin;
-    elementtiming: string;
-    fetchpriority: "high" | "low" | "auto";
+    elementtiming?: string;
+    fetchpriority?: "high" | "low" | "auto";
   }
   interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
     accept?: string;


### PR DESCRIPTION
With 1.7.4 (due to [this commit](https://github.com/ryansolid/dom-expressions/commit/48e9e83fd65990f88d5e2631c31852f2469f7b75)) now there are TS errors for `<img>` tag. The attributes should be optional.