### PR TITLE
fix(dom-expressions): handle expression in ref

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -495,7 +495,7 @@ function transformAttributes(path, results) {
                 )
               )
             );
-          } else if (t.isCallExpression(value.expression)) {
+          } else {
             const refIdentifier = path.scope.generateUidIdentifier("_ref$");
             results.exprs.unshift(
               t.variableDeclaration("var", [

--- a/packages/babel-plugin-jsx-dom-expressions/src/universal/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/universal/element.js
@@ -131,7 +131,7 @@ function transformAttributes(path, results) {
                 )
               )
             );
-          } else if (t.isCallExpression(value.expression)) {
+          } else {
             const refIdentifier = path.scope.generateUidIdentifier("_ref$");
             results.exprs.unshift(
               t.variableDeclaration("var", [

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -189,3 +189,13 @@ const template33 = (
     <button class={styles[foo()]}></button>
   </>
 );
+
+const template34 = <div use:something {...somethingElse} use:zero={0} />;
+
+const template35 = <div ref={a().b.c} />
+
+const template36 = <div ref={a().b?.c} />
+
+const template37 = <div ref={a() ? b : c} />
+
+const template38 = <div ref={a() ?? b} />

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -373,4 +373,35 @@ const template33 = [
     return _el$49;
   })()
 ];
+const template34 = (() => {
+  var _el$50 = _tmpl$4();
+  _$use(zero, _el$50, () => 0);
+  _$use(something, _el$50, () => true);
+  _$spread(_el$50, somethingElse, false, false);
+  return _el$50;
+})();
+const template35 = (() => {
+  var _el$51 = _tmpl$4();
+  var _ref$4 = a().b.c;
+  typeof _ref$4 === "function" ? _$use(_ref$4, _el$51) : (a().b.c = _el$51);
+  return _el$51;
+})();
+const template36 = (() => {
+  var _el$52 = _tmpl$4();
+  var _ref$5 = a().b?.c;
+  typeof _ref$5 === "function" && _$use(_ref$5, _el$52);
+  return _el$52;
+})();
+const template37 = (() => {
+  var _el$53 = _tmpl$4();
+  var _ref$6 = a() ? b : c;
+  typeof _ref$6 === "function" && _$use(_ref$6, _el$53);
+  return _el$53;
+})();
+const template38 = (() => {
+  var _el$54 = _tmpl$4();
+  var _ref$7 = a() ?? b;
+  typeof _ref$7 === "function" && _$use(_ref$7, _el$54);
+  return _el$54;
+})();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/code.js
@@ -189,3 +189,13 @@ const template33 = (
     <button class={styles[foo()]}></button>
   </>
 );
+
+const template34 = <div use:something {...somethingElse} use:zero={0} />;
+
+const template35 = <div ref={a().b.c} />
+
+const template36 = <div ref={a().b?.c} />
+
+const template37 = <div ref={a() ? b : c} />
+
+const template38 = <div ref={a() ?? b} />

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -32,7 +32,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
   _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is <!$><!/></span><input><div>`),
   _tmpl$17 = /*#__PURE__*/ _$template(
-    `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\r\n    random3 random4">`
+    `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4">`
   ),
   _tmpl$18 = /*#__PURE__*/ _$template(`<button>`);
 import * as styles from "./styles.module.css";
@@ -391,4 +391,36 @@ const template33 = [
     return _el$53;
   })()
 ];
