### PR TITLE
Unwrap arrow function IIFEs in component props

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
@@ -175,3 +175,15 @@ const template27 = <Component
   when={(() => prop.red ? "red" : "green")()}
 />
 
+class Template28 {
+  render() {
+    return <Component
+      when={(() => {
+        const foo = this.value;
+        if ("key" in foo) {
+          return foo
+        }
+      })()}
+    />
+  }
+}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
@@ -170,3 +170,8 @@ const template26 = <Component
     }
   })()}
 />
+
+const template27 = <Component
+  when={(() => prop.red ? "red" : "green")()}
+/>
+

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
@@ -161,3 +161,12 @@ const template24 = <Component>
 const template25 = <Component> 
   <div />
 </Component>
+
+const template26 = <Component
+  when={(() => {
+    const foo = test();
+    if ("t" in foo) {
+      return foo;
+    }
+  })()}
+/>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -381,11 +381,9 @@ const template25 = _$createComponent(Component, {
 });
 const template26 = _$createComponent(Component, {
   get when() {
-    return (() => {
-      const foo = test();
-      if ("t" in foo) {
-        return foo;
-      }
-    })();
+    const foo = test();
+    if ("t" in foo) {
+      return foo;
+    }
   }
 });

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -392,3 +392,16 @@ const template27 = _$createComponent(Component, {
     return prop.red ? "red" : "green";
   }
 });
+class Template28 {
+  render() {
+    const _self$2 = this;
+    return _$createComponent(Component, {
+      get when() {
+        const foo = _self$2.value;
+        if ("key" in foo) {
+          return foo;
+        }
+      }
+    });
+  }
+}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -379,3 +379,13 @@ const template25 = _$createComponent(Component, {
     return _tmpl$2();
   }
 });
+const template26 = _$createComponent(Component, {
+  get when() {
+    return (() => {
+      const foo = test();
+      if ("t" in foo) {
+        return foo;
+      }
+    })();
+  }
+});

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -387,3 +387,8 @@ const template26 = _$createComponent(Component, {
     }
   }
 });
+const template27 = _$createComponent(Component, {
+  get when() {
+    return prop.red ? "red" : "green";
+  }
+});


### PR DESCRIPTION
As per pull request title, unwraps arrow function IIFEs if they are directly used within a component prop.

the following `<Show />` pattern can be quite common, and this saves up some of the bytes incurred by it
```jsx
<Show
  when={(() => {
    const val = value();
    if ("key" in val) {
      return val;
    }
  })()}
>
  {(val) => (
    <>
      ...
    </>
  )}
</Show>
```