### PR TITLE
Improvements to delegated events and non-delegated events added via addEventListener

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/README.md
+++ b/packages/babel-plugin-jsx-dom-expressions/README.md
@@ -40,6 +40,7 @@ Compiles to:
 ```jsx
 import { template as _$template } from "dom";
 import { delegateEvents as _$delegateEvents } from "dom";
+import { addEventListener as _$addEventListener } from "dom";
 import { className as _$className } from "dom";
 import { effect as _$effect } from "dom";
 import { insert as _$insert } from "dom";
@@ -57,9 +58,9 @@ const view = ({
       _el$5 = _el$3.nextSibling,
       _el$6 = _el$5.firstChild;
     _$insert(_el$2, itemId);
-    _el$4.$$click = e => select(item, e);
+    _$addEventListener(_el$4, "click", e => select(item, e), true);
     _$insert(_el$4, () => item.label);
-    _el$6.$$click = e => del(item, e);
+    _$addEventListener(_el$6, "click", e => del(item, e), true);
     _$effect(() => _$className(_el$, itemId === selected() ? "danger" : ""));
     return _el$;
   })();

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -558,53 +558,19 @@ function transformAttributes(path, results) {
               (attribute.scope.getProgramParent().data.events = new Set());
             events.add(ev);
             let handler = value.expression;
-            const resolveable = detectResolvableEventHandler(attribute, handler);
-            if (t.isArrayExpression(handler)) {
-              if (handler.elements.length > 1) {
-                results.exprs.unshift(
-                  t.expressionStatement(
-                    t.assignmentExpression(
-                      "=",
-                      t.memberExpression(elem, t.identifier(`$$${ev}Data`)),
-                      handler.elements[1]
-                    )
-                  )
-                );
-              }
-              handler = handler.elements[0];
-              results.exprs.unshift(
-                t.expressionStatement(
-                  t.assignmentExpression(
-                    "=",
-                    t.memberExpression(elem, t.identifier(`$$${ev}`)),
-                    handler
-                  )
+
+            results.exprs.unshift(
+              t.expressionStatement(
+                t.callExpression(
+                  registerImportMethod(
+                    path,
+                    "addEventListener",
+                    getRendererConfig(path, "dom").moduleName
+                  ),
+                  [elem, t.stringLiteral(ev), handler, t.booleanLiteral(true)]
                 )
-              );
-            } else if (t.isFunction(handler) || resolveable) {
-              results.exprs.unshift(
-                t.expressionStatement(
-                  t.assignmentExpression(
-                    "=",
-                    t.memberExpression(elem, t.identifier(`$$${ev}`)),
-                    handler
-                  )
-                )
-              );
-            } else {
-              results.exprs.unshift(
-                t.expressionStatement(
-                  t.callExpression(
-                    registerImportMethod(
-                      path,
-                      "addEventListener",
-                      getRendererConfig(path, "dom").moduleName
-                    ),
-                    [elem, t.stringLiteral(ev), handler, t.booleanLiteral(true)]
-                  )
-                )
-              );
-            }
+              )
+            );
           } else {
             let handler = value.expression;
             const resolveable = detectResolvableEventHandler(attribute, handler);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/eventExpressions/output.js
@@ -27,12 +27,11 @@ const template = (() => {
   _$addEventListener(_el$4, "change", handler);
   _el$5.addEventListener("change", handler);
   _el$6.addEventListener("change", hoisted1);
-  _el$7.$$click = () => console.log("delegated");
-  _el$8.$$click = id => console.log("delegated", id);
-  _el$8.$$clickData = rowId;
+  _$addEventListener(_el$7, "click", () => console.log("delegated"), true);
+  _$addEventListener(_el$8, "click", [id => console.log("delegated", id), rowId], true);
   _$addEventListener(_el$9, "click", handler, true);
-  _el$10.$$click = handler;
-  _el$11.$$click = hoisted2;
+  _$addEventListener(_el$10, "click", [handler], true);
+  _$addEventListener(_el$11, "click", hoisted2, true);
   _el$12.addEventListener("click", () => console.log("listener"));
   _el$12.addEventListener("CAPS-ev", () => console.log("custom"));
   _el$13.addEventListener("camelClick", () => console.log("listener"), true);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/eventExpressions/output.js
@@ -2,6 +2,7 @@ import { template as _$template } from "r-dom";
 import { delegateEvents as _$delegateEvents } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 import { runHydrationEvents as _$runHydrationEvents } from "r-dom";
+import { addEventListener as _$addEventListener } from "r-dom";
 const _tmpl$ = /*#__PURE__*/ _$template(
   `<div id="main"><button>Change Bound</button><button>Change Bound</button><button>Click Delegated</button><button>Click Delegated</button><button>Click Listener</button><button>Click Capture`
 );
@@ -15,9 +16,8 @@ const template = (() => {
     _el$7 = _el$6.nextSibling;
   _el$2.addEventListener("change", () => console.log("bound"));
   _el$3.addEventListener("change", e => (id => console.log("bound", id))(id, e));
-  _el$4.$$click = () => console.log("delegated");
-  _el$5.$$click = id => console.log("delegated", id);
-  _el$5.$$clickData = rowId;
+  _$addEventListener(_el$4, "click", () => console.log("delegated"), true);
+  _$addEventListener(_el$5, "click", [id => console.log("delegated", id), rowId], true);
   _el$6.addEventListener("click", () => console.log("listener"));
   _el$6.addEventListener("CAPS-ev", () => console.log("custom"));
   _el$7.addEventListener("camelClick", () => console.log("listener"), true);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/eventExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/eventExpressions/output.js
@@ -27,12 +27,11 @@ const template = (() => {
   _$addEventListener(_el$4, "change", handler);
   _el$5.addEventListener("change", handler);
   _el$6.addEventListener("change", hoisted1);
-  _el$7.$$click = () => console.log("delegated");
-  _el$8.$$click = id => console.log("delegated", id);
-  _el$8.$$clickData = rowId;
+  _$addEventListener(_el$7, "click", () => console.log("delegated"), true);
+  _$addEventListener(_el$8, "click", [id => console.log("delegated", id), rowId], true);
   _$addEventListener(_el$9, "click", handler, true);
-  _el$10.$$click = handler;
-  _el$11.$$click = hoisted2;
+  _$addEventListener(_el$10, "click", [handler], true);
+  _$addEventListener(_el$11, "click", hoisted2, true);
   _el$12.addEventListener("click", () => console.log("listener"));
   _el$12.addEventListener("CAPS-ev", () => console.log("custom"));
   _el$13.addEventListener("camelClick", () => console.log("listener"), true);


### PR DESCRIPTION
Essentially, this makes of `node[$$${name}]` an array.  The motivation is that using a delegated event in an element effectively gets rid of the last added event, instead of appending to a list of events added. If we wanted to add many `onclick` handlers, we will have to resort to native events, which is a pity.

Consider the following, whenever we click the div it will output `hi 2`, as adding the event removes the first `onClick`.

```js
 <div
      onClick={() => console.log("hi 1")}
      ref={(element) => {
        onMount(() => {
          addEventListener(element, "click", () => console.log("hi 2"), true);
        });
      }}
    >
      click me
    </div>
```
Playground: https://playground.solidjs.com/anonymous/9b7e2d2e-625f-4774-81d1-67c1dbeb9d7a


As for the Native events, I have reused/added a similar logic to the delegated ones. The motivation is to add and reuse only 1 listener and dispatch it as many times as needed to anyone wanting to listen to it.  As the behaviour is basically the same as delegated events, I believe it's a nice optimization. Which also includes the in place optimization of using the array for _binding without actually binding_, that delegated events use.

Considerations:
- I ran the test and seems that all are passing. 
- ~I didn't actually test this code yet, I need to figure out how to use this with solid, Im not sure how to put this on babel-plugin-jsx-dom-expressions~ Tested by copying and pasting the relevant bits to `babel-plugin-jsx-dom-expressions/index.js and solid-js/web/dist/web.js` 
- The native events won't really behave as the real native events in a few edge cases, like in, calling to `stopImmediatePropagation` in a handler should stop the event for the remaining listeners. There's no way to detect this (unless you do some prototype hacking), in any case the delegated events suffer the same problem, so I don't consider it a big deal.
- it would probably be nice to add a complementary removeEventListener. 

Thanks!