### PR TITLE
Correctly escape style attribute in SSR output

### DIFF
--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -315,7 +315,7 @@ export function ssrClassList(value) {
 
 export function ssrStyle(value) {
   if (!value) return "";
-  if (typeof value === "string") return value;
+  if (typeof value === "string") return JSON.stringify(value); // JSON.stringify to guarantee that double quotes in the style string are escaped correctly
   let result = "";
   const k = Object.keys(value);
   for (let i = 0; i < k.length; i++) {

--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -315,7 +315,7 @@ export function ssrClassList(value) {
 
 export function ssrStyle(value) {
   if (!value) return "";
-  if (typeof value === "string") return JSON.stringify(value).slice(1, -1); // JSON.stringify to guarantee that double quotes in the style string are escaped correctly
+  if (typeof value === "string") return escape(value, true);
   let result = "";
   const k = Object.keys(value);
   for (let i = 0; i < k.length; i++) {

--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -315,7 +315,7 @@ export function ssrClassList(value) {
 
 export function ssrStyle(value) {
   if (!value) return "";
-  if (typeof value === "string") return JSON.stringify(value); // JSON.stringify to guarantee that double quotes in the style string are escaped correctly
+  if (typeof value === "string") return JSON.stringify(value).slice(1, -1); // JSON.stringify to guarantee that double quotes in the style string are escaped correctly
   let result = "";
   const k = Object.keys(value);
   for (let i = 0; i < k.length; i++) {


### PR DESCRIPTION
Fixes the behavior that you can observe here: https://stackblitz.com/edit/solid-ssr-vite-juconn?file=src%2Fpages%2FHome.tsx where if you put a string that contains a double quote into the style attribute of an element, the server side rendered version isn't correctly escaped. Example: `<main data-hk="0.0.0.2.13.0.0.6.0.0.0.0.0.1"><h2 style="--my-var: url("./test.svg");">Home!</h2></main>`

Edit: fix wasn't as easy as I thought, gotta improve this a lil