### PR TITLE
Prefer to set property when property & attribute are identical

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
@@ -227,7 +227,7 @@ function normalizeAttributes(path) {
         a.node.name.name === "className" ||
         a.node.name.name === "classList")
   );
-  // combine class propertoes
+  // combine class properties
   if (classAttributes.length > 1) {
     const first = classAttributes[0].node,
       values = [],

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -46,7 +46,6 @@ const BooleanAttributes = /*#__PURE__*/ new Set(booleans);
 
 const Properties = /*#__PURE__*/ new Set([
   "className",
-  "src",
   "value",
   "readOnly",
   "formNoValidate",

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -1,3 +1,19 @@
+const reflectedAttributes = [
+  "align",
+  "alt",
+  "href",
+  "id",
+  "loading",
+  "name",
+  "rel",
+  "role",
+  "src",
+  "srcset",
+  "sizes",
+  "title",
+  "type"
+];
+
 const booleans = [
   "allowfullscreen",
   "async",
@@ -30,12 +46,14 @@ const BooleanAttributes = /*#__PURE__*/ new Set(booleans);
 
 const Properties = /*#__PURE__*/ new Set([
   "className",
+  "src",
   "value",
   "readOnly",
   "formNoValidate",
   "isMap",
   "noModule",
   "playsInline",
+  ...reflectedAttributes,
   ...booleans
 ]);
 
@@ -75,6 +93,10 @@ const PropAliases = /*#__PURE__*/ Object.assign(Object.create(null), {
     $: "readOnly",
     INPUT: 1,
     TEXTAREA: 1
+  },
+  src: {
+    $: "src",
+    IMG: 1
   }
 });
 

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -7,9 +7,9 @@ const reflectedAttributes = [
   "name",
   "rel",
   "role",
+  "sizes",
   "src",
   "srcset",
-  "sizes",
   "title",
   "type"
 ];

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -1,12 +1,10 @@
 const reflectedAttributes = [
   "align",
   "alt",
-  "href",
   "id",
   "loading",
   "name",
   "rel",
-  "role",
   "sizes",
   "src",
   "srcset",

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -93,10 +93,6 @@ const PropAliases = /*#__PURE__*/ Object.assign(Object.create(null), {
     $: "readOnly",
     INPUT: 1,
     TEXTAREA: 1
-  },
-  src: {
-    $: "src",
-    IMG: 1
   }
 });
 


### PR DESCRIPTION
## Changes
1. It saves 5+ bytes for every single attribute that's instead set as a property, so I've added a list of [reflected attributes](https://html.spec.whatwg.org/#reflected-idl-attribute) to the Properties list.
1. Fix 1 typo in a comment

## Bundle size win
#### Example code
```tsx
render(
  () => (
    <>
      <a id={Math.random() > 0.5 ? 'linkA' : 'linkB'}>link</a>                   {/* id */}
      <button name={Math.random() > 0.5 ? 'name a' : 'name b'}>name btn</button> {/* name */}
      <link rel={Math.random() > 0.5 ? 'preload' : 'preconnect'}>link</link>     {/* rel */}
      <img src={logo} alt={Math.random() > 0.5 ? 'a img' : 'b img'} />           {/* src */}
      <input type={Math.random() > 0.5 ? 'text' : 'password'} />                 {/* type */}
    </>
  ),
  document.body
);
```
#### OLD output
```js
(() => {
  return [
    ((c = G()), e(() => a(c, 'id', Math.random() > 0.5 ? 'linkA' : 'linkB')), c),
    ((r = k()), e(() => a(r, 'name', Math.random() > 0.5 ? 'name a' : 'name b')), r),
    ((o = z()), e(() => a(o, 'rel', Math.random() > 0.5 ? 'preload' : 'preconnect')), o),
    ((n = E()),
    a(n, 'src', 'data:image/svg+xml,somesvg'),
    e(() => a(n, 'alt', Math.random() > 0.5 ? 'a img' : 'b img')),
    n),
    ((t = B()), e(() => a(t, 'type', Math.random() > 0.5 ? 'text' : 'password')), t),
  ];
}, document.body);
```
#### NEW output `(-0.1KB)`
```js
(() => {
  return [
    ((c = A()), e(() => (c.id = Math.random() > 0.5 ? 'linkA' : 'linkB')), c),
    ((r = G()), e(() => (r.name = Math.random() > 0.5 ? 'name a' : 'name b')), r),
    ((o = k()), e(() => (o.rel = Math.random() > 0.5 ? 'preload' : 'preconnect')), o),
    ((n = O()),
    (n.src = 'data:image/svg+xml,somesvg'),
    e(() => (n.alt = Math.random() > 0.5 ? 'a img' : 'b img')),
    n),
    ((t = E()), e(() => (t.type = Math.random() > 0.5 ? 'text' : 'password')), t),
  ];
  var t, n, l, o, r, c, f;
}, document.body);
```

## Notes
1. There are more reflected properties to be added in the future for further gains, although some properties like `maxlength (string)`/`maxLength (number)` will require slightly more effort to coerce types