### PR TITLE
make `voidFn()` return value explicit

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -549,7 +549,7 @@ export function Hydration(props) {
   return props.children;
 }
 
-function voidFn() {}
+const voidFn = () => undefined
 
 // experimental
 export const RequestContext = Symbol();


### PR DESCRIPTION
This is to get tree shaking when using SolidStart's `getRequestEvent()` function e.g.
```js
export default () => {
	const requestEvent = getRequestEvent()
	
	if (requestEvent) {
		// server code here
	}

	// ...
}
```

For some reason Rollup can't statically analyse a function without an explicit return value. So before this change, the server code gets bundled into the client, but after this change, Rollup is able to see that `getRequestEvent()` always returns `undefined` meaning that `requestEvent` is always `undefined` meaning that the if statement can be tree shaken away for the client build.