### PR TITLE
Friendly message for when mount point doesn't exists

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -48,7 +48,7 @@ export {
 export function render(code, element, init, options = {}) {
   if(!element && "_DX_DEV_" && sharedConfig.context) {
      throw new Error(
-        "The `element` passed to `render(..., element)` doesn't exist in the document. Check if element exists in the document."
+        "The `element` passed to `render(..., element)` doesn't exist in the document. Make sure `element` exists in the document."
      );
   }
   let disposer;

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -46,6 +46,11 @@ export {
 };
 
 export function render(code, element, init, options = {}) {
+  if(!element && "_DX_DEV_" && sharedConfig.context) {
+     throw new Error(
+        "The `element` passed to `render(..., element)` doesn't exist in the document. Check if element exists in the document."
+     );
+  }
   let disposer;
   root(dispose => {
     disposer = dispose;

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -46,7 +46,7 @@ export {
 };
 
 export function render(code, element, init, options = {}) {
-  if(!element && "_DX_DEV_" && sharedConfig.context) {
+  if(!element && "_DX_DEV_") {
      throw new Error(
         "The `element` passed to `render(..., element)` doesn't exist in the document. Make sure `element` exists in the document."
      );


### PR DESCRIPTION
When the element passed to `render` doesn't exist, it shows a cryptic `element is null`. Improve that with a friendly message. 
I'm not sure what `sharedConfig.context` do, followed it is used in similar places.