### PR TITLE
feat: streaming serializer

### DIFF
--- a/packages/dom-expressions/package.json
+++ b/packages/dom-expressions/package.json
@@ -20,11 +20,11 @@
   },
   "peerDependencies": {
     "csstype": "^3.0",
-    "seroval": "^0.7.0"
+    "seroval": "^0.10.1"
   },
   "devDependencies": {
     "babel-plugin-jsx-dom-expressions": "^0.36.10",
     "csstype": "^3.1",
-    "seroval": "^0.7.0"
+    "seroval": "^0.10.1"
   }
 }

--- a/packages/dom-expressions/src/serializer.d.ts
+++ b/packages/dom-expressions/src/serializer.d.ts
@@ -1,1 +1,3 @@
-export default function stringify(root: unknown): string;
+import { Serializer } from "seroval";
+
+export default function createSerializer(onData: (value: string) => void): Serializer;

--- a/packages/dom-expressions/src/serializer.js
+++ b/packages/dom-expressions/src/serializer.js
@@ -1,10 +1,21 @@
-import { serialize, Feature } from "seroval"
+import { Feature, Serializer, CROSS_REFERENCE_HEADER } from "seroval"
 
 const ES2017FLAG = 
   Feature.AggregateError // ES2021
   | Feature.BigInt // ES2020
   | Feature.BigIntTypedArray // ES2020;
 
-export default function stringify(data) {
-  return serialize(data, { disabledFeatures: ES2017FLAG });
+const GLOBAL_IDENTIFIER = '$HY.r'; // TODO this is a pending name
+
+export default function createSerializer(onData) {
+  return new Serializer({
+    globalIdentifier: GLOBAL_IDENTIFIER,
+    disabledFeatures: ES2017FLAG,
+    onData,
+  });
+}
+
+// TODO
+export function getHeaderScript() {
+  return CROSS_REFERENCE_HEADER;
 }

--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -1,8 +1,7 @@
 import { Aliases, BooleanAttributes, ChildProperties } from "./constants";
 import { sharedConfig, root } from "rxcore";
-import stringify from "./serializer";
 import createSerializer from "./serializer";
-export { stringify };
+export { createSerializer };
 export { createComponent } from "rxcore";
 
 // Based on https://github.com/WebReflection/domtagger/blob/master/esm/sanitizer.js
@@ -21,8 +20,7 @@ export function renderToString(code, options = {}) {
     assets: [],
     nonce: options.nonce,
     writeResource(id, p) {
-      if (sharedConfig.context.noHydrate) return;
-      serializer.write(id, p);
+      !sharedConfig.context.noHydrate && serializer.write(id, p);
     }
   };
   let html = root(d => {
@@ -52,6 +50,9 @@ export function renderToStream(code, options = {}) {
   let { nonce, onCompleteShell, onCompleteAll, renderId } = options;
   let dispose;
   const blockingResources = [];
+  const serializer = createSerializer((value) => {
+    // TODO
+  });
   const registry = new Map();
   const dedupe = new WeakMap();
   const checkEnd = () => {
@@ -120,18 +121,21 @@ export function renderToStream(code, options = {}) {
       );
     },
     writeResource(id, p, error, wait) {
+      // TODO this is a draft
       const serverOnly = sharedConfig.context.noHydrate;
-      if (error) return !serverOnly && pushTask(serializeSet(dedupe, id, p));
-      if (!p || typeof p !== "object" || !("then" in p))
-        return !serverOnly && pushTask(serializeSet(dedupe, id, p));
-      if (!firstFlushed) wait && blockingResources.push(p);
-      else !serverOnly && pushTask(`_$HY.init("${id}")`);
-      if (serverOnly) return;
-      p.then(d => {
-        !completed && pushTask(serializeSet(dedupe, id, d));
-      }).catch(() => {
-        !completed && pushTask(`_$HY.set("${id}", {})`);
-      });
+      if (error) return !serverOnly && serializer.write(id, p);
+      if (!firstFlushed) {
+        if (wait) {
+          blockingResources.push(p);
+          !serverOnly && p.then((d) => {
+            serializer.write(id, d);
+          }).catch(() => {
+            serializer.write(id, {});
+          });
+        }
+      } else {
+        !serverOnly && serializer.write(p);
+      }
     },
     registerFragment(key) {
       if (!registry.has(key)) {
@@ -512,13 +516,6 @@ function waitForFragments(registry, key) {
     }
   }
   return false;
-}
-
-function serializeSet(registry, key, value) {
-  const exist = registry.get(value);
-  if (exist) return `_$HY.set("${key}", _$HY.r["${exist}"][0])`;
-  value !== null && typeof value === "object" && registry.set(value, key);
-  return `_$HY.set("${key}", ${stringify(value)})`;
 }
 
 function replacePlaceholder(html, key, value) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
         specifier: ^3.1
         version: 3.1.1
       seroval:
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.10.1
+        version: 0.10.1
 
   packages/hyper-dom-expressions:
     devDependencies:
@@ -7059,8 +7059,8 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /seroval@0.7.0:
-    resolution: {integrity: sha512-GeyRvryi+5aHBsOXK4KexhhjTB8rkBvLfHxK5RWy8S3Dwq/hk7VNFcg2yT0k4f2lGJPYlWHRkV3/UpGjhJ5Scg==}
+  /seroval@0.10.1:
+    resolution: {integrity: sha512-6EzTDEqM8y5Ttt/C+iGltW5tCIZs8OVdFh/XhFvhcKfG5UI1duWTP3VomN/g/vAVnPQjILX+WaXPuAILu0bcIg==}
     engines: {node: '>=10'}
     dev: true
 


### PR DESCRIPTION
This is a work-in-progress. This PR integrates seroval's new streaming serializer to be utilized by SolidJS as a whole. With the new serializer, SolidJS will be able to:
- Dedupe references in both nested objects and across resources
- Allows SolidJS to serialize `Promise` and `ReadableStream` instances 
- Allow nested `Promise` instances to be naturally deferred (only top-level `Promise` instances can be blocked). These instances are then serialized and streamed later on.
- Part of the HydrationScript would be delegated to seroval as seroval has its own "hydration" script.