### PR TITLE
only assign ref to a variable

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -462,11 +462,11 @@ function transformAttributes(path, results) {
             value.expression = value.expression.expression;
           }
           let binding,
-            isFunction =
+            isConstant =
               t.isIdentifier(value.expression) &&
               (binding = path.scope.getBinding(value.expression.name)) &&
               binding.kind === "const";
-          if (!isFunction && t.isLVal(value.expression)) {
+          if (!isConstant && binding && t.isLVal(value.expression)) {
             const refIdentifier = path.scope.generateUidIdentifier("_ref$");
             results.exprs.unshift(
               t.variableDeclaration("var", [
@@ -487,7 +487,7 @@ function transformAttributes(path, results) {
                 )
               )
             );
-          } else if (isFunction || t.isFunction(value.expression)) {
+          } else if (isConstant || t.isFunction(value.expression)) {
             results.exprs.unshift(
               t.expressionStatement(
                 t.callExpression(

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -384,7 +384,7 @@ const template34 = (() => {
 const template35 = (() => {
   var _el$51 = _tmpl$4();
   var _ref$4 = a().b.c;
-  typeof _ref$4 === "function" ? _$use(_ref$4, _el$51) : (a().b.c = _el$51);
+  typeof _ref$4 === "function" && _$use(_ref$4, _el$51);
   return _el$51;
 })();
 const template36 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -22,7 +22,7 @@ const Child = props => {
       var _el$ = _tmpl$(),
         _el$2 = _el$.firstChild;
       var _ref$ = props.ref;
-      typeof _ref$ === "function" ? _$use(_ref$, _el$) : (props.ref = _el$);
+      typeof _ref$ === "function" && _$use(_ref$, _el$);
       _$insert(_el$, () => props.name, null);
       return _el$;
     })(),

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -403,7 +403,7 @@ const template34 = (() => {
 const template35 = (() => {
   var _el$55 = _$getNextElement(_tmpl$4);
   var _ref$4 = a().b.c;
-  typeof _ref$4 === "function" ? _$use(_ref$4, _el$55) : (a().b.c = _el$55);
+  typeof _ref$4 === "function" && _$use(_ref$4, _el$55);
   return _el$55;
 })();
 const template36 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/components/output.js
@@ -31,7 +31,7 @@ const Child = props => {
         _el$3 = _el$2.nextSibling,
         [_el$4, _co$] = _$getNextMarker(_el$3.nextSibling);
       var _ref$ = props.ref;
-      typeof _ref$ === "function" ? _$use(_ref$, _el$) : (props.ref = _el$);
+      typeof _ref$ === "function" && _$use(_ref$, _el$);
       _$insert(_el$, () => props.name, _el$4, _co$);
       return _el$;
     })(),

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_wrapperless_fixtures__/components/output.js
@@ -21,7 +21,7 @@ const Child = props => {
       var _el$ = _tmpl$(),
         _el$2 = _el$.firstChild;
       var _ref$ = props.ref;
-      typeof _ref$ === "function" ? _$use(_ref$, _el$) : (props.ref = _el$);
+      typeof _ref$ === "function" && _$use(_ref$, _el$);
       _$insert(_el$, () => props.name, null);
       return _el$;
     })(),

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -190,7 +190,7 @@ const template16 = (() => {
 const template17 = (() => {
   var _el$23 = _tmpl$3();
   var _ref$4 = a().b.c;
-  typeof _ref$4 === "function" ? _$use(_ref$4, _el$23) : (a().b.c = _el$23);
+  typeof _ref$4 === "function" && _$use(_ref$4, _el$23);
   return _el$23;
 })();
 const template18 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/components/output.js
@@ -22,7 +22,7 @@ const Child = props => {
       var _el$ = _tmpl$(),
         _el$2 = _el$.firstChild;
       var _ref$ = props.ref;
-      typeof _ref$ === "function" ? _$use(_ref$, _el$) : (props.ref = _el$);
+      typeof _ref$ === "function" && _$use(_ref$, _el$);
       _$insert(_el$, () => props.name, null);
       return _el$;
     })(),

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/hybrid/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/hybrid/output.js
@@ -24,7 +24,7 @@ const Child = props => {
       var _el$ = _tmpl$(),
         _el$2 = _el$.firstChild;
       var _ref$ = props.ref;
-      typeof _ref$ === "function" ? _$use(_ref$, _el$) : (props.ref = _el$);
+      typeof _ref$ === "function" && _$use(_ref$, _el$);
       _$insert(_el$, () => props.name, null);
       _$effect(() =>
         _$setAttribute(
@@ -85,7 +85,7 @@ const Child = props => {
                       var _el$7 = _tmpl$(),
                         _el$8 = _el$7.firstChild;
                       var _ref$2 = props.ref;
-                      typeof _ref$2 === "function" ? _$use(_ref$2, _el$7) : (props.ref = _el$7);
+                      typeof _ref$2 === "function" && _$use(_ref$2, _el$7);
                       _$insert(_el$7, () => props.name, null);
                       _$effect(() =>
                         _$setAttribute(

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -183,7 +183,7 @@ export function spread(node, props = {}, isSVG, skipChildren) {
   if (!skipChildren) {
     effect(() => (prevProps.children = insertExpression(node, props.children, prevProps.children)));
   }
-  effect(() => (typeof props.ref === "function" ? use(props.ref, node) : (props.ref = node)));
+  effect(() => typeof props.ref === "function" && use(props.ref, node));
   effect(() => assign(node, props, isSVG, true, prevProps, true));
   return prevProps;
 }


### PR DESCRIPTION
This fixes a bug where we generate ref assignment `props.ref = ` or anything that is assignable (left value) which was also wrongly followed it in dom-expressions `client.js` (by me).