+const template34 = (() => {
+  var _el$54 = _$getNextElement(_tmpl$4);
+  _$use(zero, _el$54, () => 0);
+  _$use(something, _el$54, () => true);
+  _$spread(_el$54, somethingElse, false, false);
+  _$runHydrationEvents();
+  return _el$54;
+})();
+const template35 = (() => {
+  var _el$55 = _$getNextElement(_tmpl$4);
+  var _ref$4 = a().b.c;
+  typeof _ref$4 === "function" ? _$use(_ref$4, _el$55) : (a().b.c = _el$55);
+  return _el$55;
+})();
+const template36 = (() => {
+  var _el$56 = _$getNextElement(_tmpl$4);
+  var _ref$5 = a().b?.c;
+  typeof _ref$5 === "function" && _$use(_ref$5, _el$56);
+  return _el$56;
+})();
+const template37 = (() => {
+  var _el$57 = _$getNextElement(_tmpl$4);
+  var _ref$6 = a() ? b : c;
+  typeof _ref$6 === "function" && _$use(_ref$6, _el$57);
+  return _el$57;
+})();
+const template38 = (() => {
+  var _el$58 = _$getNextElement(_tmpl$4);
+  var _ref$7 = a() ?? b;
+  typeof _ref$7 === "function" && _$use(_ref$7, _el$58);
+  return _el$58;
+})();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/code.js
@@ -66,3 +66,13 @@ const template13 = <input type="checkbox" checked={true} readonly="" />;
 const template14 = <input type="checkbox" checked={state.visible} readonly={value} />;
 
 const template15 = <mesh scale={[1, 1, 1]} rotateX={0} />;
+
+const template16 = <div use:something {...somethingElse} use:zero={0} />;
+
+const template17 = <div ref={a().b.c} />
+
+const template18 = <div ref={a().b?.c} />
+
+const template19 = <div ref={a() ? b : c} />
+
+const template20 = <div ref={a() ?? b} />

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -180,3 +180,34 @@ const template15 = (() => {
   _$setProp(_el$21, "rotateX", 0);
   return _el$21;
 })();
+const template16 = (() => {
+  var _el$22 = _tmpl$3();
+  _$use(zero, _el$22, () => 0);
+  _$use(something, _el$22, () => true);
+  _$spread(_el$22, somethingElse, false, false);
+  return _el$22;
+})();
+const template17 = (() => {
+  var _el$23 = _tmpl$3();
+  var _ref$4 = a().b.c;
+  typeof _ref$4 === "function" ? _$use(_ref$4, _el$23) : (a().b.c = _el$23);
+  return _el$23;
+})();
+const template18 = (() => {
+  var _el$24 = _tmpl$3();
+  var _ref$5 = a().b?.c;
+  typeof _ref$5 === "function" && _$use(_ref$5, _el$24);
+  return _el$24;
+})();
+const template19 = (() => {
+  var _el$25 = _tmpl$3();
+  var _ref$6 = a() ? b : c;
+  typeof _ref$6 === "function" && _$use(_ref$6, _el$25);
+  return _el$25;
+})();
+const template20 = (() => {
+  var _el$26 = _tmpl$3();
+  var _ref$7 = a() ?? b;
+  typeof _ref$7 === "function" && _$use(_ref$7, _el$26);
+  return _el$26;
+})();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/code.js
@@ -163,3 +163,13 @@ const template30 = (
     random3 random4"
   />
 );
+
+const template31 = <div use:something {...somethingElse} use:zero={0} />;
+
+const template32 = <div ref={a().b.c} />
+
+const template33 = <div ref={a().b?.c} />
+
+const template34 = <div ref={a() ? b : c} />
+
+const template35 = <div ref={a() ?? b} />

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
@@ -23,7 +23,7 @@ var _tmpl$ = ['<a href="/" class="', '">Welcome</a>'],
   _tmpl$17 = ["<div", ">", "</div>"],
   _tmpl$18 = ["<div>", "", "</div>"],
   _tmpl$19 =
-    '<div class="class1 class2 class3 class4 class5 class6" style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;" random="random1 random2\r\n    random3 random4"></div>';
+    '<div class="class1 class2 class3 class4 class5 class6" style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;" random="random1 random2\n    random3 random4"></div>';
 const selected = true;
 let id = "my-h1";
 let link;
