### PR TITLE
fix names of `http-equiv` and `accept-charset` attributes

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -741,7 +741,7 @@ export namespace JSX {
     name?: FunctionMaybe<string>;
   }
   interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
-    acceptcharset?: FunctionMaybe<string>;
+    "accept-charset"?: FunctionMaybe<string>;
     action?: FunctionMaybe<string>;
     autocomplete?: FunctionMaybe<string>;
     encoding?: FunctionMaybe<HTMLFormEncType>;
@@ -750,7 +750,6 @@ export namespace JSX {
     name?: FunctionMaybe<string>;
     novalidate?: FunctionMaybe<boolean>;
     target?: FunctionMaybe<string>;
-    acceptCharset?: FunctionMaybe<string>;
     noValidate?: FunctionMaybe<boolean>;
   }
   interface IframeHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -885,9 +884,8 @@ export namespace JSX {
   interface MetaHTMLAttributes<T> extends HTMLAttributes<T> {
     charset?: FunctionMaybe<string>;
     content?: FunctionMaybe<string>;
-    httpequiv?: FunctionMaybe<string>;
+    "http-equiv"?: FunctionMaybe<string>;
     name?: FunctionMaybe<string>;
-    httpEquiv?: FunctionMaybe<string>;
   }
   interface MeterHTMLAttributes<T> extends HTMLAttributes<T> {
     form?: FunctionMaybe<string>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -839,7 +839,7 @@ export namespace JSX {
     name?: string;
   }
   interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
-    acceptcharset?: string;
+    "accept-charset"?: string;
     action?: string;
     autocomplete?: string;
     encoding?: HTMLFormEncType;
@@ -848,7 +848,6 @@ export namespace JSX {
     name?: string;
     novalidate?: boolean;
     target?: string;
-    acceptCharset?: string;
     noValidate?: boolean;
   }
   interface IframeHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -989,9 +988,8 @@ export namespace JSX {
   interface MetaHTMLAttributes<T> extends HTMLAttributes<T> {
     charset?: string;
     content?: string;
-    httpequiv?: string;
+    "http-equiv"?: string;
     name?: string;
-    httpEquiv?: string;
   }
   interface MeterHTMLAttributes<T> extends HTMLAttributes<T> {
     form?: string;


### PR DESCRIPTION
Fixes #260