### PR TITLE
Add enterkeyhint to textarea type def

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1101,6 +1101,7 @@ export namespace JSX {
     cols?: number | string;
     dirname?: string;
     disabled?: boolean;
+    enterkeyhint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send";
     form?: string;
     maxlength?: number | string;
     minlength?: number | string;


### PR DESCRIPTION
Already exists on` <input>` but not on `<textarea>`. 

https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute