### PR TITLE
feat: camelCase CSS properties in style objects

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -56,6 +56,8 @@ const alwaysClose = [
   "fieldset"
 ];
 
+const upperCaseChars = /[A-Z]/g;
+
 export function transformElement(path, info) {
   let tagName = getTagName(path.node),
     config = getConfig(path),
@@ -137,6 +139,8 @@ export function setAttr(path, elem, name, value, { isSVG, dynamic, prevId, isCE,
 
   // TODO: consider moving to a helper
   if (namespace === "style") {
+    if (upperCaseChars.test(name)) name = name.replace(upperCaseChars, "-$&").toLowerCase();
+
     if (t.isStringLiteral(value)) {
       return t.callExpression(
         t.memberExpression(

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -178,3 +178,9 @@ const template32 = (
     style={{ "background-color": undefined }}
   />
 );
+
+const template33 = (
+  <div
+    style={{ backgroundColor: color(), marginRight: "40px" }}
+  />
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -350,4 +350,14 @@ const template32 = (() => {
   _el$45.style.removeProperty("background-color");
   return _el$45;
 })();
+const template33 = (() => {
+  const _el$46 = _tmpl$4();
+  _el$46.style.setProperty("margin-right", "40px");
+  _$effect(() =>
+    color() != null
+      ? _el$46.style.setProperty("background-color", color())
+      : _el$46.style.removeProperty("background-color")
+  );
+  return _el$46;
+})();
 _$delegateEvents(["click", "input"]);

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -378,7 +378,7 @@ export namespace JSX {
     onwheel?: EventHandlerUnion<T, WheelEvent>;
   }
 
-  interface CSSProperties extends csstype.PropertiesHyphen {
+  interface CSSProperties extends csstype.PropertiesHyphen, csstype.Properties {
     // Override
     [key: `-${string}`]: string | number | undefined;
   }


### PR DESCRIPTION
This PR adds the ability to use camelCase CSS property names in style objects.

### Example

```jsx
// old
<div style={{ 'margin-top': '40px' }}>
```

```jsx
// new
<div style={{ marginTop: '40px' }}>
```

### Testing

Testing has been added to ensure the Babel transform converts camelCase CSS property names to kebab-case ones.

### Definitions

The JSX definitions file has also been updated and TypeScript/IntelliSense recognizes the camelCase CSS property names.
