### PR TITLE
Don't unwrap IIFE if it contains parameters

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -161,7 +161,8 @@ export default function transformComponent(path) {
               );
             } else if (
               t.isCallExpression(value.expression) &&
-              t.isArrowFunctionExpression(value.expression.callee)
+              t.isArrowFunctionExpression(value.expression.callee) &&
+              value.expression.callee.params.length === 0
             ) {
               const callee = value.expression.callee;
               const body = t.isBlockStatement(callee.body)

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
@@ -162,14 +162,22 @@ const template25 = <Component>
   <div />
 </Component>
 
-const template26 = <Component
-  when={(() => {
-    const foo = test();
-    if ("t" in foo) {
-      return foo;
-    }
-  })()}
-/>
+const template26 = <>
+  <Component
+    when={(() => {
+      const foo = test();
+      if ("t" in foo) {
+        return foo;
+      }
+    })()}
+  />
+
+  <Component
+    when={((val = 123) => {
+      return val * 2
+    })()}
+  />
+</>
 
 const template27 = <Component
   when={(() => prop.red ? "red" : "green")()}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -379,14 +379,21 @@ const template25 = _$createComponent(Component, {
     return _tmpl$2();
   }
 });
-const template26 = _$createComponent(Component, {
-  get when() {
-    const foo = test();
-    if ("t" in foo) {
-      return foo;
+const template26 = [
+  _$createComponent(Component, {
+    get when() {
+      const foo = test();
+      if ("t" in foo) {
+        return foo;
+      }
     }
-  }
-});
+  }),
+  _$createComponent(Component, {
+    get when() {
+      return val * 2;
+    }
+  })
+];
 const template27 = _$createComponent(Component, {
   get when() {
     return prop.red ? "red" : "green";

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -390,7 +390,9 @@ const template26 = [
   }),
   _$createComponent(Component, {
     get when() {
-      return val * 2;
+      return ((val = 123) => {
+        return val * 2;
+      })();
     }
   })
 ];


### PR DESCRIPTION
- Adds test for an IIFE with a parameter
- Adjust the transformation so unwrapping only happens when there isn't any