### PR TITLE
add `width` and `height` attributes to `SourceHTMLAttributes`

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1017,6 +1017,8 @@ export namespace JSX {
     src?: FunctionMaybe<string>;
     srcset?: FunctionMaybe<string>;
     type?: FunctionMaybe<string>;
+    width?: number | undefined;
+    height?: number | undefined;
   }
   interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
     media?: FunctionMaybe<string>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1135,6 +1135,8 @@ export namespace JSX {
     src?: string | undefined;
     srcset?: string | undefined;
     type?: string | undefined;
+    width?: number | undefined;
+    height?: number | undefined;
   }
   interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
     media?: string | undefined;


### PR DESCRIPTION
Source: https://developer.mozilla.org/en-US/docs/Web/API/HTMLSourceElement