### PR TITLE
Smaller identifiers for merged dynamics

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
@@ -1,5 +1,5 @@
 import * as t from "@babel/types";
-import { getConfig, getRendererConfig, registerImportMethod } from "../shared/utils";
+import { getConfig, getNumberedId, getRendererConfig, registerImportMethod } from "../shared/utils";
 import { setAttr } from "./element";
 
 export function createTemplate(path, result, wrap) {
@@ -129,50 +129,65 @@ function wrapDynamics(path, dynamics) {
       ])
     );
   }
-  const declarations = [],
-    statements = [],
-    identifiers = [],
-    prevId = t.identifier("_p$");
-  dynamics.forEach(({ elem, key, value, isSVG, isCE, tagName }) => {
-    const identifier = path.scope.generateUidIdentifier("v$");
-    if (key.startsWith("class:") && !t.isBooleanLiteral(value) && !t.isUnaryExpression(value)) {
+
+  const prevId = t.identifier("_p$");
+
+  /** @type {t.VariableDeclarator[]} */
+  const declarations = [];
+  /** @type {t.ExpressionStatement[]} */
+  const statements = [];
+  /** @type {t.Identifier[]} */
+  const properties = [];
+
+  dynamics.forEach(({ elem, key, value, isSVG, isCE, tagName }, index) => {
+    const varIdent = path.scope.generateUidIdentifier("v$");
+
+    const propIdent = t.identifier(getNumberedId(index));
+    const propMember = t.memberExpression(prevId, propIdent);
+
+    if (
+      key.startsWith("class:") &&
+      !t.isBooleanLiteral(value) &&
+      !t.isUnaryExpression(value)
+    ) {
       value = t.unaryExpression("!", t.unaryExpression("!", value));
     }
-    identifiers.push(identifier);
-    declarations.push(t.variableDeclarator(identifier, value));
+
+    properties.push(propIdent);
+    declarations.push(t.variableDeclarator(varIdent, value));
+
     if (key === "classList" || key === "style") {
-      const prev = t.memberExpression(prevId, identifier);
       statements.push(
         t.expressionStatement(
           t.assignmentExpression(
             "=",
-            prev,
-            setAttr(path, elem, key, identifier, {
+            propMember,
+            setAttr(path, elem, key, varIdent, {
               isSVG,
               isCE,
               tagName,
               dynamic: true,
-              prevId: prev
-            })
-          )
-        )
+              prevId: propMember,
+            }),
+          ),
+        ),
       );
     } else {
-      const prev = key.startsWith("style:") ? identifier : undefined;
+      const prev = key.startsWith("style:") ? varIdent : undefined;
       statements.push(
         t.expressionStatement(
           t.logicalExpression(
             "&&",
-            t.binaryExpression("!==", identifier, t.memberExpression(prevId, identifier)),
+            t.binaryExpression("!==", varIdent, propMember),
             setAttr(
               path,
               elem,
               key,
-              t.assignmentExpression("=", t.memberExpression(prevId, identifier), identifier),
-              { isSVG, isCE, tagName, dynamic: true, prevId: prev }
-            )
-          )
-        )
+              t.assignmentExpression("=", propMember, varIdent),
+              { isSVG, isCE, tagName, dynamic: true, prevId: prev },
+            ),
+          ),
+        ),
       );
     }
   });
@@ -184,10 +199,12 @@ function wrapDynamics(path, dynamics) {
         t.blockStatement([
           t.variableDeclaration("const", declarations),
           ...statements,
-          t.returnStatement(prevId)
-        ])
+          t.returnStatement(prevId),
+        ]),
       ),
-      t.objectExpression(identifiers.map(id => t.objectProperty(id, t.identifier("undefined"))))
-    ])
+      t.objectExpression(
+        properties.map((id) => t.objectProperty(id, t.identifier("undefined"))),
+      ),
+    ]),
   );
 }

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -403,3 +403,19 @@ export function canNativeSpread(key, { checkNameSpaces } = {}) {
   if (key === "ref") return false;
   return true;
 }
