### PR TITLE
avoid updating text node if value is the same after converting to a string

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -413,7 +413,10 @@ function insertExpression(parent, value, current, marker, unwrapArray) {
 
   if (t === "string" || t === "number") {
     if (hydrating) return current;
-    if (t === "number") value = value.toString();
+    if (t === "number") {
+      value = value.toString();
+      if (value === current) return current;
+    }
     if (multi) {
       let node = current[0];
       if (node && node.nodeType === 3) {


### PR DESCRIPTION
On this example, the node flashes on the dev tools because its failing the equality check, as whats on the dom is a string and the new value is a number https://playground.solidjs.com/anonymous/abf375c1-7f30-4d09-bf19-e543a5681e70

quoting from a discord message

> That's happening because it's failing this triple equality check https://github.com/ryansolid/dom-expressions/blob/main/packages/dom-expressions/src/client.js#L409 , as what's rendered is the 0 string and the new data is 0 the number. It's then converted to a string https://github.com/ryansolid/dom-expressions/blob/main/packages/dom-expressions/src/client.js#L416
but then it's not compared when updating on this case https://github.com/ryansolid/dom-expressions/blob/main/packages/dom-expressions/src/client.js#L425C26-L425C41
If you convert it to a string on the neutralizeCount call it stops flashing on the dev tools https://playground.solidjs.com/anonymous/cadbf84e-aef3-4a19-9b99-f0b6434e2725

