### PR TITLE
Comments out transformation of `this`

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
@@ -21,7 +21,8 @@ import transformFragmentChildren from "./fragment";
 
 export function transformJSX(path) {
   const config = getConfig(path);
-  const replace = transformThis(path);
+  // TODO should detect if in a `class` to transform `this`
+  // const replaceThis = transformThis(path);
   const result = transformNode(
     path,
     t.isJSXFragment(path.node)
@@ -34,7 +35,8 @@ export function transformJSX(path) {
 
   const template = getCreateTemplate(config, path, result);
 
-  path.replaceWith(replace(template(path, result, false)));
+  // path.replaceWith(replaceThis(template(path, result, false)));
+  path.replaceWith(template(path, result, false));
 }
 
 export function transformThis(path) {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
@@ -115,14 +115,6 @@ const template12 = (
   </div>
 );
 
-class Template13 {
-  render() {
-    <Component prop={this.something} onClick={() => this.shouldStay}>
-      <Nested prop={this.data}>{this.content}</Nested>
-    </Component>;
-  }
-}
-
 const Template14 = <Component>{data()}</Component>;
 
 const Template15 = <Component {...props}/>
@@ -132,7 +124,7 @@ const Template16 = <Component something={something} {...props}/>
 const Template17 = <Pre><span>1</span> <span>2</span> <span>3</span></Pre>
 const Template18 = <Pre>
   <span>1</span>
-  <span>2</span> 
+  <span>2</span>
   <span>3</span>
 </Pre>
 
@@ -154,10 +146,10 @@ const template22 = <Component passObject={{ ...a }} ></Component>
 
 const template23 = <Component disabled={"t" in test}>{"t" in test && "true"}</Component>
 
-const template24 = <Component> 
+const template24 = <Component>
   {state.dynamic}
 </Component>
 
-const template25 = <Component> 
+const template25 = <Component>
   <div />
 </Component>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -291,27 +291,6 @@ const template12 = (() => {
   );
   return _el$28;
 })();
-class Template13 {
-  render() {
-    const _self$ = this;
-    _$createComponent(Component, {
-      get prop() {
-        return _self$.something;
-      },
-      onClick: () => _self$.shouldStay,
-      get children() {
-        return _$createComponent(Nested, {
-          get prop() {
-            return _self$.data;
-          },
-          get children() {
-            return _self$.content;
-          }
-        });
-      }
-    });
-  }
-}
 const Template14 = _$createComponent(Component, {
   get children() {
     return data();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/code.js
@@ -115,14 +115,6 @@ const template12 = (
   </div>
 );
 
-class Template13 {
-  render() {
-    <Component prop={this.something} onClick={() => this.shouldStay}>
-      <Nested prop={this.data}>{this.content}</Nested>
-    </Component>;
-  }
-}
-
 const Template14 = <Component>{data()}</Component>;
 
 const Template15 = <Component {...props}/>
@@ -132,7 +124,7 @@ const Template16 = <Component something={something} {...props}/>
 const Template17 = <Pre><span>1</span> <span>2</span> <span>3</span></Pre>
 const Template18 = <Pre>
   <span>1</span>
-  <span>2</span> 
+  <span>2</span>
   <span>3</span>
 </Pre>
 
@@ -154,10 +146,10 @@ const template22 = <Component passObject={{ ...a }} ></Component>
 
 const template23 = <Component disabled={"t" in test}>{"t" in test && "true"}</Component>
 
-const template24 = <Component> 
+const template24 = <Component>
   {state.dynamic}
 </Component>
 
-const template25 = <Component> 
+const template25 = <Component>
   <div />
 </Component>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/output.js
@@ -348,27 +348,6 @@ const template12 = (() => {
   );
   return _el$54;
 })();
-class Template13 {
-  render() {
-    const _self$ = this;
-    _$createComponent(Component, {
-      get prop() {
-        return _self$.something;
-      },
-      onClick: () => _self$.shouldStay,
-      get children() {
-        return _$createComponent(Nested, {
-          get prop() {
-            return _self$.data;
-          },
-          get children() {
-            return _self$.content;
-          }
-        });
-      }
-    });
-  }
-}
 const Template14 = _$createComponent(Component, {
   get children() {
     return data();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/code.js
@@ -115,14 +115,6 @@ const template12 = (
   </div>
 );
 
-class Template13 {
-  render() {
-    <Component prop={this.something} onClick={() => this.shouldStay}>
-      <Nested prop={this.data}>{this.content}</Nested>
-    </Component>;
-  }
-}
-
 const Template14 = <Component>{data()}</Component>;
 
 const Template15 = <Component {...props}/>
@@ -132,7 +124,7 @@ const Template16 = <Component something={something} {...props}/>
 const Template17 = <Pre><span>1</span> <span>2</span> <span>3</span></Pre>
 const Template18 = <Pre>
   <span>1</span>
-  <span>2</span> 
+  <span>2</span>
   <span>3</span>
 </Pre>
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
@@ -290,27 +290,6 @@ const template12 = (() => {
   );
   return _el$28;
 })();
-class Template13 {
-  render() {
-    const _self$ = this;
-    _$createComponent(Component, {
-      get prop() {
-        return _self$.something;
-      },
-      onClick: () => _self$.shouldStay,
-      get children() {
-        return _$createComponent(Nested, {
-          get prop() {
-            return _self$.data;
-          },
-          get children() {
-            return _self$.content;
-          }
-        });
-      }
-    });
-  }
-}
 const Template14 = _$createComponent(Component, {
   get children() {
     return data();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/components/code.js
@@ -115,14 +115,6 @@ const template12 = (
   </div>
 );
 
-class Template13 {
-  render() {
-    <Component prop={this.something} onClick={() => this.shouldStay}>
-      <Nested prop={this.data}>{this.content}</Nested>
-    </Component>;
-  }
-}
-
 const Template14 = <Component>{data()}</Component>;
 
 const Template15 = <Component {...props}/>
@@ -132,7 +124,7 @@ const Template16 = <Component something={something} {...props}/>
 const Template17 = <Pre><span>1</span> <span>2</span> <span>3</span></Pre>
 const Template18 = <Pre>
   <span>1</span>
-  <span>2</span> 
+  <span>2</span>
   <span>3</span>
 </Pre>
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/components/output.js
@@ -291,27 +291,6 @@ const template12 = (() => {
   );
   return _el$28;
 })();
-class Template13 {
-  render() {
-    const _self$ = this;
-    _$createComponent(Component, {
-      get prop() {
-        return _self$.something;
-      },
-      onClick: () => _self$.shouldStay,
-      get children() {
-        return _$createComponent(Nested, {
-          get prop() {
-            return _self$.data;
-          },
-          get children() {
-            return _self$.content;
-          }
-        });
-      }
-    });
-  }
-}
 const Template14 = _$createComponent(Component, {
   get children() {
     return data();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/code.js
@@ -115,14 +115,6 @@ const template12 = (
   </div>
 );
 
-class Template13 {
-  render() {
-    <Component prop={this.something} onClick={() => this.shouldStay}>
-      <Nested prop={this.data}>{this.content}</Nested>
-    </Component>;
-  }
-}
-
 const Template14 = <Component>{data()}</Component>;
 
 const Template15 = <Component {...props}/>
@@ -132,7 +124,7 @@ const Template16 = <Component something={something} {...props}/>
 const Template17 = <Pre><span>1</span> <span>2</span> <span>3</span></Pre>
 const Template18 = <Pre>
   <span>1</span>
-  <span>2</span> 
+  <span>2</span>
   <span>3</span>
 </Pre>
 
@@ -154,10 +146,10 @@ const template22 = <Component passObject={{ ...a }} ></Component>
 
 const template23 = <Component disabled={"t" in test}>{"t" in test && "true"}</Component>
 
-const template24 = <Component> 
+const template24 = <Component>
   {state.dynamic}
 </Component>
 
-const template25 = <Component> 
+const template25 = <Component>
   <div />
 </Component>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/output.js
@@ -203,27 +203,6 @@ const template12 = _$ssr(
     })
   )
 );
-class Template13 {
-  render() {
-    const _self$ = this;
-    _$createComponent(Component, {
-      get prop() {
-        return _self$.something;
-      },
-      onClick: () => _self$.shouldStay,
-      get children() {
-        return _$createComponent(Nested, {
-          get prop() {
-            return _self$.data;
-          },
-          get children() {
-            return _self$.content;
-          }
-        });
-      }
-    });
-  }
-}
 const Template14 = _$createComponent(Component, {
   get children() {
     return data();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/code.js
@@ -115,14 +115,6 @@ const template12 = (
   </div>
 );
 
-class Template13 {
-  render() {
-    <Component prop={this.something} onClick={() => this.shouldStay}>
-      <Nested prop={this.data}>{this.content}</Nested>
-    </Component>;
-  }
-}
-
 const Template14 = <Component>{data()}</Component>;
 
 const Template15 = <Component {...props}/>
@@ -132,7 +124,7 @@ const Template16 = <Component something={something} {...props}/>
 const Template17 = <Pre><span>1</span> <span>2</span> <span>3</span></Pre>
 const Template18 = <Pre>
   <span>1</span>
-  <span>2</span> 
+  <span>2</span>
   <span>3</span>
 </Pre>
 
@@ -154,10 +146,10 @@ const template22 = <Component passObject={{ ...a }} ></Component>
 
 const template23 = <Component disabled={"t" in test}>{"t" in test && "true"}</Component>
 
-const template24 = <Component> 
+const template24 = <Component>
   {state.dynamic}
 </Component>
 
-const template25 = <Component> 
+const template25 = <Component>
   <div />
 </Component>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/output.js
@@ -234,27 +234,6 @@ const template12 = _$ssr(
     })
   )
 );
-class Template13 {
-  render() {
-    const _self$ = this;
-    _$createComponent(Component, {
-      get prop() {
-        return _self$.something;
-      },
-      onClick: () => _self$.shouldStay,
-      get children() {
-        return _$createComponent(Nested, {
-          get prop() {
-            return _self$.data;
-          },
-          get children() {
-            return _self$.content;
-          }
-        });
-      }
-    });
-  }
-}
 const Template14 = _$createComponent(Component, {
   get children() {
     return data();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/components/code.js
@@ -113,14 +113,6 @@ const template12 = (
   </div>
 );
 
-class Template13 {
-  render() {
-    <Component prop={this.something} onClick={() => this.shouldStay}>
-      <Nested prop={this.data}>{this.content}</Nested>
-    </Component>;
-  }
-}
-
 const Template14 = <Component>{data()}</Component>;
 
 const Template15 = <Component {...props}/>
@@ -130,7 +122,7 @@ const Template16 = <Component something={something} {...props}/>
 const Template17 = <Pre><span>1</span> <span>2</span> <span>3</span></Pre>
 const Template18 = <Pre>
   <span>1</span>
-  <span>2</span> 
+  <span>2</span>
   <span>3</span>
 </Pre>
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/components/output.js
@@ -284,27 +284,6 @@ const template12 = (() => {
   );
   return _el$23;
 })();
-class Template13 {
-  render() {
-    const _self$ = this;
-    _$createComponent(Component, {
-      get prop() {
-        return _self$.something;
-      },
-      onClick: () => _self$.shouldStay,
-      get children() {
-        return _$createComponent(Nested, {
-          get prop() {
-            return _self$.data;
-          },
-          get children() {
-            return _self$.content;
-          }
-        });
-      }
-    });
-  }
-}
 const Template14 = _$createComponent(Component, {
   get children() {
     return data();


### PR DESCRIPTION
Related to https://github.com/ryansolid/dom-expressions/issues/247

It comments out the transformation of `this` to `$self` as its breaking function binding in solid. 
Presumably the transformation is for compatibility with `mobx-jsx` which I guess is barely used compared to solid.