### PR TITLE
updates `draggable` attribute to allow `"true" | "false"`

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -705,7 +705,7 @@ export namespace JSX {
     contenteditable?: boolean | "inherit";
     contextmenu?: string;
     dir?: HTMLDir;
-    draggable?: boolean;
+    draggable?: boolean | "false" | "true";
     hidden?: boolean | "hidden" | "until-found";
     id?: string;
     inert?: boolean;


### PR DESCRIPTION
`draggable="false"` was giving me a typescript error on the JSX of the editor. 

I have a question, all the booleans used on attributes on this file can be updated to be `boolean | "true" | "false"` right? (besides any other allowed value). If so, I can take a look to update them all.