### PR TITLE
fix(dom-expressions): type of SVG `<use>`

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1890,11 +1890,16 @@ export namespace JSX {
     textLength?: FunctionMaybe<number | string>;
     lengthAdjust?: FunctionMaybe<"spacing" | "spacingAndGlyphs">;
   }
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+   */
   interface UseSVGAttributes<T>
-    extends GraphicsElementSVGAttributes<T>,
-      ConditionalProcessingSVGAttributes,
-      ExternalResourceSVGAttributes,
+    extends CoreSVGAttributes<T>,
       StylableSVGAttributes,
+      ConditionalProcessingSVGAttributes,
+      GraphicsElementSVGAttributes<T>,
+      PresentationSVGAttributes,
+      ExternalResourceSVGAttributes,
       TransformableSVGAttributes {
     x?: FunctionMaybe<number | string>;
     y?: FunctionMaybe<number | string>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1967,11 +1967,16 @@ export namespace JSX {
     textLength?: number | string;
     lengthAdjust?: "spacing" | "spacingAndGlyphs";
   }
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+   */
   interface UseSVGAttributes<T>
-    extends GraphicsElementSVGAttributes<T>,
-      ConditionalProcessingSVGAttributes,
-      ExternalResourceSVGAttributes,
+    extends CoreSVGAttributes<T>,
       StylableSVGAttributes,
+      ConditionalProcessingSVGAttributes,
+      GraphicsElementSVGAttributes<T>,
+      PresentationSVGAttributes,
+      ExternalResourceSVGAttributes,
       TransformableSVGAttributes {
     x?: number | string;
     y?: number | string;


### PR DESCRIPTION
Closes https://github.com/solidjs/solid/issues/2052