@@ -202,3 +202,8 @@ const template28 = _$ssrElement(
 );
 const template29 = _$ssr(_tmpl$17, _$ssrAttribute("attribute", !!someValue, false), !!someValue);
 const template30 = _$ssr(_tmpl$19);
+const template31 = _$ssrElement("div", somethingElse, undefined, false);
+const template32 = _$ssr(_tmpl$8);
+const template33 = _$ssr(_tmpl$8);
+const template34 = _$ssr(_tmpl$8);
+const template35 = _$ssr(_tmpl$8);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/code.js
@@ -163,3 +163,13 @@ const template30 = (
     random3 random4"
   />
 );
+
+const template31 = <div use:something {...somethingElse} use:zero={0} />;
+
+const template32 = <div ref={a().b.c} />
+
+const template33 = <div ref={a().b?.c} />
+
+const template34 = <div ref={a() ? b : c} />
+
+const template35 = <div ref={a() ?? b} />

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
@@ -26,7 +26,7 @@ var _tmpl$ = ['<a href="/" class="', '">Welcome</a>'],
   _tmpl$19 = ["<div", ">", "</div>"],
   _tmpl$20 = [
     "<div",
-    ' class="class1 class2 class3 class4 class5 class6" style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;" random="random1 random2\r\n    random3 random4"></div>'
+    ' class="class1 class2 class3 class4 class5 class6" style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;" random="random1 random2\n    random3 random4"></div>'
   ];
 const selected = true;
 let id = "my-h1";
@@ -234,3 +234,8 @@ const template29 = _$ssr(
   !!someValue
 );
 const template30 = _$ssr(_tmpl$20, _$ssrHydrationKey());
+const template31 = _$ssrElement("div", somethingElse, undefined, true);
+const template32 = _$ssr(_tmpl$8, _$ssrHydrationKey());
+const template33 = _$ssr(_tmpl$8, _$ssrHydrationKey());
+const template34 = _$ssr(_tmpl$8, _$ssrHydrationKey());
+const template35 = _$ssr(_tmpl$8, _$ssrHydrationKey());

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/code.js
@@ -104,3 +104,11 @@ const template18 = (
 const template19 = <div style={{ a: "static", ...rest }} ></div>
 
 const template20 = <div use:something {...somethingElse} use:zero={0} />;
+
+const template21 = <div ref={a().b.c} />
+
+const template22 = <div ref={a().b?.c} />
+
+const template23 = <div ref={a() ? b : c} />
+
+const template24 = <div ref={a() ?? b} />

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
@@ -232,3 +232,27 @@ const template20 = (() => {
   _$spread(_el$29, somethingElse, false);
   return _el$29;
 })();
+const template21 = (() => {
+  var _el$30 = _$createElement("div");
+  var _ref$4 = a().b.c;
+  typeof _ref$4 === "function" ? _$use(_ref$4, _el$30) : (a().b.c = _el$30);
+  return _el$30;
+})();
+const template22 = (() => {
+  var _el$31 = _$createElement("div");
+  var _ref$5 = a().b?.c;
+  typeof _ref$5 === "function" && _$use(_ref$5, _el$31);
+  return _el$31;
+})();
+const template23 = (() => {
+  var _el$32 = _$createElement("div");
+  var _ref$6 = a() ? b : c;
+  typeof _ref$6 === "function" && _$use(_ref$6, _el$32);
+  return _el$32;
+})();
+const template24 = (() => {
+  var _el$33 = _$createElement("div");
+  var _ref$7 = a() ?? b;
+  typeof _ref$7 === "function" && _$use(_ref$7, _el$33);
+  return _el$33;
+})();


### PR DESCRIPTION
fixes https://github.com/solidjs/solid/issues/2137

these are still relevant here so didn't touch them
```jsx
let refTarget;
const template8 = <div ref={refTarget} />;
```

```jsx
const template10 = <div ref={refFactory()} />;
```

not sure why the check for call expression was there though.