### PR TITLE
Fix `this` compilation

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -13,6 +13,7 @@ import { transformNode, getCreateTemplate } from "./transform";
 
 function convertComponentIdentifier(node) {
   if (t.isJSXIdentifier(node)) {
+    if (node.name === 'this') return t.thisExpression();
     if (t.isValidIdentifier(node.name)) node.type = "Identifier";
     else return t.stringLiteral(node.name);
   } else if (t.isJSXMemberExpression(node)) {

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
@@ -47,11 +47,12 @@ export function transformThis(path) {
   });
   return node => {
     if (thisId) {
-      let parent = path.getStatementParent();
-      const decl = t.variableDeclaration("const", [
-        t.variableDeclarator(thisId, t.thisExpression())
-      ]);
-      parent.insertBefore(decl);
+      const parent = path.scope.getFunctionParent();
+      parent.push({
+        id: thisId,
+        init: t.thisExpression(),
+        kind: 'const',
+      });
     }
     return node;
   };

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
@@ -38,16 +38,19 @@ export function transformJSX(path) {
 }
 
 export function transformThis(path) {
+  const parent = path.scope.getFunctionParent();
   let thisId;
   path.traverse({
     ThisExpression(path) {
-      thisId || (thisId = path.scope.generateUidIdentifier("self$"));
-      path.replaceWith(thisId);
+      const current = path.scope.getFunctionParent();
+      if (current === parent) {
+        thisId || (thisId = path.scope.generateUidIdentifier("self$"));
+        path.replaceWith(thisId);
+      }
     }
   });
   return node => {
     if (thisId) {
-      const parent = path.scope.getFunctionParent();
       parent.push({
         id: thisId,
         init: t.thisExpression(),

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
@@ -42,7 +42,11 @@ export function transformThis(path) {
   let thisId;
   path.traverse({
     ThisExpression(path) {
-      const current = path.scope.getFunctionParent();
+      let current = path.scope.getFunctionParent();
+
+      while (current !== parent && current.path.isArrowFunctionExpression()) {
+        current = current.path.parentPath.scope.getFunctionParent()
+      }
       if (current === parent) {
         thisId || (thisId = path.scope.generateUidIdentifier("self$"));
         path.replaceWith(thisId);


### PR DESCRIPTION
- Fixes #293 
- Fixes #292

Example:

```js
class Example {
  template = () => (
    <this.H1
      onClick={() => this.foo()}
      onLoad={(function () {
        console.log(this)
      }).bind({ foo: 'bar' })}
    >
      <h1 onClick={() => this.bar()}>{this.title}</h1>
      <this.Child onClick={() => this.bar()}>{this.title}</this.Child>
    </this.H1>
  )
}
```

Output:

```js
var _client = require("../../src/client");
const _tmpl$ = /*#__PURE__*/(0, _client.template)(`<h1>`);
class Example {
  template = () => {
    const _self$ = this;
    return (0, _client.createComponent)(this.H1, {
      onClick: () => _self$.foo(),
      get onLoad() {
        return function () {
          console.log(this);
        }.bind({
          foo: 'bar'
        });
      },
      get children() {
        return [(() => {
          const _el$ = _tmpl$();
          _el$.$$click = () => _self$.bar();
          (0, _client.insert)(_el$, () => _self$.title);
          return _el$;
        })(), (0, _client.createComponent)(_self$.Child, {
          onClick: () => _self$.bar(),
          get children() {
            return _self$.title;
          }
        })];
      }
    });
  };
}
(0, _client.delegateEvents)(["click"]);
```