### PR TITLE
add heading tags to const DOMElements

### DIFF
--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -469,7 +469,13 @@ const DOMElements = /*#__PURE__*/ new Set([
   "video",
   "wbr",
   "xmp",
-  "input"
+  "input",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6"
 ]);
 
 export {


### PR DESCRIPTION
As mentioned [here](https://github.com/solidjs/solid/issues/1713) heading tags are currently not included in DOMElements. This pr adds h1-h6 to the constant.