### PR TITLE
Improve event delegation handling of open shadow DOM

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -389,7 +389,16 @@ function eventHandler(e) {
       data !== undefined ? handler.call(node, data, e) : handler.call(node, e);
       if (e.cancelBubble) return;
     }
-    node = node._$host || node.parentNode || node.host;
+    if(node._$host || node.parentNode) {
+      node = node._$host || node.parentNode;
+    }
+    else if(node = node.host) {
+      // walking up shadow DOM so retarget to host
+      Object.defineProperty(e, "target", {
+        configurable: true,
+        value: node
+      });
+    }
   }
 }
 

--- a/packages/dom-expressions/test/dom/events-shadow.spec.jsx
+++ b/packages/dom-expressions/test/dom/events-shadow.spec.jsx
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as r from "../../src/client";
+import * as S from "s-js";
+
+describe("Synthetic event target with shadow DOM web components", () => {
+  const Elements = {
+    button: null,
+    slotButton: null,
+    outerContainer: null,
+    innerContainer: null,
+    myComponent: null,
+  };
+
+  let innerOnClickHandler = null;
+  const innerOnClick = (e) => {
+    innerOnClickHandler?.(e);
+  }
+
+  let outerOnClickHandler = null;
+  const outerOnClick = (e) => {
+    outerOnClickHandler?.(e);
+  }
+
+  class MyComponent extends HTMLElement {
+    constructor() {
+      super();
+      const shadowRoot = this.attachShadow({ mode: 'open' });
+      S.root(() =>
+        shadowRoot.appendChild(
+          <div ref={Elements.innerContainer} onClick={innerOnClick}>
+            <button ref={Elements.button} />
+            <slot name="theslot"></slot>
+          </div>
+        )
+      );
+    }
+  }
+  
+  customElements.define('my-component', MyComponent);
+
+
+
+  document.body.innerHTML = "";
+  S.root(() =>
+    document.body.appendChild(
+      <div ref={Elements.outerContainer} onClick={outerOnClick}>
+        <my-component ref={Elements.myComponent}>
+          <button slot="theslot" id="slotbutton" ref={Elements.slotButton}></button>
+        </my-component>
+      </div>
+    )
+  );
+
+  r.delegateEvents(['click'], document);
+
+  test("Events inside web component have target button", () => {
+    let target = null;
+    innerOnClickHandler = (e) => target = e.target;
+    Elements.button.click();
+    innerOnClickHandler = null;
+    expect(target.tagName).toBe("BUTTON");
+  });
+
+  test("Events outside web component have target my-component", () => {
+    let target = null;
+    outerOnClickHandler = (e) => target = e.target;
+    Elements.button.click();
+    outerOnClickHandler = null;
+    expect(target.tagName).toBe('MY-COMPONENT');
+  });
+
+  test("Events on document (non-delegated) have target my-component", () => {
+    let target = null;
+    const handler = (e) => target = e.target;
+    document.addEventListener('click', handler);
+    Elements.button.click();
+    document.removeEventListener('click', handler);
+    expect(target.tagName).toBe('MY-COMPONENT');
+  });
+
+  test("Events outside web component but from slot have target slotbutton", () => {
+    let target = null;
+    outerOnClickHandler = (e) => target = e.target;
+    Elements.slotButton.click();
+    outerOnClickHandler = null;
+    expect(target.id).toBe('slotbutton');
+  });
+
+  test("Events inside web component but from slot have target slotbutton", () => {
+    let target = null;
+    innerOnClickHandler = (e) => target = e.target;
+    Elements.slotButton.click();
+    innerOnClickHandler = null;
+    expect(target.id).toBe('slotbutton');
+  })
+});
+

--- a/packages/dom-expressions/test/dom/events-shadow.spec.jsx
+++ b/packages/dom-expressions/test/dom/events-shadow.spec.jsx
@@ -46,7 +46,7 @@ describe("Synthetic event target with shadow DOM web components", () => {
   S.root(() =>
     document.body.appendChild(
       <div ref={Elements.outerContainer} onClick={outerOnClick}>
-        <my-component ref={Elements.myComponent}>
+        <my-component id="mycomponent" ref={Elements.myComponent}>
           <button slot="theslot" id="slotbutton" ref={Elements.slotButton}></button>
         </my-component>
       </div>


### PR DESCRIPTION
Fix https://github.com/solidjs/solid/issues/2103

Adds unit tests for event delegation with open shadow dom.

- Set target when traversing shadow root hosts
- Uses composedPath so that delegated handlers inside the shadow dom get events from within slots
- Doesn't retarget when traversing a portal with useShadow

When a portal mount is in shadow dom (and possibly some other cases when mixing portals and shadow dom), it can't naturally end with the original target, so it needs the explicit retarget at the end to handle that edge case.

Mixing portals and shadow dom (especially slots) may have some interesting interactions, I've tried to make it have the most intuitive behaviour even when that doesn't follow the standard because bubbling through portals is already non standard behaviour.