### PR TITLE
Add onToggle and onBeforeToggle handlers

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -155,6 +155,7 @@ export namespace JSX {
     onAnimationStart?: EventHandlerUnion<T, AnimationEvent>;
     onAuxClick?: EventHandlerUnion<T, MouseEvent>;
     onBeforeInput?: EventHandlerUnion<T, InputEvent>;
+    onBeforeToggle?: EventHandlerUnion<T, ToggleEvent>;
     onBlur?: EventHandlerUnion<T, FocusEvent>;
     onCanPlay?: EventHandlerUnion<T, Event>;
     onCanPlayThrough?: EventHandlerUnion<T, Event>;
@@ -220,6 +221,7 @@ export namespace JSX {
     >;
     onSuspend?: EventHandlerUnion<T, Event>;
     onTimeUpdate?: EventHandlerUnion<T, Event>;
+    onToggle?: EventHandlerUnion<T, ToggleEvent>;
     onTouchCancel?: EventHandlerUnion<T, TouchEvent>;
     onTouchEnd?: EventHandlerUnion<T, TouchEvent>;
     onTouchMove?: EventHandlerUnion<T, TouchEvent>;
@@ -242,6 +244,7 @@ export namespace JSX {
     onanimationstart?: EventHandlerUnion<T, AnimationEvent>;
     onauxclick?: EventHandlerUnion<T, MouseEvent>;
     onbeforeinput?: EventHandlerUnion<T, InputEvent>;
+    onbeforetoggle?: EventHandlerUnion<T, ToggleEvent>;
     onblur?: EventHandlerUnion<T, FocusEvent>;
     oncanplay?: EventHandlerUnion<T, Event>;
     oncanplaythrough?: EventHandlerUnion<T, Event>;
@@ -307,6 +310,7 @@ export namespace JSX {
     >;
     onsuspend?: EventHandlerUnion<T, Event>;
     ontimeupdate?: EventHandlerUnion<T, Event>;
+    ontoggle?: EventHandlerUnion<T, ToggleEvent>;
     ontouchcancel?: EventHandlerUnion<T, TouchEvent>;
     ontouchend?: EventHandlerUnion<T, TouchEvent>;
     ontouchmove?: EventHandlerUnion<T, TouchEvent>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -221,6 +221,7 @@ export namespace JSX {
     onAnimationStart?: EventHandlerUnion<T, AnimationEvent>;
     onAuxClick?: EventHandlerUnion<T, MouseEvent>;
     onBeforeInput?: InputEventHandlerUnion<T, InputEvent>;
+    onBeforeToggle?: EventHandlerUnion<T, ToggleEvent>;
     onBlur?: FocusEventHandlerUnion<T, FocusEvent>;
     onCanPlay?: EventHandlerUnion<T, Event>;
     onCanPlayThrough?: EventHandlerUnion<T, Event>;
@@ -286,6 +287,7 @@ export namespace JSX {
     >;
     onSuspend?: EventHandlerUnion<T, Event>;
     onTimeUpdate?: EventHandlerUnion<T, Event>;
+    onToggle?: EventHandlerUnion<T, ToggleEvent>;
     onTouchCancel?: EventHandlerUnion<T, TouchEvent>;
     onTouchEnd?: EventHandlerUnion<T, TouchEvent>;
     onTouchMove?: EventHandlerUnion<T, TouchEvent>;
@@ -308,6 +310,7 @@ export namespace JSX {
     onanimationstart?: EventHandlerUnion<T, AnimationEvent>;
     onauxclick?: EventHandlerUnion<T, MouseEvent>;
     onbeforeinput?: InputEventHandlerUnion<T, InputEvent>;
+    onbeforetoggle?: EventHandlerUnion<T, ToggleEvent>;
     onblur?: FocusEventHandlerUnion<T, FocusEvent>;
     oncanplay?: EventHandlerUnion<T, Event>;
     oncanplaythrough?: EventHandlerUnion<T, Event>;
@@ -373,6 +376,7 @@ export namespace JSX {
     >;
     onsuspend?: EventHandlerUnion<T, Event>;
     ontimeupdate?: EventHandlerUnion<T, Event>;
+    ontoggle?: EventHandlerUnion<T, ToggleEvent>;
     ontouchcancel?: EventHandlerUnion<T, TouchEvent>;
     ontouchend?: EventHandlerUnion<T, TouchEvent>;
     ontouchmove?: EventHandlerUnion<T, TouchEvent>;


### PR DESCRIPTION
The new [Toggle events](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent) are available on any element with a valid `popover` attribute, as well as previously [on `<details>`](https://github.com/ryansolid/dom-expressions/pull/110)

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforetoggle_event