+
+const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$";
+const base = chars.length;
+
+export function getNumberedId(num) {
+  let out = "";
+
+  do {
+    const digit = num % base;
+
+    num = Math.floor(num / base);
+    out = chars[digit] + out;
+  } while (num !== 0);
+
+  return out;
+}

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -404,7 +404,7 @@ export function canNativeSpread(key, { checkNameSpaces } = {}) {
   return true;
 }
 
-const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$";
+const chars = "etaoinshrdlucwmfygpbTAOISWCBvkxjqzPHFMDRELNGUKVYJQZX_$";
 const base = chars.length;
 
 export function getNumberedId(num) {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
@@ -36,22 +36,22 @@ const template2 = (() => {
         _v$3 = state.x,
         _v$4 = state.y,
         _v$5 = props.stroke;
-      _v$ !== _p$._v$ && _$setAttribute(_el$3, "class", (_p$._v$ = _v$));
-      _v$2 !== _p$._v$2 && _$setAttribute(_el$3, "stroke-width", (_p$._v$2 = _v$2));
-      _v$3 !== _p$._v$3 && _$setAttribute(_el$3, "x", (_p$._v$3 = _v$3));
-      _v$4 !== _p$._v$4 && _$setAttribute(_el$3, "y", (_p$._v$4 = _v$4));
-      _v$5 !== _p$._v$5 &&
-        ((_p$._v$5 = _v$5) != null
+      _v$ !== _p$.a && _$setAttribute(_el$3, "class", (_p$.a = _v$));
+      _v$2 !== _p$.b && _$setAttribute(_el$3, "stroke-width", (_p$.b = _v$2));
+      _v$3 !== _p$.c && _$setAttribute(_el$3, "x", (_p$.c = _v$3));
+      _v$4 !== _p$.d && _$setAttribute(_el$3, "y", (_p$.d = _v$4));
+      _v$5 !== _p$.e &&
+        ((_p$.e = _v$5) != null
           ? _el$3.style.setProperty("stroke-width", _v$5)
           : _el$3.style.removeProperty("stroke-width"));
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined,
-      _v$4: undefined,
-      _v$5: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined,
+      d: undefined,
+      e: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
@@ -36,22 +36,22 @@ const template2 = (() => {
         _v$3 = state.x,
         _v$4 = state.y,
         _v$5 = props.stroke;
-      _v$ !== _p$.a && _$setAttribute(_el$3, "class", (_p$.a = _v$));
-      _v$2 !== _p$.b && _$setAttribute(_el$3, "stroke-width", (_p$.b = _v$2));
-      _v$3 !== _p$.c && _$setAttribute(_el$3, "x", (_p$.c = _v$3));
-      _v$4 !== _p$.d && _$setAttribute(_el$3, "y", (_p$.d = _v$4));
-      _v$5 !== _p$.e &&
-        ((_p$.e = _v$5) != null
+      _v$ !== _p$.e && _$setAttribute(_el$3, "class", (_p$.e = _v$));
+      _v$2 !== _p$.t && _$setAttribute(_el$3, "stroke-width", (_p$.t = _v$2));
+      _v$3 !== _p$.a && _$setAttribute(_el$3, "x", (_p$.a = _v$3));
+      _v$4 !== _p$.o && _$setAttribute(_el$3, "y", (_p$.o = _v$4));
+      _v$5 !== _p$.i &&
+        ((_p$.i = _v$5) != null
           ? _el$3.style.setProperty("stroke-width", _v$5)
           : _el$3.style.removeProperty("stroke-width"));
       return _p$;
     },
     {
+      e: undefined,
+      t: undefined,
       a: undefined,
-      b: undefined,
-      c: undefined,
-      d: undefined,
-      e: undefined
+      o: undefined,
+      i: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -139,18 +139,18 @@ const template7 = (() => {
         },
         _v$2 = props.top,
         _v$3 = !!props.active;
-      _p$._v$ = _$style(_el$13, _v$, _p$._v$);
-      _v$2 !== _p$._v$2 &&
-        ((_p$._v$2 = _v$2) != null
+      _p$.a = _$style(_el$13, _v$, _p$.a);
+      _v$2 !== _p$.b &&
+        ((_p$.b = _v$2) != null
           ? _el$13.style.setProperty("padding-top", _v$2)
           : _el$13.style.removeProperty("padding-top"));
-      _v$3 !== _p$._v$3 && _el$13.classList.toggle("my-class", (_p$._v$3 = _v$3));
+      _v$3 !== _p$.c && _el$13.classList.toggle("my-class", (_p$.c = _v$3));
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined
     }
   );
   return _el$13;
@@ -230,17 +230,17 @@ const template20 = (() => {
         _v$5 = max(),
         _v$6 = min(),
         _v$7 = max();
-      _v$4 !== _p$._v$4 && _$setAttribute(_el$27, "min", (_p$._v$4 = _v$4));
-      _v$5 !== _p$._v$5 && _$setAttribute(_el$27, "max", (_p$._v$5 = _v$5));
-      _v$6 !== _p$._v$6 && _$setAttribute(_el$28, "min", (_p$._v$6 = _v$6));
-      _v$7 !== _p$._v$7 && _$setAttribute(_el$28, "max", (_p$._v$7 = _v$7));
+      _v$4 !== _p$.a && _$setAttribute(_el$27, "min", (_p$.a = _v$4));
+      _v$5 !== _p$.b && _$setAttribute(_el$27, "max", (_p$.b = _v$5));
+      _v$6 !== _p$.c && _$setAttribute(_el$28, "min", (_p$.c = _v$6));
+      _v$7 !== _p$.d && _$setAttribute(_el$28, "max", (_p$.d = _v$7));
       return _p$;
     },
     {
-      _v$4: undefined,
-      _v$5: undefined,
-      _v$6: undefined,
-      _v$7: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined,
+      d: undefined
     }
   );
   _$effect(() => (_el$27.value = s()));

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -139,18 +139,18 @@ const template7 = (() => {
         },
         _v$2 = props.top,
         _v$3 = !!props.active;
-      _p$.a = _$style(_el$13, _v$, _p$.a);
-      _v$2 !== _p$.b &&
-        ((_p$.b = _v$2) != null
+      _p$.e = _$style(_el$13, _v$, _p$.e);
+      _v$2 !== _p$.t &&
+        ((_p$.t = _v$2) != null
           ? _el$13.style.setProperty("padding-top", _v$2)
           : _el$13.style.removeProperty("padding-top"));
-      _v$3 !== _p$.c && _el$13.classList.toggle("my-class", (_p$.c = _v$3));
+      _v$3 !== _p$.a && _el$13.classList.toggle("my-class", (_p$.a = _v$3));
       return _p$;
     },
     {
-      a: undefined,
-      b: undefined,
-      c: undefined
+      e: undefined,
+      t: undefined,
+      a: undefined
     }
   );
   return _el$13;
@@ -230,17 +230,17 @@ const template20 = (() => {
         _v$5 = max(),
         _v$6 = min(),
         _v$7 = max();
-      _v$4 !== _p$.a && _$setAttribute(_el$27, "min", (_p$.a = _v$4));
-      _v$5 !== _p$.b && _$setAttribute(_el$27, "max", (_p$.b = _v$5));
-      _v$6 !== _p$.c && _$setAttribute(_el$28, "min", (_p$.c = _v$6));
-      _v$7 !== _p$.d && _$setAttribute(_el$28, "max", (_p$.d = _v$7));
+      _v$4 !== _p$.e && _$setAttribute(_el$27, "min", (_p$.e = _v$4));
+      _v$5 !== _p$.t && _$setAttribute(_el$27, "max", (_p$.t = _v$5));
+      _v$6 !== _p$.a && _$setAttribute(_el$28, "min", (_p$.a = _v$6));
+      _v$7 !== _p$.o && _$setAttribute(_el$28, "max", (_p$.o = _v$7));
       return _p$;
     },
     {
+      e: undefined,
+      t: undefined,
       a: undefined,
-      b: undefined,
-      c: undefined,
-      d: undefined
+      o: undefined
     }
   );
   _$effect(() => (_el$27.value = s()));

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -23,17 +23,17 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$._v$ && (_el$2.someAttr = _p$._v$ = _v$);
-      _v$2 !== _p$._v$2 && (_el$2.notprop = _p$._v$2 = _v$2);
-      _v$3 !== _p$._v$3 && _$setAttribute(_el$2, "my-attr", (_p$._v$3 = _v$3));
-      _v$4 !== _p$._v$4 && (_el$2.someProp = _p$._v$4 = _v$4);
+      _v$ !== _p$.a && (_el$2.someAttr = _p$.a = _v$);
+      _v$2 !== _p$.b && (_el$2.notprop = _p$.b = _v$2);
+      _v$3 !== _p$.c && _$setAttribute(_el$2, "my-attr", (_p$.c = _v$3));
+      _v$4 !== _p$.d && (_el$2.someProp = _p$.d = _v$4);
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined,
-      _v$4: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined,
+      d: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -23,17 +23,17 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$.a && (_el$2.someAttr = _p$.a = _v$);
-      _v$2 !== _p$.b && (_el$2.notprop = _p$.b = _v$2);
-      _v$3 !== _p$.c && _$setAttribute(_el$2, "my-attr", (_p$.c = _v$3));
-      _v$4 !== _p$.d && (_el$2.someProp = _p$.d = _v$4);
+      _v$ !== _p$.e && (_el$2.someAttr = _p$.e = _v$);
+      _v$2 !== _p$.t && (_el$2.notprop = _p$.t = _v$2);
+      _v$3 !== _p$.a && _$setAttribute(_el$2, "my-attr", (_p$.a = _v$3));
+      _v$4 !== _p$.o && (_el$2.someProp = _p$.o = _v$4);
       return _p$;
     },
     {
+      e: undefined,
+      t: undefined,
       a: undefined,
-      b: undefined,
-      c: undefined,
-      d: undefined
+      o: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
@@ -39,22 +39,22 @@ const template2 = (() => {
         _v$3 = state.x,
         _v$4 = state.y,
         _v$5 = props.stroke;
-      _v$ !== _p$._v$ && _$setAttribute(_el$3, "class", (_p$._v$ = _v$));
-      _v$2 !== _p$._v$2 && _$setAttribute(_el$3, "stroke-width", (_p$._v$2 = _v$2));
-      _v$3 !== _p$._v$3 && _$setAttribute(_el$3, "x", (_p$._v$3 = _v$3));
-      _v$4 !== _p$._v$4 && _$setAttribute(_el$3, "y", (_p$._v$4 = _v$4));
-      _v$5 !== _p$._v$5 &&
-        ((_p$._v$5 = _v$5) != null
+      _v$ !== _p$.a && _$setAttribute(_el$3, "class", (_p$.a = _v$));
+      _v$2 !== _p$.b && _$setAttribute(_el$3, "stroke-width", (_p$.b = _v$2));
+      _v$3 !== _p$.c && _$setAttribute(_el$3, "x", (_p$.c = _v$3));
+      _v$4 !== _p$.d && _$setAttribute(_el$3, "y", (_p$.d = _v$4));
+      _v$5 !== _p$.e &&
+        ((_p$.e = _v$5) != null
           ? _el$3.style.setProperty("stroke-width", _v$5)
           : _el$3.style.removeProperty("stroke-width"));
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined,
-      _v$4: undefined,
-      _v$5: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined,
+      d: undefined,
+      e: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
@@ -39,22 +39,22 @@ const template2 = (() => {
         _v$3 = state.x,
         _v$4 = state.y,
         _v$5 = props.stroke;
-      _v$ !== _p$.a && _$setAttribute(_el$3, "class", (_p$.a = _v$));
-      _v$2 !== _p$.b && _$setAttribute(_el$3, "stroke-width", (_p$.b = _v$2));
-      _v$3 !== _p$.c && _$setAttribute(_el$3, "x", (_p$.c = _v$3));
-      _v$4 !== _p$.d && _$setAttribute(_el$3, "y", (_p$.d = _v$4));
-      _v$5 !== _p$.e &&
-        ((_p$.e = _v$5) != null
+      _v$ !== _p$.e && _$setAttribute(_el$3, "class", (_p$.e = _v$));
+      _v$2 !== _p$.t && _$setAttribute(_el$3, "stroke-width", (_p$.t = _v$2));
+      _v$3 !== _p$.a && _$setAttribute(_el$3, "x", (_p$.a = _v$3));
+      _v$4 !== _p$.o && _$setAttribute(_el$3, "y", (_p$.o = _v$4));
+      _v$5 !== _p$.i &&
+        ((_p$.i = _v$5) != null
           ? _el$3.style.setProperty("stroke-width", _v$5)
           : _el$3.style.removeProperty("stroke-width"));
       return _p$;
     },
     {
+      e: undefined,
+      t: undefined,
       a: undefined,
-      b: undefined,
-      c: undefined,
-      d: undefined,
-      e: undefined
+      o: undefined,
+      i: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -140,18 +140,18 @@ const template7 = (() => {
         },
         _v$2 = props.top,
         _v$3 = !!props.active;
-      _p$.a = _$style(_el$13, _v$, _p$.a);
-      _v$2 !== _p$.b &&
-        ((_p$.b = _v$2) != null
+      _p$.e = _$style(_el$13, _v$, _p$.e);
+      _v$2 !== _p$.t &&
+        ((_p$.t = _v$2) != null
           ? _el$13.style.setProperty("padding-top", _v$2)
           : _el$13.style.removeProperty("padding-top"));
-      _v$3 !== _p$.c && _el$13.classList.toggle("my-class", (_p$.c = _v$3));
+      _v$3 !== _p$.a && _el$13.classList.toggle("my-class", (_p$.a = _v$3));
       return _p$;
     },
     {
-      a: undefined,
-      b: undefined,
-      c: undefined
+      e: undefined,
+      t: undefined,
+      a: undefined
     }
   );
   return _el$13;
@@ -233,17 +233,17 @@ const template20 = (() => {
         _v$5 = max(),
         _v$6 = min(),
         _v$7 = max();
-      _v$4 !== _p$.a && _$setAttribute(_el$27, "min", (_p$.a = _v$4));
-      _v$5 !== _p$.b && _$setAttribute(_el$27, "max", (_p$.b = _v$5));
-      _v$6 !== _p$.c && _$setAttribute(_el$28, "min", (_p$.c = _v$6));
-      _v$7 !== _p$.d && _$setAttribute(_el$28, "max", (_p$.d = _v$7));
+      _v$4 !== _p$.e && _$setAttribute(_el$27, "min", (_p$.e = _v$4));
+      _v$5 !== _p$.t && _$setAttribute(_el$27, "max", (_p$.t = _v$5));
+      _v$6 !== _p$.a && _$setAttribute(_el$28, "min", (_p$.a = _v$6));
+      _v$7 !== _p$.o && _$setAttribute(_el$28, "max", (_p$.o = _v$7));
       return _p$;
     },
     {
+      e: undefined,
+      t: undefined,
       a: undefined,
-      b: undefined,
-      c: undefined,
-      d: undefined
+      o: undefined
     }
   );
   _$effect(() => _$setProperty(_el$27, "value", s()));

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -140,18 +140,18 @@ const template7 = (() => {
         },
         _v$2 = props.top,
         _v$3 = !!props.active;
-      _p$._v$ = _$style(_el$13, _v$, _p$._v$);
-      _v$2 !== _p$._v$2 &&
-        ((_p$._v$2 = _v$2) != null
+      _p$.a = _$style(_el$13, _v$, _p$.a);
+      _v$2 !== _p$.b &&
+        ((_p$.b = _v$2) != null
           ? _el$13.style.setProperty("padding-top", _v$2)
           : _el$13.style.removeProperty("padding-top"));
-      _v$3 !== _p$._v$3 && _el$13.classList.toggle("my-class", (_p$._v$3 = _v$3));
+      _v$3 !== _p$.c && _el$13.classList.toggle("my-class", (_p$.c = _v$3));
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined
     }
   );
   return _el$13;
@@ -233,17 +233,17 @@ const template20 = (() => {
         _v$5 = max(),
         _v$6 = min(),
         _v$7 = max();
-      _v$4 !== _p$._v$4 && _$setAttribute(_el$27, "min", (_p$._v$4 = _v$4));
-      _v$5 !== _p$._v$5 && _$setAttribute(_el$27, "max", (_p$._v$5 = _v$5));
-      _v$6 !== _p$._v$6 && _$setAttribute(_el$28, "min", (_p$._v$6 = _v$6));
-      _v$7 !== _p$._v$7 && _$setAttribute(_el$28, "max", (_p$._v$7 = _v$7));
+      _v$4 !== _p$.a && _$setAttribute(_el$27, "min", (_p$.a = _v$4));
+      _v$5 !== _p$.b && _$setAttribute(_el$27, "max", (_p$.b = _v$5));
+      _v$6 !== _p$.c && _$setAttribute(_el$28, "min", (_p$.c = _v$6));
+      _v$7 !== _p$.d && _$setAttribute(_el$28, "max", (_p$.d = _v$7));
       return _p$;
     },
     {
-      _v$4: undefined,
-      _v$5: undefined,
-      _v$6: undefined,
-      _v$7: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined,
+      d: undefined
     }
   );
   _$effect(() => _$setProperty(_el$27, "value", s()));

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
@@ -25,17 +25,17 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$.a && _$setProperty(_el$2, "someAttr", (_p$.a = _v$));
-      _v$2 !== _p$.b && _$setProperty(_el$2, "notprop", (_p$.b = _v$2));
-      _v$3 !== _p$.c && _$setAttribute(_el$2, "my-attr", (_p$.c = _v$3));
-      _v$4 !== _p$.d && (_el$2.someProp = _p$.d = _v$4);
+      _v$ !== _p$.e && _$setProperty(_el$2, "someAttr", (_p$.e = _v$));
+      _v$2 !== _p$.t && _$setProperty(_el$2, "notprop", (_p$.t = _v$2));
+      _v$3 !== _p$.a && _$setAttribute(_el$2, "my-attr", (_p$.a = _v$3));
+      _v$4 !== _p$.o && (_el$2.someProp = _p$.o = _v$4);
       return _p$;
     },
     {
+      e: undefined,
+      t: undefined,
       a: undefined,
-      b: undefined,
-      c: undefined,
-      d: undefined
+      o: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
@@ -25,17 +25,17 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$._v$ && _$setProperty(_el$2, "someAttr", (_p$._v$ = _v$));
-      _v$2 !== _p$._v$2 && _$setProperty(_el$2, "notprop", (_p$._v$2 = _v$2));
-      _v$3 !== _p$._v$3 && _$setAttribute(_el$2, "my-attr", (_p$._v$3 = _v$3));
-      _v$4 !== _p$._v$4 && (_el$2.someProp = _p$._v$4 = _v$4);
+      _v$ !== _p$.a && _$setProperty(_el$2, "someAttr", (_p$.a = _v$));
+      _v$2 !== _p$.b && _$setProperty(_el$2, "notprop", (_p$.b = _v$2));
+      _v$3 !== _p$.c && _$setAttribute(_el$2, "my-attr", (_p$.c = _v$3));
+      _v$4 !== _p$.d && (_el$2.someProp = _p$.d = _v$4);
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined,
-      _v$4: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined,
+      d: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
@@ -36,22 +36,22 @@ const template2 = (() => {
         _v$3 = state.x,
         _v$4 = state.y,
         _v$5 = props.stroke;
-      _v$ !== _p$._v$ && _$setAttribute(_el$3, "class", (_p$._v$ = _v$));
-      _v$2 !== _p$._v$2 && _$setAttribute(_el$3, "stroke-width", (_p$._v$2 = _v$2));
-      _v$3 !== _p$._v$3 && _$setAttribute(_el$3, "x", (_p$._v$3 = _v$3));
-      _v$4 !== _p$._v$4 && _$setAttribute(_el$3, "y", (_p$._v$4 = _v$4));
-      _v$5 !== _p$._v$5 &&
-        ((_p$._v$5 = _v$5) != null
+      _v$ !== _p$.a && _$setAttribute(_el$3, "class", (_p$.a = _v$));
+      _v$2 !== _p$.b && _$setAttribute(_el$3, "stroke-width", (_p$.b = _v$2));
+      _v$3 !== _p$.c && _$setAttribute(_el$3, "x", (_p$.c = _v$3));
+      _v$4 !== _p$.d && _$setAttribute(_el$3, "y", (_p$.d = _v$4));
+      _v$5 !== _p$.e &&
+        ((_p$.e = _v$5) != null
           ? _el$3.style.setProperty("stroke-width", _v$5)
           : _el$3.style.removeProperty("stroke-width"));
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined,
-      _v$4: undefined,
-      _v$5: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined,
+      d: undefined,
+      e: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
@@ -36,22 +36,22 @@ const template2 = (() => {
         _v$3 = state.x,
         _v$4 = state.y,
         _v$5 = props.stroke;
-      _v$ !== _p$.a && _$setAttribute(_el$3, "class", (_p$.a = _v$));
-      _v$2 !== _p$.b && _$setAttribute(_el$3, "stroke-width", (_p$.b = _v$2));
-      _v$3 !== _p$.c && _$setAttribute(_el$3, "x", (_p$.c = _v$3));
-      _v$4 !== _p$.d && _$setAttribute(_el$3, "y", (_p$.d = _v$4));
-      _v$5 !== _p$.e &&
-        ((_p$.e = _v$5) != null
+      _v$ !== _p$.e && _$setAttribute(_el$3, "class", (_p$.e = _v$));
+      _v$2 !== _p$.t && _$setAttribute(_el$3, "stroke-width", (_p$.t = _v$2));
+      _v$3 !== _p$.a && _$setAttribute(_el$3, "x", (_p$.a = _v$3));
+      _v$4 !== _p$.o && _$setAttribute(_el$3, "y", (_p$.o = _v$4));
+      _v$5 !== _p$.i &&
+        ((_p$.i = _v$5) != null
           ? _el$3.style.setProperty("stroke-width", _v$5)
           : _el$3.style.removeProperty("stroke-width"));
       return _p$;
     },
     {
+      e: undefined,
+      t: undefined,
       a: undefined,
-      b: undefined,
-      c: undefined,
-      d: undefined,
-      e: undefined
+      o: undefined,
+      i: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -118,18 +118,18 @@ const template7 = (() => {
         },
         _v$2 = props.top,
         _v$3 = !!props.active;
-      _p$.a = _$style(_el$13, _v$, _p$.a);
-      _v$2 !== _p$.b &&
-        ((_p$.b = _v$2) != null
+      _p$.e = _$style(_el$13, _v$, _p$.e);
+      _v$2 !== _p$.t &&
+        ((_p$.t = _v$2) != null
           ? _el$13.style.setProperty("padding-top", _v$2)
           : _el$13.style.removeProperty("padding-top"));
-      _v$3 !== _p$.c && _el$13.classList.toggle("my-class", (_p$.c = _v$3));
+      _v$3 !== _p$.a && _el$13.classList.toggle("my-class", (_p$.a = _v$3));
       return _p$;
     },
     {
-      a: undefined,
-      b: undefined,
-      c: undefined
+      e: undefined,
+      t: undefined,
+      a: undefined
     }
   );
   return _el$13;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -118,18 +118,18 @@ const template7 = (() => {
         },
         _v$2 = props.top,
         _v$3 = !!props.active;
-      _p$._v$ = _$style(_el$13, _v$, _p$._v$);
-      _v$2 !== _p$._v$2 &&
-        ((_p$._v$2 = _v$2) != null
+      _p$.a = _$style(_el$13, _v$, _p$.a);
+      _v$2 !== _p$.b &&
+        ((_p$.b = _v$2) != null
           ? _el$13.style.setProperty("padding-top", _v$2)
           : _el$13.style.removeProperty("padding-top"));
-      _v$3 !== _p$._v$3 && _el$13.classList.toggle("my-class", (_p$._v$3 = _v$3));
+      _v$3 !== _p$.c && _el$13.classList.toggle("my-class", (_p$.c = _v$3));
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined
     }
   );
   return _el$13;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/customElements/output.js
@@ -23,17 +23,17 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$._v$ && (_el$2.someAttr = _p$._v$ = _v$);
-      _v$2 !== _p$._v$2 && (_el$2.notprop = _p$._v$2 = _v$2);
-      _v$3 !== _p$._v$3 && _$setAttribute(_el$2, "my-attr", (_p$._v$3 = _v$3));
-      _v$4 !== _p$._v$4 && (_el$2.someProp = _p$._v$4 = _v$4);
+      _v$ !== _p$.a && (_el$2.someAttr = _p$.a = _v$);
+      _v$2 !== _p$.b && (_el$2.notprop = _p$.b = _v$2);
+      _v$3 !== _p$.c && _$setAttribute(_el$2, "my-attr", (_p$.c = _v$3));
+      _v$4 !== _p$.d && (_el$2.someProp = _p$.d = _v$4);
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined,
-      _v$4: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined,
+      d: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/customElements/output.js
@@ -23,17 +23,17 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$.a && (_el$2.someAttr = _p$.a = _v$);
-      _v$2 !== _p$.b && (_el$2.notprop = _p$.b = _v$2);
-      _v$3 !== _p$.c && _$setAttribute(_el$2, "my-attr", (_p$.c = _v$3));
-      _v$4 !== _p$.d && (_el$2.someProp = _p$.d = _v$4);
+      _v$ !== _p$.e && (_el$2.someAttr = _p$.e = _v$);
+      _v$2 !== _p$.t && (_el$2.notprop = _p$.t = _v$2);
+      _v$3 !== _p$.a && _$setAttribute(_el$2, "my-attr", (_p$.a = _v$3));
+      _v$4 !== _p$.o && (_el$2.someProp = _p$.o = _v$4);
       return _p$;
     },
     {
+      e: undefined,
+      t: undefined,
       a: undefined,
-      b: undefined,
-      c: undefined,
-      d: undefined
+      o: undefined
     }
   );
   return _el$2;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
@@ -115,15 +115,15 @@ const template7 = (() => {
         },
         _v$2 = props.top,
         _v$3 = props.active;
-      _v$ !== _p$.a && (_p$.a = _$setProp(_el$13, "style", _v$, _p$.a));
-      _v$2 !== _p$.b && (_p$.b = _$setProp(_el$13, "style:padding-top", _v$2, _p$.b));
-      _v$3 !== _p$.c && (_p$.c = _$setProp(_el$13, "class:my-class", _v$3, _p$.c));
+      _v$ !== _p$.e && (_p$.e = _$setProp(_el$13, "style", _v$, _p$.e));
+      _v$2 !== _p$.t && (_p$.t = _$setProp(_el$13, "style:padding-top", _v$2, _p$.t));
+      _v$3 !== _p$.a && (_p$.a = _$setProp(_el$13, "class:my-class", _v$3, _p$.a));
       return _p$;
     },
     {
-      a: undefined,
-      b: undefined,
-      c: undefined
+      e: undefined,
+      t: undefined,
+      a: undefined
     }
   );
   return _el$13;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
@@ -115,15 +115,15 @@ const template7 = (() => {
         },
         _v$2 = props.top,
         _v$3 = props.active;
-      _v$ !== _p$._v$ && (_p$._v$ = _$setProp(_el$13, "style", _v$, _p$._v$));
-      _v$2 !== _p$._v$2 && (_p$._v$2 = _$setProp(_el$13, "style:padding-top", _v$2, _p$._v$2));
-      _v$3 !== _p$._v$3 && (_p$._v$3 = _$setProp(_el$13, "class:my-class", _v$3, _p$._v$3));
+      _v$ !== _p$.a && (_p$.a = _$setProp(_el$13, "style", _v$, _p$.a));
+      _v$2 !== _p$.b && (_p$.b = _$setProp(_el$13, "style:padding-top", _v$2, _p$.b));
+      _v$3 !== _p$.c && (_p$.c = _$setProp(_el$13, "class:my-class", _v$3, _p$.c));
       return _p$;
     },
     {
-      _v$: undefined,
-      _v$2: undefined,
-      _v$3: undefined
+      a: undefined,
+      b: undefined,
+      c: undefined
     }
   );
   return _el$13;


### PR DESCRIPTION
- Use a custom base54 identifier instead of Babel's unique identifiers for the object properties