### PR TITLE
Update types

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -199,7 +199,7 @@ export namespace JSX {
     onProgress?: EventHandlerUnion<T, Event>;
     onRateChange?: EventHandlerUnion<T, Event>;
     onReset?: EventHandlerUnion<T, Event>;
-    onScroll?: EventHandlerUnion<T, UIEvent>;
+    onScroll?: EventHandlerUnion<T, Event>;
     onScrollEnd?: EventHandlerUnion<T, Event>;
     onSeeked?: EventHandlerUnion<T, Event>;
     onSeeking?: EventHandlerUnion<T, Event>;
@@ -286,7 +286,7 @@ export namespace JSX {
     onprogress?: EventHandlerUnion<T, Event>;
     onratechange?: EventHandlerUnion<T, Event>;
     onreset?: EventHandlerUnion<T, Event>;
-    onscroll?: EventHandlerUnion<T, UIEvent>;
+    onscroll?: EventHandlerUnion<T, Event>;
     onscrollend?: EventHandlerUnion<T, Event>;
     onseeked?: EventHandlerUnion<T, Event>;
     onseeking?: EventHandlerUnion<T, Event>;

--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1,4 +1,4 @@
-import * as csstype from 'csstype';
+import * as csstype from "csstype";
 
 /**
  * Based on JSX types for Surplus and Inferno and adapted for `dom-expressions`.
@@ -9,7 +9,7 @@ import * as csstype from 'csstype';
 type DOMElement = Element;
 
 export namespace JSX {
-  type FunctionMaybe<T = unknown> = ({ (): T }) | T;
+  type FunctionMaybe<T = unknown> = { (): T } | T;
   type Element =
     | Node
     | ArrayElement
@@ -61,7 +61,7 @@ export namespace JSX {
     };
     $ServerOnly?: boolean;
   }
-  type Accessor<T> = () => T
+  type Accessor<T> = () => T;
   interface Directives {}
   interface DirectiveFunctions {
     [x: string]: (el: Element, accessor: Accessor<any>) => void;
@@ -74,7 +74,9 @@ export namespace JSX {
     [Key in keyof Directives as `use:${Key}`]?: Directives[Key];
   };
   type DirectiveFunctionAttributes<T> = {
-    [K in keyof DirectiveFunctions as string extends K ? never : `use:${K}`]?: DirectiveFunctions[K] extends (
+    [K in keyof DirectiveFunctions as string extends K
+      ? never
+      : `use:${K}`]?: DirectiveFunctions[K] extends (
       el: infer E, // will be unknown if not provided
       ...rest: infer R // use rest so that we can check whether it's provided or not
     ) => void
@@ -95,13 +97,23 @@ export namespace JSX {
   };
   type OnAttributes<T> = {
     [Key in keyof CustomEvents as `on:${Key}`]?: EventHandler<T, CustomEvents[Key]>;
-  }
+  };
   type OnCaptureAttributes<T> = {
-    [Key in keyof CustomCaptureEvents as `oncapture:${Key}`]?: EventHandler<T, CustomCaptureEvents[Key]>;
-  }
-  interface DOMAttributes<T> extends CustomAttributes<T>, DirectiveAttributes, DirectiveFunctionAttributes<T>,
-                                     PropAttributes, AttrAttributes, OnAttributes<T>, OnCaptureAttributes<T>,
-                                     CustomEventHandlersCamelCase<T>, CustomEventHandlersLowerCase<T> {
+    [Key in keyof CustomCaptureEvents as `oncapture:${Key}`]?: EventHandler<
+      T,
+      CustomCaptureEvents[Key]
+    >;
+  };
+  interface DOMAttributes<T>
+    extends CustomAttributes<T>,
+      DirectiveAttributes,
+      DirectiveFunctionAttributes<T>,
+      PropAttributes,
+      AttrAttributes,
+      OnAttributes<T>,
+      OnCaptureAttributes<T>,
+      CustomEventHandlersCamelCase<T>,
+      CustomEventHandlersLowerCase<T> {
     children?: Element;
     innerHTML?: string;
     innerText?: string | number;
@@ -188,6 +200,7 @@ export namespace JSX {
     onRateChange?: EventHandlerUnion<T, Event>;
     onReset?: EventHandlerUnion<T, Event>;
     onScroll?: EventHandlerUnion<T, UIEvent>;
+    onScrollEnd?: EventHandlerUnion<T, Event>;
     onSeeked?: EventHandlerUnion<T, Event>;
     onSeeking?: EventHandlerUnion<T, Event>;
     onSelect?: EventHandlerUnion<T, UIEvent>;
@@ -204,7 +217,10 @@ export namespace JSX {
     onTouchEnd?: EventHandlerUnion<T, TouchEvent>;
     onTouchMove?: EventHandlerUnion<T, TouchEvent>;
     onTouchStart?: EventHandlerUnion<T, TouchEvent>;
+    onTransitionStart?: EventHandlerUnion<T, TransitionEvent>;
     onTransitionEnd?: EventHandlerUnion<T, TransitionEvent>;
+    onTransitionRun?: EventHandlerUnion<T, TransitionEvent>;
+    onTransitionCancel?: EventHandlerUnion<T, TransitionEvent>;
     onVolumeChange?: EventHandlerUnion<T, Event>;
     onWaiting?: EventHandlerUnion<T, Event>;
     onWheel?: EventHandlerUnion<T, WheelEvent>;
@@ -271,6 +287,7 @@ export namespace JSX {
     onratechange?: EventHandlerUnion<T, Event>;
     onreset?: EventHandlerUnion<T, Event>;
     onscroll?: EventHandlerUnion<T, UIEvent>;
+    onscrollend?: EventHandlerUnion<T, Event>;
     onseeked?: EventHandlerUnion<T, Event>;
     onseeking?: EventHandlerUnion<T, Event>;
     onselect?: EventHandlerUnion<T, UIEvent>;
@@ -287,7 +304,10 @@ export namespace JSX {
     ontouchend?: EventHandlerUnion<T, TouchEvent>;
     ontouchmove?: EventHandlerUnion<T, TouchEvent>;
     ontouchstart?: EventHandlerUnion<T, TouchEvent>;
+    ontransitionstart?: EventHandlerUnion<T, TransitionEvent>;
     ontransitionend?: EventHandlerUnion<T, TransitionEvent>;
+    ontransitionrun?: EventHandlerUnion<T, TransitionEvent>;
+    ontransitioncancel?: EventHandlerUnion<T, TransitionEvent>;
     onvolumechange?: EventHandlerUnion<T, Event>;
     onwaiting?: EventHandlerUnion<T, Event>;
     onwheel?: EventHandlerUnion<T, WheelEvent>;
@@ -295,7 +315,7 @@ export namespace JSX {
 
   interface CSSProperties extends csstype.PropertiesHyphen {
     // Override
-    [key: `-${string}`]: string | number | undefined
+    [key: `-${string}`]: string | number | undefined;
   }
 
   type HTMLAutocapitalize = "off" | "none" | "on" | "sentences" | "words" | "characters";
@@ -538,76 +558,77 @@ export namespace JSX {
     /** Defines the human readable text alternative of aria-valuenow for a range widget. */
     "aria-valuetext"?: string;
     role?: FunctionMaybe<
-    | "alert"
-    | "alertdialog"
-    | "application"
-    | "article"
-    | "banner"
-    | "button"
-    | "cell"
-    | "checkbox"
-    | "columnheader"
-    | "combobox"
-    | "complementary"
-    | "contentinfo"
-    | "definition"
-    | "dialog"
-    | "directory"
-    | "document"
-    | "feed"
-    | "figure"
-    | "form"
-    | "grid"
-    | "gridcell"
-    | "group"
-    | "heading"
-    | "img"
-    | "link"
-    | "list"
-    | "listbox"
-    | "listitem"
-    | "log"
-    | "main"
-    | "marquee"
-    | "math"
-    | "menu"
-    | "menubar"
-    | "menuitem"
-    | "menuitemcheckbox"
-    | "menuitemradio"
-    | "meter"
-    | "navigation"
-    | "none"
-    | "note"
-    | "option"
-    | "presentation"
-    | "progressbar"
-    | "radio"
-    | "radiogroup"
-    | "region"
-    | "row"
-    | "rowgroup"
-    | "rowheader"
-    | "scrollbar"
-    | "search"
-    | "searchbox"
-    | "separator"
-    | "slider"
-    | "spinbutton"
-    | "status"
-    | "switch"
-    | "tab"
-    | "table"
-    | "tablist"
-    | "tabpanel"
-    | "term"
-    | "textbox"
-    | "timer"
-    | "toolbar"
-    | "tooltip"
-    | "tree"
-    | "treegrid"
-    | "treeitem">;
+      | "alert"
+      | "alertdialog"
+      | "application"
+      | "article"
+      | "banner"
+      | "button"
+      | "cell"
+      | "checkbox"
+      | "columnheader"
+      | "combobox"
+      | "complementary"
+      | "contentinfo"
+      | "definition"
+      | "dialog"
+      | "directory"
+      | "document"
+      | "feed"
+      | "figure"
+      | "form"
+      | "grid"
+      | "gridcell"
+      | "group"
+      | "heading"
+      | "img"
+      | "link"
+      | "list"
+      | "listbox"
+      | "listitem"
+      | "log"
+      | "main"
+      | "marquee"
+      | "math"
+      | "menu"
+      | "menubar"
+      | "menuitem"
+      | "menuitemcheckbox"
+      | "menuitemradio"
+      | "meter"
+      | "navigation"
+      | "none"
+      | "note"
+      | "option"
+      | "presentation"
+      | "progressbar"
+      | "radio"
+      | "radiogroup"
+      | "region"
+      | "row"
+      | "rowgroup"
+      | "rowheader"
+      | "scrollbar"
+      | "search"
+      | "searchbox"
+      | "separator"
+      | "slider"
+      | "spinbutton"
+      | "status"
+      | "switch"
+      | "tab"
+      | "table"
+      | "tablist"
+      | "tabpanel"
+      | "term"
+      | "textbox"
+      | "timer"
+      | "toolbar"
+      | "tooltip"
+      | "tree"
+      | "treegrid"
+      | "treeitem"
+    >;
   }
 
   interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
@@ -643,7 +664,9 @@ export namespace JSX {
     itemref?: FunctionMaybe<string>;
     part?: FunctionMaybe<string>;
     exportparts?: FunctionMaybe<string>;
-    inputmode?: FunctionMaybe<"none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search">;
+    inputmode?: FunctionMaybe<
+      "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search"
+    >;
     contentEditable?: FunctionMaybe<boolean | "inherit">;
     contextMenu?: FunctionMaybe<string>;
     tabIndex?: FunctionMaybe<number | string>;
@@ -654,7 +677,9 @@ export namespace JSX {
     itemId?: FunctionMaybe<string>;
     itemRef?: FunctionMaybe<string>;
     exportParts?: FunctionMaybe<string>;
-    inputMode?: FunctionMaybe<"none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search">;
+    inputMode?: FunctionMaybe<
+      "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search"
+    >;
   }
   interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
     download?: FunctionMaybe<any>;
@@ -1017,7 +1042,7 @@ export namespace JSX {
     rowspan?: FunctionMaybe<number | string>;
     colSpan?: FunctionMaybe<number | string>;
     rowSpan?: FunctionMaybe<number | string>;
-    scope?: FunctionMaybe<'col' | 'row' | 'rowgroup' | 'colgroup'>;
+    scope?: FunctionMaybe<"col" | "row" | "rowgroup" | "colgroup">;
   }
   interface TimeHTMLAttributes<T> extends HTMLAttributes<T> {
     datetime?: FunctionMaybe<string>;
@@ -1223,26 +1248,30 @@ export namespace JSX {
       | "stroke"
       | "all"
       | "none"
-      | "inherit">;
-    "shape-rendering"?: FunctionMaybe<"auto" | "optimizeSpeed" | "crispEdges" | "geometricPrecision" | "inherit">;
+      | "inherit"
+    >;
+    "shape-rendering"?: FunctionMaybe<
+      "auto" | "optimizeSpeed" | "crispEdges" | "geometricPrecision" | "inherit"
+    >;
     "stop-color"?: FunctionMaybe<string>;
     "stop-opacity"?: FunctionMaybe<number | string | "inherit">;
     stroke?: FunctionMaybe<string>;
     "stroke-dasharray"?: FunctionMaybe<string>;
     "stroke-dashoffset"?: FunctionMaybe<number | string>;
     "stroke-linecap"?: FunctionMaybe<"butt" | "round" | "square" | "inherit">;
-    "stroke-linejoin"?: FunctionMaybe<"arcs" | "bevel" | "miter" | "miter-clip" | "round" | "inherit">;
+    "stroke-linejoin"?: FunctionMaybe<
+      "arcs" | "bevel" | "miter" | "miter-clip" | "round" | "inherit"
+    >;
     "stroke-miterlimit"?: FunctionMaybe<number | string | "inherit">;
     "stroke-opacity"?: FunctionMaybe<number | string | "inherit">;
     "stroke-width"?: FunctionMaybe<number | string>;
     "text-anchor"?: FunctionMaybe<"start" | "middle" | "end" | "inherit">;
-    "text-decoration"?: FunctionMaybe<"none" | "underline" | "overline" | "line-through" | "blink" | "inherit">;
+    "text-decoration"?: FunctionMaybe<
+      "none" | "underline" | "overline" | "line-through" | "blink" | "inherit"
+    >;
     "text-rendering"?: FunctionMaybe<
-      | "auto"
-      | "optimizeSpeed"
-      | "optimizeLegibility"
-      | "geometricPrecision"
-      | "inherit">;
+      "auto" | "optimizeSpeed" | "optimizeLegibility" | "geometricPrecision" | "inherit"
+    >;
     "unicode-bidi"?: FunctionMaybe<string>;
     visibility?: FunctionMaybe<"visible" | "hidden" | "collapse" | "inherit">;
     "word-spacing"?: FunctionMaybe<number | string>;
@@ -1293,7 +1322,7 @@ export namespace JSX {
     gradientUnits?: FunctionMaybe<SVGUnits>;
     gradientTransform?: FunctionMaybe<string>;
     spreadMethod?: FunctionMaybe<"pad" | "reflect" | "repeat">;
-    href?: FunctionMaybe<string>
+    href?: FunctionMaybe<string>;
   }
   interface GraphicsElementSVGAttributes<T>
     extends CoreSVGAttributes<T>,

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -267,6 +267,7 @@ export namespace JSX {
     onRateChange?: EventHandlerUnion<T, Event>;
     onReset?: EventHandlerUnion<T, Event>;
     onScroll?: EventHandlerUnion<T, UIEvent>;
+    onScrollEnd?: EventHandlerUnion<T, Event>;
     onSeeked?: EventHandlerUnion<T, Event>;
     onSeeking?: EventHandlerUnion<T, Event>;
     onSelect?: EventHandlerUnion<T, UIEvent>;
@@ -353,6 +354,7 @@ export namespace JSX {
     onratechange?: EventHandlerUnion<T, Event>;
     onreset?: EventHandlerUnion<T, Event>;
     onscroll?: EventHandlerUnion<T, UIEvent>;
+    onscrollend?: EventHandlerUnion<T, Event>;
     onseeked?: EventHandlerUnion<T, Event>;
     onseeking?: EventHandlerUnion<T, Event>;
     onselect?: EventHandlerUnion<T, UIEvent>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -266,7 +266,7 @@ export namespace JSX {
     onProgress?: EventHandlerUnion<T, Event>;
     onRateChange?: EventHandlerUnion<T, Event>;
     onReset?: EventHandlerUnion<T, Event>;
-    onScroll?: EventHandlerUnion<T, UIEvent>;
+    onScroll?: EventHandlerUnion<T, Event>;
     onScrollEnd?: EventHandlerUnion<T, Event>;
     onSeeked?: EventHandlerUnion<T, Event>;
     onSeeking?: EventHandlerUnion<T, Event>;
@@ -353,7 +353,7 @@ export namespace JSX {
     onprogress?: EventHandlerUnion<T, Event>;
     onratechange?: EventHandlerUnion<T, Event>;
     onreset?: EventHandlerUnion<T, Event>;
-    onscroll?: EventHandlerUnion<T, UIEvent>;
+    onscroll?: EventHandlerUnion<T, Event>;
     onscrollend?: EventHandlerUnion<T, Event>;
     onseeked?: EventHandlerUnion<T, Event>;
     onseeking?: EventHandlerUnion<T, Event>;

--- a/packages/dom-expressions/test/verify_types.ts
+++ b/packages/dom-expressions/test/verify_types.ts
@@ -1,49 +1,50 @@
-import { JSX } from '../src/jsx'
+import { JSX } from "../src/jsx";
 
 /**
  * Statically verify type definitions of `jsx-runtime`.
- * 
+ *
  * This file checks that JSX interfaces extend built-in type definitions from dom.
  * It's not meant to be run with unit tests; it will only report errors in your IDE or `tsc`.
  */
 
 function verifyHTMLElementTags(t: keyof HTMLElementTagNameMap): keyof JSX.HTMLElementTags {
-    return t
+  return t;
 }
 
-type SvgTagsNoDuplicates = keyof JSX.SVGElementTags | 'a' | 'script' | 'style' | 'title';
+type SvgTagsNoDuplicates = keyof JSX.SVGElementTags | "a" | "script" | "style" | "title";
 function verifySVGElementTags(t: keyof SVGElementTagNameMap): SvgTagsNoDuplicates {
-    return t
+  return t;
 }
 
 interface EventHandlersWithUnimplemented extends JSX.CustomEventHandlersLowerCase<{}> {
-    onanimationcancel: any;
-    oncancel: any;
-    onclose: any;
-    oncuechange: any;
-    onformdata: any;
-    onresize: any;
-    onsecuritypolicyviolation: any;
-    onselectionchange: any;
-    onselectstart: any;
-    onslotchange: any;
-    ontoggle: any;
-    ontransitioncancel: any;
-    ontransitionrun: any;
-    ontransitionstart: any;
-    onwebkitanimationend: any;
-    onwebkitanimationiteration: any;
-    onwebkitanimationstart: any;
-    onwebkittransitionend: any;
-    addEventListener: any;
-    removeEventListener: any;
+  onanimationcancel: any;
+  oncancel: any;
+  onclose: any;
+  oncuechange: any;
+  onformdata: any;
+  onresize: any;
+  onsecuritypolicyviolation: any;
+  onselectionchange: any;
+  onselectstart: any;
+  onslotchange: any;
+  ontoggle: any;
+  onwebkitanimationend: any;
+  onwebkitanimationiteration: any;
+  onwebkitanimationstart: any;
+  onwebkittransitionend: any;
+  addEventListener: any;
+  removeEventListener: any;
 }
 
-function verifyCustomGlobalEventHandlers(t: keyof GlobalEventHandlers): keyof EventHandlersWithUnimplemented {
-    return t
+function verifyCustomGlobalEventHandlers(
+  t: keyof GlobalEventHandlers
+): keyof EventHandlersWithUnimplemented {
+  return t;
 }
 
-type LoweredEventHandlerNames = Lowercase<keyof JSX.CustomEventHandlersCamelCase<{}>>
-function verifyEventHandlerCaseMatches(t: keyof JSX.CustomEventHandlersLowerCase<{}>): LoweredEventHandlerNames {
-    return t
+type LoweredEventHandlerNames = Lowercase<keyof JSX.CustomEventHandlersCamelCase<{}>>;
+function verifyEventHandlerCaseMatches(
+  t: keyof JSX.CustomEventHandlersLowerCase<{}>
+): LoweredEventHandlerNames {
+  return t;
 }


### PR DESCRIPTION
Adds 
- transition events to `jsx-h.d.ts`. 
- `onscrollend` events to `jsx-h.d.ts` and `jsx.d.ts`
- removes transition events from Unimplemented on `verify_types.ts`
- prettier reformatted the files `jsx-h.d.ts` and `verify_types.ts`
- change onscroll event type from `UIEvent` to `Event` https://discord.com/channels/722131463138705510/817960620736380928/1113852027148193943