### PR TITLE
Fix `/*@once*/` only works with first child of object

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -89,7 +89,6 @@ export function isDynamic(path, { checkMember, checkTags, checkCallExpressions =
     expr.leadingComments[0] &&
     expr.leadingComments[0].value.trim() === config.staticMarker
   ) {
-    expr.leadingComments.shift();
     return false;
   }
   if (

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -102,11 +102,11 @@ const template2 = (() => {
 })();
 const template3 = (() => {
   const _el$9 = _tmpl$3();
-  _$setAttribute(_el$9, "id", state.id);
-  state.color != null
+  _$setAttribute(_el$9, "id", /*@once*/ state.id);
+  /*@once*/ state.color != null
     ? _el$9.style.setProperty("background-color", state.color)
     : _el$9.style.removeProperty("background-color");
-  _el$9.textContent = state.content;
+  _el$9.textContent = /*@once*/ state.content;
   _$effect(() => _$setAttribute(_el$9, "name", state.name));
   return _el$9;
 })();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -105,7 +105,7 @@ const template2 = _$createComponent(Child, {
   get dynamic() {
     return state.data;
   },
-  stale: state.data,
+  stale: /*@once*/ state.data,
   handleClick: clickHandler,
   get ["hyphen-ated"]() {
     return state.data;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/insertChildren/output.js
@@ -61,11 +61,11 @@ const template10 = _$createComponent(
 );
 const template11 = (() => {
   const _el$9 = _tmpl$2();
-  _$insert(_el$9, state.children);
+  _$insert(_el$9, /*@once*/ state.children);
   return _el$9;
 })();
 const template12 = _$createComponent(Module, {
-  children: state.children
+  children: /*@once*/ state.children
 });
 const template13 = (() => {
   const _el$10 = _tmpl$2();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -108,11 +108,11 @@ const template2 = (() => {
 })();
 const template3 = (() => {
   const _el$9 = _$getNextElement(_tmpl$3);
-  _$setAttribute(_el$9, "id", state.id);
-  state.color != null
+  _$setAttribute(_el$9, "id", /*@once*/ state.id);
+  /*@once*/ state.color != null
     ? _el$9.style.setProperty("background-color", state.color)
     : _el$9.style.removeProperty("background-color");
-  _el$9.textContent = state.content;
+  _el$9.textContent = /*@once*/ state.content;
   _$effect(() => _$setAttribute(_el$9, "name", state.name));
   return _el$9;
 })();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/output.js
@@ -123,7 +123,7 @@ const template2 = _$createComponent(Child, {
   get dynamic() {
     return state.data;
   },
-  stale: state.data,
+  stale: /*@once*/ state.data,
   handleClick: clickHandler,
   get ["hyphen-ated"]() {
     return state.data;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/insertChildren/output.js
@@ -67,11 +67,11 @@ const template10 = _$createComponent(
 );
 const template11 = (() => {
   const _el$9 = _$getNextElement(_tmpl$2);
-  _$insert(_el$9, state.children);
+  _$insert(_el$9, /*@once*/ state.children);
   return _el$9;
 })();
 const template12 = _$createComponent(Module, {
-  children: state.children
+  children: /*@once*/ state.children
 });
 const template13 = (() => {
   const _el$10 = _$getNextElement(_tmpl$2);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
@@ -104,7 +104,7 @@ const template2 = _$createComponent(Child, {
   get dynamic() {
     return state.data;
   },
-  stale: state.data,
+  stale: /*@once*/ state.data,
   handleClick: clickHandler,
   get ["hyphen-ated"]() {
     return state.data;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/code.js
@@ -66,3 +66,17 @@ const template13 = <input type="checkbox" checked={true} readonly="" />;
 const template14 = <input type="checkbox" checked={state.visible} readonly={value} />;
 
 const template15 = <mesh scale={[1, 1, 1]} rotateX={0} />;
+
+const template16 = (
+  <div
+    style={/*@once*/ { "background-color": color(), "margin-right": props.top }}
+  />
+);
+
+const template17 = (
+  <div
+    style={/*@once*/ { "background-color": color(), "margin-right": props.top }}
+    style:padding-top={props.top}
+    class:my-class={props.active}
+  />
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -86,11 +86,11 @@ const template2 = (() => {
 })();
 const template3 = (() => {
   const _el$9 = _tmpl$3();
-  _$setAttribute(_el$9, "id", state.id);
-  state.color != null
+  _$setAttribute(_el$9, "id", /*@once*/ state.id);
+  /*@once*/ state.color != null
     ? _el$9.style.setProperty("background-color", state.color)
     : _el$9.style.removeProperty("background-color");
-  _el$9.textContent = state.content;
+  _el$9.textContent = /*@once*/ state.content;
   _$effect(() => _$setAttribute(_el$9, "name", state.name));
   return _el$9;
 })();
@@ -181,4 +181,40 @@ const template15 = (() => {
   _$setProp(_el$21, "scale", [1, 1, 1]);
   _$setProp(_el$21, "rotateX", 0);
   return _el$21;
+})();
+const template16 = (() => {
+  const _el$22 = _tmpl$3();
+  /*@once*/ color() != null
+    ? _el$22.style.setProperty("background-color", color())
+    : _el$22.style.removeProperty("background-color");
+  props.top != null
+    ? _el$22.style.setProperty("margin-right", props.top)
+    : _el$22.style.removeProperty("margin-right");
+  return _el$22;
+})();
+const template17 = (() => {
+  const _el$23 = _tmpl$3();
+  /*@once*/ color() != null
+    ? _el$23.style.setProperty("background-color", color())
+    : _el$23.style.removeProperty("background-color");
+  props.top != null
+    ? _el$23.style.setProperty("margin-right", props.top)
+    : _el$23.style.removeProperty("margin-right");
+  _$effect(
+    _p$ => {
+      const _v$4 = props.top,
+        _v$5 = !!props.active;
+      _v$4 !== _p$._v$4 &&
+        ((_p$._v$4 = _v$4) != null
+          ? _el$23.style.setProperty("padding-top", _v$4)
+          : _el$23.style.removeProperty("padding-top"));
+      _v$5 !== _p$._v$5 && _el$23.classList.toggle("my-class", (_p$._v$5 = _v$5));
+      return _p$;
+    },
+    {
+      _v$4: undefined,
+      _v$5: undefined
+    }
+  );
+  return _el$23;
 })();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/components/output.js
@@ -105,7 +105,7 @@ const template2 = _$createComponent(Child, {
   get dynamic() {
     return state.data;
   },
-  stale: state.data,
+  stale: /*@once*/ state.data,
   handleClick: clickHandler,
   get ["hyphen-ated"]() {
     return state.data;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/insertChildren/output.js
@@ -60,11 +60,11 @@ const template10 = _$createComponent(
 );
 const template11 = (() => {
   const _el$9 = _tmpl$2();
-  _$insert(_el$9, state.children);
+  _$insert(_el$9, /*@once*/ state.children);
   return _el$9;
 })();
 const template12 = _$createComponent(Module, {
-  children: state.children
+  children: /*@once*/ state.children
 });
 const template13 = (() => {
   const _el$10 = _tmpl$2();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
@@ -82,7 +82,7 @@ const template3 = _$ssr(
   _$ssrAttribute("id", _$escape(/*@once*/ state.id, true), false),
   "background-color:" + _$escape(state.color, true),
   _$ssrAttribute("name", _$escape(state.name, true), false),
-  _$escape(state.content)
+  _$escape(/*@once*/ state.content)
 );
 const template4 = _$ssr(_tmpl$5, `hi ${_$escape(state.class, true) || ""} ccc:ddd`);
 const template5 = _$ssr(_tmpl$5, `a  b`);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/output.js
@@ -69,7 +69,7 @@ const template2 = _$createComponent(Child, {
   get dynamic() {
     return state.data;
   },
-  stale: state.data,
+  stale: /*@once*/ state.data,
   handleClick: clickHandler,
   get ["hyphen-ated"]() {
     return state.data;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/insertChildren/output.js
@@ -34,9 +34,9 @@ const template10 = _$createComponent(
     children: "Hello"
   })
 );
-const template11 = _$ssr(_tmpl$2, _$escape(state.children));
+const template11 = _$ssr(_tmpl$2, _$escape(/*@once*/ state.children));
 const template12 = _$createComponent(Module, {
-  children: state.children
+  children: /*@once*/ state.children
 });
 const template13 = _$ssr(_tmpl$2, _$escape(children));
 const template14 = _$createComponent(Module, {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/output.js
@@ -92,7 +92,7 @@ const template2 = _$createComponent(Child, {
   get dynamic() {
     return state.data;
   },
-  stale: state.data,
+  stale: /*@once*/ state.data,
   handleClick: clickHandler,
   get ["hyphen-ated"]() {
     return state.data;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/insertChildren/output.js
@@ -35,9 +35,9 @@ const template10 = _$createComponent(
     children: "Hello"
   })
 );
-const template11 = _$ssr(_tmpl$2, _$ssrHydrationKey(), _$escape(state.children));
+const template11 = _$ssr(_tmpl$2, _$ssrHydrationKey(), _$escape(/*@once*/ state.children));
 const template12 = _$createComponent(Module, {
-  children: state.children
+  children: /*@once*/ state.children
 });
 const template13 = _$ssr(_tmpl$2, _$ssrHydrationKey(), _$escape(children));
 const template14 = _$createComponent(Module, {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
@@ -75,11 +75,15 @@ const template2 = (() => {
 })();
 const template3 = (() => {
   const _el$9 = _$createElement("div");
-  _$setProp(_el$9, "id", state.id);
-  _$setProp(_el$9, "style", {
-    "background-color": state.color
-  });
-  _$setProp(_el$9, "textContent", state.content);
+  _$setProp(_el$9, "id", /*@once*/ state.id);
+  _$setProp(
+    _el$9,
+    "style",
+    /*@once*/ {
+      "background-color": state.color
+    }
+  );
+  _$setProp(_el$9, "textContent", /*@once*/ state.content);
   _$effect(_$p => _$setProp(_el$9, "name", state.name, _$p));
   return _el$9;
 })();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/components/output.js
@@ -97,7 +97,7 @@ const template2 = _$createComponent(Child, {
   get dynamic() {
     return state.data;
   },
-  stale: state.data,
+  stale: /*@once*/ state.data,
   handleClick: clickHandler,
   get ["hyphen-ated"]() {
     return state.data;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/insertChildren/output.js
@@ -62,11 +62,11 @@ const template10 = _$createComponent(
 );
 const template11 = (() => {
   const _el$11 = _$createElement("module");
-  _$insert(_el$11, state.children);
+  _$insert(_el$11, /*@once*/ state.children);
   return _el$11;
 })();
 const template12 = _$createComponent(Module, {
-  children: state.children
+  children: /*@once*/ state.children
 });
 const template13 = (() => {
   const _el$12 = _$createElement("module");


### PR DESCRIPTION
Related to #252 

Somehow figured that the problem was that removing the comment makes the expression dynamic again for the next object evaluated. That's why it works _once_ and then stops working. 

Added a test expecting the effect to not be present. 

The effect will be present even in the presence of `@once` if you use a spread, which I didn't figure how to handle nor what to expect to be honest. I didn't add a test for it because it will fail.