### PR TITLE
Move to seroval 1.0

### DIFF
--- a/packages/dom-expressions/package.json
+++ b/packages/dom-expressions/package.json
@@ -20,11 +20,13 @@
   },
   "peerDependencies": {
     "csstype": "^3.0",
-    "seroval": "^0.15.1"
+    "seroval": "^1.0.0",
+    "seroval-plugins": "^1.0.0"
   },
   "devDependencies": {
     "babel-plugin-jsx-dom-expressions": "^0.37.9",
     "csstype": "^3.1",
-    "seroval": "^0.15.1"
+    "seroval": "^1.0.0",
+    "seroval-plugins": "^1.0.0"
   }
 }

--- a/packages/dom-expressions/package.json
+++ b/packages/dom-expressions/package.json
@@ -21,12 +21,12 @@
   "peerDependencies": {
     "csstype": "^3.0",
     "seroval": "^1.0.0",
-    "seroval-plugins": "^1.0.0"
+    "seroval-plugins": "^1.0.1"
   },
   "devDependencies": {
     "babel-plugin-jsx-dom-expressions": "^0.37.9",
     "csstype": "^3.1",
     "seroval": "^1.0.0",
-    "seroval-plugins": "^1.0.0"
+    "seroval-plugins": "^1.0.1"
   }
 }

--- a/packages/dom-expressions/src/serializer.js
+++ b/packages/dom-expressions/src/serializer.js
@@ -1,4 +1,16 @@
-import { Feature, Serializer, getCrossReferenceHeader } from "seroval"
+import { Feature, Serializer, getCrossReferenceHeader } from "seroval";
+import {
+  CustomEventPlugin,
+  DOMExceptionPlugin,
+  EventPlugin,
+  FormDataPlugin,
+  HeadersPlugin,
+  ReadableStreamPlugin,
+  RequestPlugin,
+  ResponsePlugin,
+  URLSearchParamsPlugin,
+  URLPlugin,
+} from 'seroval-plugins/web';
 
 const ES2017FLAG =
   Feature.AggregateError // ES2021
@@ -10,6 +22,20 @@ const GLOBAL_IDENTIFIER = '_$HY.r'; // TODO this is a pending name
 export function createSerializer({ onData, onDone, scopeId, onError }) {
   return new Serializer({
     scopeId,
+    plugins: [
+      // BlobPlugin,
+      CustomEventPlugin,
+      DOMExceptionPlugin,
+      EventPlugin,
+      // FilePlugin,
+      FormDataPlugin,
+      HeadersPlugin,
+      ReadableStreamPlugin,
+      RequestPlugin,
+      ResponsePlugin,
+      URLSearchParamsPlugin,
+      URLPlugin,
+    ],
     globalIdentifier: GLOBAL_IDENTIFIER,
     disabledFeatures: ES2017FLAG,
     onData,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,19 +113,22 @@ importers:
         specifier: ^3.1
         version: 3.1.1
       seroval:
-        specifier: ^0.15.1
-        version: 0.15.1
+        specifier: ^1.0.0
+        version: 1.0.0
+      seroval-plugins:
+        specifier: ^1.0.0
+        version: 1.0.0(seroval@1.0.0)
 
   packages/hyper-dom-expressions:
     devDependencies:
       dom-expressions:
-        specifier: ^0.37.9
+        specifier: ^0.37.10
         version: link:../dom-expressions
 
   packages/lit-dom-expressions:
     devDependencies:
       dom-expressions:
-        specifier: ^0.37.9
+        specifier: ^0.37.10
         version: link:../dom-expressions
       html-parse-string:
         specifier: ^0.0.9
@@ -7139,8 +7142,17 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /seroval@0.15.1:
-    resolution: {integrity: sha512-OPVtf0qmeC7RW+ScVX+7aOS+xoIM7pWcZ0jOWg2aTZigCydgRB04adfteBRbecZnnrO1WuGQ+C3tLeBBzX2zSQ==}
+  /seroval-plugins@1.0.0(seroval@1.0.0):
+    resolution: {integrity: sha512-ATs2B23J8YuOJnhhv1mmi8V73KceXv04cm7Xs9hZCZ00SATTIMmd98YQge2UZGuCv8JJEL3FC7whOJC/YAJC0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: '>=0.15'
+    dependencies:
+      seroval: 1.0.0
+    dev: true
+
+  /seroval@1.0.0:
+    resolution: {integrity: sha512-HA2BtUaLO6Gqpc1uc//v08DqvWKfGrD7wpsJSw+qkgBubJbYuKBVE2i2v09k5kwM6wA7R/dN37LCg+t48sBpCg==}
     engines: {node: '>=10'}
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       seroval-plugins:
-        specifier: ^1.0.0
-        version: 1.0.0(seroval@1.0.0)
+        specifier: ^1.0.1
+        version: 1.0.1(seroval@1.0.0)
 
   packages/hyper-dom-expressions:
     devDependencies:
@@ -7142,8 +7142,8 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /seroval-plugins@1.0.0(seroval@1.0.0):
-    resolution: {integrity: sha512-ATs2B23J8YuOJnhhv1mmi8V73KceXv04cm7Xs9hZCZ00SATTIMmd98YQge2UZGuCv8JJEL3FC7whOJC/YAJC0Q==}
+  /seroval-plugins@1.0.1(seroval@1.0.0):
+    resolution: {integrity: sha512-NXeb6S2jh+sxFI8NMBpzyVWItblit9/j7B1q+vfxUccj0ycbqu4h3hzrrmb7GSy7b6WqTmo0apGBsLH5ei/VUg==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: '>=0.15'


### PR DESCRIPTION
The Web API support in seroval has been moved to another package, `seroval-plugins`. This PR makes it so that seroval 1.0 is supported, while also adding the `seroval-plugins` package as a new dependency.