### PR TITLE
fix(dom-expressions): proper ref handling in spread

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -183,7 +183,7 @@ export function spread(node, props = {}, isSVG, skipChildren) {
   if (!skipChildren) {
     effect(() => (prevProps.children = insertExpression(node, props.children, prevProps.children)));
   }
-  effect(() => props.ref && props.ref(node));
+  effect(() => (typeof props.ref === "function" ? use(props.ref, node) : (props.ref = node)));
   effect(() => assign(node, props, isSVG, true, prevProps, true));
   return prevProps;
 }


### PR DESCRIPTION
fixes https://github.com/solidjs/solid/issues/2136

i'm not sure if `untrack(() => props.ref(node))` is better