### PR TITLE
preliminary support for `bool:` [needs help]

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -705,6 +705,42 @@ function transformAttributes(path, results) {
             tagName
           });
         } else if(key.slice(0, 5) === 'bool:'){
+
+            // inline it on the template when possible
+            let content = value;
+
+            if (t.isJSXExpressionContainer(content)) content = content.expression;
+
+            function addBoolAttribute() {
+              results.template += `${needsSpacing ? " " : ""}${key.slice(5)}`;
+              needsSpacing = true;
+            }
+
+            switch (content.type) {
+              case "StringLiteral": {
+                if (content.value.length && content.value !== "0") {
+                  addBoolAttribute();
+                }
+                return;
+              }
+              case "NullLiteral": {
+                return;
+              }
+              case "BooleanLiteral": {
+                if (content.value) {
+                  addBoolAttribute();
+                }
+                return;
+              }
+              case "Identifier": {
+                if (content.name === "undefined") {
+                  return;
+                }
+                break;
+              }
+            }
+
+            // when not possible to inline it in the template
             results.exprs.push(
               t.expressionStatement(
                 setAttr(

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -216,6 +216,13 @@ export function setAttr(path, elem, name, value, { isSVG, dynamic, prevId, isCE,
     return t.assignmentExpression("=", t.memberExpression(elem, t.identifier("data")), value);
   }
 
+  if(namespace === 'bool') {
+    return t.callExpression(
+      registerImportMethod(path, "setBoolAttribute", getRendererConfig(path, "dom").moduleName),
+      [elem, t.stringLiteral(name), value]
+    );
+  }
+
   const isChildProp = ChildProperties.has(name);
   const isProp = Properties.has(name);
   const alias = getPropAlias(name, tagName.toUpperCase());
@@ -697,6 +704,18 @@ function transformAttributes(path, results) {
             isCE,
             tagName
           });
+        } else if(key.slice(0, 5) === 'bool:'){
+            results.exprs.push(
+              t.expressionStatement(
+                setAttr(
+                  attribute,
+                  elem,
+                  key,
+                  t.isJSXExpressionContainer(value) ? value.expression : value,
+                  { isSVG, isCE, tagName },
+                ),
+              ),
+            );
         } else {
           results.exprs.push(
             t.expressionStatement(

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -8,10 +8,11 @@ export const reservedNameSpaces = new Set([
   "style",
   "use",
   "prop",
-  "attr"
+  "attr",
+  "bool"
 ]);
 
-export const nonSpreadNameSpaces = new Set(["class", "style", "use", "prop", "attr"]);
+export const nonSpreadNameSpaces = new Set(["class", "style", "use", "prop", "attr", "bool"]);
 
 export function getConfig(path) {
   return path.hub.file.metadata.config;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -203,6 +203,7 @@ const template41 = (
   </select>
 );
 
+// bool:
 function boolTest(){return true}
 const boolTestBinding = false
 const boolTestObjBinding = {value:false}
@@ -210,20 +211,22 @@ const boolTestObjBinding = {value:false}
 const template42 = <div bool:quack="">empty string</div>;
 const template43 = <div bool:quack={""}>js empty</div>;
 const template44 = <div bool:quack="hola">hola</div>;
-const template45 = <div bool:quack={"hola"}>hola js</div>;
+const template45 = <div bool:quack={"hola js"}>"hola js"</div>;
 const template46 = <div bool:quack={true}>true</div>;
 const template47 = <div bool:quack={false}>false</div>;
 const template48 = <div bool:quack={1}>1</div>;
 const template49 = <div bool:quack={0}>0</div>;
-const template50 = <div bool:quack={undefined}>undefined</div>;
-const template51 = <div bool:quack={null}>null</div>;
-const template52 = <div bool:quack={boolTest()}>boolTest()</div>;
-const template53 = <div bool:quack={boolTest}>boolTest</div>;
-const template54 = <div bool:quack={boolTestBinding}>boolTestBinding</div>;
-const template55 = <div bool:quack={boolTestObjBinding.value}>boolTestObjBinding.value</div>;
-const template56 = <div bool:quack={()=>false}>fn</div>;
+const template50 = <div bool:quack={"1"}>"1"</div>;
+const template51 = <div bool:quack={"0"}>"0"</div>;
+const template52 = <div bool:quack={undefined}>undefined</div>;
+const template53 = <div bool:quack={null}>null</div>;
+const template54 = <div bool:quack={boolTest()}>boolTest()</div>;
+const template55 = <div bool:quack={boolTest}>boolTest</div>;
+const template56 = <div bool:quack={boolTestBinding}>boolTestBinding</div>;
+const template57 = <div bool:quack={boolTestObjBinding.value}>boolTestObjBinding.value</div>;
+const template58 = <div bool:quack={()=>false}>fn</div>;
 
-const template57 = <div before bool:quack="true">should have space before</div>;
-const template58 = <div before bool:quack="true" after>should have space before/after</div>;
-const template59 = <div bool:quack="true" after>should have space before/after</div>;
-// this crash it for some reason- */ const template60 = <div bool:quack>really empty</div>;
+const template59 = <div before bool:quack="true">should have space before</div>;
+const template60 = <div before bool:quack="true" after>should have space before/after</div>;
+const template61 = <div bool:quack="true" after>should have space before/after</div>;
+// this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -202,3 +202,28 @@ const template41 = (
     <option value={Color.Blue}>Blue</option>
   </select>
 );
+
+function boolTest(){return true}
+const boolTestBinding = false
+const boolTestObjBinding = {value:false}
+
+const template42 = <div bool:quack="">empty string</div>;
+const template43 = <div bool:quack={""}>js empty</div>;
+const template44 = <div bool:quack="hola">hola</div>;
+const template45 = <div bool:quack={"hola"}>hola js</div>;
+const template46 = <div bool:quack={true}>true</div>;
+const template47 = <div bool:quack={false}>false</div>;
+const template48 = <div bool:quack={1}>1</div>;
+const template49 = <div bool:quack={0}>0</div>;
+const template50 = <div bool:quack={undefined}>undefined</div>;
+const template51 = <div bool:quack={null}>null</div>;
+const template52 = <div bool:quack={boolTest()}>boolTest()</div>;
+const template53 = <div bool:quack={boolTest}>boolTest</div>;
+const template54 = <div bool:quack={boolTestBinding}>boolTestBinding</div>;
+const template55 = <div bool:quack={boolTestObjBinding.value}>boolTestObjBinding.value</div>;
+const template56 = <div bool:quack={()=>false}>fn</div>;
+
+const template57 = <div before bool:quack="true">should have space before</div>;
+const template58 = <div before bool:quack="true" after>should have space before/after</div>;
+const template59 = <div bool:quack="true" after>should have space before/after</div>;
+// this crash it for some reason- */ const template60 = <div bool:quack>really empty</div>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -36,22 +36,24 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
   _tmpl$21 = /*#__PURE__*/ _$template(`<div>empty string`),
   _tmpl$22 = /*#__PURE__*/ _$template(`<div>js empty`),
-  _tmpl$23 = /*#__PURE__*/ _$template(`<div>hola`),
-  _tmpl$24 = /*#__PURE__*/ _$template(`<div>hola js`),
-  _tmpl$25 = /*#__PURE__*/ _$template(`<div>true`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<div quack>hola`),
+  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>"hola js"`),
+  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>true`),
   _tmpl$26 = /*#__PURE__*/ _$template(`<div>false`),
-  _tmpl$27 = /*#__PURE__*/ _$template(`<div>1`),
+  _tmpl$27 = /*#__PURE__*/ _$template(`<div quack>1`),
   _tmpl$28 = /*#__PURE__*/ _$template(`<div>0`),
-  _tmpl$29 = /*#__PURE__*/ _$template(`<div>undefined`),
-  _tmpl$30 = /*#__PURE__*/ _$template(`<div>null`),
-  _tmpl$31 = /*#__PURE__*/ _$template(`<div>boolTest()`),
-  _tmpl$32 = /*#__PURE__*/ _$template(`<div>boolTest`),
-  _tmpl$33 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
-  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
-  _tmpl$35 = /*#__PURE__*/ _$template(`<div>fn`),
-  _tmpl$36 = /*#__PURE__*/ _$template(`<div before>should have space before`),
-  _tmpl$37 = /*#__PURE__*/ _$template(`<div before after>should have space before/after`),
-  _tmpl$38 = /*#__PURE__*/ _$template(`<div after>should have space before/after`);
+  _tmpl$29 = /*#__PURE__*/ _$template(`<div quack>"1"`),
+  _tmpl$30 = /*#__PURE__*/ _$template(`<div>"0"`),
+  _tmpl$31 = /*#__PURE__*/ _$template(`<div>undefined`),
+  _tmpl$32 = /*#__PURE__*/ _$template(`<div>null`),
+  _tmpl$33 = /*#__PURE__*/ _$template(`<div>boolTest()`),
+  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest`),
+  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
+  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
+  _tmpl$37 = /*#__PURE__*/ _$template(`<div>fn`),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<div before quack>should have space before`),
+  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack after>should have space before/after`),
+  _tmpl$40 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after`);
 import * as styles from "./styles.module.css";
 const selected = true;
 let id = "my-h1";
@@ -445,6 +447,8 @@ const template41 = (() => {
   _$effect(() => (_el$57.value = state.color));
   return _el$57;
 })();
+
+// bool:
 function boolTest() {
   return true;
 }
@@ -452,95 +456,45 @@ const boolTestBinding = false;
 const boolTestObjBinding = {
   value: false
 };
-const template42 = (() => {
-  var _el$60 = _tmpl$21();
-  _$setBoolAttribute(_el$60, "quack", "");
-  return _el$60;
-})();
-const template43 = (() => {
-  var _el$61 = _tmpl$22();
-  _$setBoolAttribute(_el$61, "quack", "");
-  return _el$61;
-})();
-const template44 = (() => {
-  var _el$62 = _tmpl$23();
-  _$setBoolAttribute(_el$62, "quack", "hola");
-  return _el$62;
-})();
-const template45 = (() => {
-  var _el$63 = _tmpl$24();
-  _$setBoolAttribute(_el$63, "quack", "hola");
-  return _el$63;
-})();
-const template46 = (() => {
-  var _el$64 = _tmpl$25();
-  _$setBoolAttribute(_el$64, "quack", true);
-  return _el$64;
-})();
-const template47 = (() => {
-  var _el$65 = _tmpl$26();
-  _$setBoolAttribute(_el$65, "quack", false);
-  return _el$65;
-})();
-const template48 = (() => {
-  var _el$66 = _tmpl$27();
-  _$setBoolAttribute(_el$66, "quack", "1");
-  return _el$66;
-})();
-const template49 = (() => {
-  var _el$67 = _tmpl$28();
-  _$setBoolAttribute(_el$67, "quack", "0");
-  return _el$67;
-})();
-const template50 = (() => {
-  var _el$68 = _tmpl$29();
-  _$setBoolAttribute(_el$68, "quack", undefined);
-  return _el$68;
-})();
-const template51 = (() => {
-  var _el$69 = _tmpl$30();
-  _$setBoolAttribute(_el$69, "quack", null);
-  return _el$69;
-})();
-const template52 = (() => {
-  var _el$70 = _tmpl$31();
-  _$effect(() => _$setBoolAttribute(_el$70, "quack", boolTest()));
-  return _el$70;
-})();
-const template53 = (() => {
-  var _el$71 = _tmpl$32();
-  _$setBoolAttribute(_el$71, "quack", boolTest);
-  return _el$71;
-})();
+const template42 = _tmpl$21();
+const template43 = _tmpl$22();
+const template44 = _tmpl$23();
+const template45 = _tmpl$24();
+const template46 = _tmpl$25();
+const template47 = _tmpl$26();
+const template48 = _tmpl$27();
+const template49 = _tmpl$28();
+const template50 = _tmpl$29();
+const template51 = _tmpl$30();
+const template52 = _tmpl$31();
+const template53 = _tmpl$32();
 const template54 = (() => {
   var _el$72 = _tmpl$33();
-  _$setBoolAttribute(_el$72, "quack", boolTestBinding);
+  _$effect(() => _$setBoolAttribute(_el$72, "quack", boolTest()));
   return _el$72;
 })();
 const template55 = (() => {
   var _el$73 = _tmpl$34();
-  _$effect(() => _$setBoolAttribute(_el$73, "quack", boolTestObjBinding.value));
+  _$setBoolAttribute(_el$73, "quack", boolTest);
   return _el$73;
 })();
 const template56 = (() => {
   var _el$74 = _tmpl$35();
-  _$setBoolAttribute(_el$74, "quack", () => false);
+  _$setBoolAttribute(_el$74, "quack", boolTestBinding);
   return _el$74;
 })();
 const template57 = (() => {
   var _el$75 = _tmpl$36();
-  _$setBoolAttribute(_el$75, "quack", "true");
+  _$effect(() => _$setBoolAttribute(_el$75, "quack", boolTestObjBinding.value));
   return _el$75;
 })();
 const template58 = (() => {
   var _el$76 = _tmpl$37();
-  _$setBoolAttribute(_el$76, "quack", "true");
+  _$setBoolAttribute(_el$76, "quack", () => false);
   return _el$76;
 })();
-const template59 = (() => {
-  var _el$77 = _tmpl$38();
-  _$setBoolAttribute(_el$77, "quack", "true");
-  return _el$77;
-})();
-// this crash it for some reason- */ const template60 = <div bool:quack>really empty</div>;
+const template59 = _tmpl$38();
+const template60 = _tmpl$39();
+const template61 = _tmpl$40();
+// this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -1,5 +1,6 @@
 import { template as _$template } from "r-dom";
 import { delegateEvents as _$delegateEvents } from "r-dom";
+import { setBoolAttribute as _$setBoolAttribute } from "r-dom";
 import { insert as _$insert } from "r-dom";
 import { memo as _$memo } from "r-dom";
 import { addEventListener as _$addEventListener } from "r-dom";
@@ -32,7 +33,25 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   ),
   _tmpl$18 = /*#__PURE__*/ _$template(`<button>`),
   _tmpl$19 = /*#__PURE__*/ _$template(`<input value=10>`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`);
+  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<div>empty string`),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<div>js empty`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<div>hola`),
+  _tmpl$24 = /*#__PURE__*/ _$template(`<div>hola js`),
+  _tmpl$25 = /*#__PURE__*/ _$template(`<div>true`),
+  _tmpl$26 = /*#__PURE__*/ _$template(`<div>false`),
+  _tmpl$27 = /*#__PURE__*/ _$template(`<div>1`),
+  _tmpl$28 = /*#__PURE__*/ _$template(`<div>0`),
+  _tmpl$29 = /*#__PURE__*/ _$template(`<div>undefined`),
+  _tmpl$30 = /*#__PURE__*/ _$template(`<div>null`),
+  _tmpl$31 = /*#__PURE__*/ _$template(`<div>boolTest()`),
+  _tmpl$32 = /*#__PURE__*/ _$template(`<div>boolTest`),
+  _tmpl$33 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
+  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
+  _tmpl$35 = /*#__PURE__*/ _$template(`<div>fn`),
+  _tmpl$36 = /*#__PURE__*/ _$template(`<div before>should have space before`),
+  _tmpl$37 = /*#__PURE__*/ _$template(`<div before after>should have space before/after`),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<div after>should have space before/after`);
 import * as styles from "./styles.module.css";
 const selected = true;
 let id = "my-h1";
@@ -426,4 +445,102 @@ const template41 = (() => {
   _$effect(() => (_el$57.value = state.color));
   return _el$57;
 })();
+function boolTest() {
+  return true;
+}
+const boolTestBinding = false;
+const boolTestObjBinding = {
+  value: false
+};
+const template42 = (() => {
+  var _el$60 = _tmpl$21();
+  _$setBoolAttribute(_el$60, "quack", "");
+  return _el$60;
+})();
+const template43 = (() => {
+  var _el$61 = _tmpl$22();
+  _$setBoolAttribute(_el$61, "quack", "");
+  return _el$61;
+})();
+const template44 = (() => {
+  var _el$62 = _tmpl$23();
+  _$setBoolAttribute(_el$62, "quack", "hola");
+  return _el$62;
+})();
+const template45 = (() => {
+  var _el$63 = _tmpl$24();
+  _$setBoolAttribute(_el$63, "quack", "hola");
+  return _el$63;
+})();
+const template46 = (() => {
+  var _el$64 = _tmpl$25();
+  _$setBoolAttribute(_el$64, "quack", true);
+  return _el$64;
+})();
+const template47 = (() => {
+  var _el$65 = _tmpl$26();
+  _$setBoolAttribute(_el$65, "quack", false);
+  return _el$65;
+})();
+const template48 = (() => {
+  var _el$66 = _tmpl$27();
+  _$setBoolAttribute(_el$66, "quack", "1");
+  return _el$66;
+})();
+const template49 = (() => {
+  var _el$67 = _tmpl$28();
+  _$setBoolAttribute(_el$67, "quack", "0");
+  return _el$67;
+})();
+const template50 = (() => {
+  var _el$68 = _tmpl$29();
+  _$setBoolAttribute(_el$68, "quack", undefined);
+  return _el$68;
+})();
+const template51 = (() => {
+  var _el$69 = _tmpl$30();
+  _$setBoolAttribute(_el$69, "quack", null);
+  return _el$69;
+})();
+const template52 = (() => {
+  var _el$70 = _tmpl$31();
+  _$effect(() => _$setBoolAttribute(_el$70, "quack", boolTest()));
+  return _el$70;
+})();
+const template53 = (() => {
+  var _el$71 = _tmpl$32();
+  _$setBoolAttribute(_el$71, "quack", boolTest);
+  return _el$71;
+})();
+const template54 = (() => {
+  var _el$72 = _tmpl$33();
+  _$setBoolAttribute(_el$72, "quack", boolTestBinding);
+  return _el$72;
+})();
+const template55 = (() => {
+  var _el$73 = _tmpl$34();
+  _$effect(() => _$setBoolAttribute(_el$73, "quack", boolTestObjBinding.value));
+  return _el$73;
+})();
+const template56 = (() => {
+  var _el$74 = _tmpl$35();
+  _$setBoolAttribute(_el$74, "quack", () => false);
+  return _el$74;
+})();
+const template57 = (() => {
+  var _el$75 = _tmpl$36();
+  _$setBoolAttribute(_el$75, "quack", "true");
+  return _el$75;
+})();
+const template58 = (() => {
+  var _el$76 = _tmpl$37();
+  _$setBoolAttribute(_el$76, "quack", "true");
+  return _el$76;
+})();
+const template59 = (() => {
+  var _el$77 = _tmpl$38();
+  _$setBoolAttribute(_el$77, "quack", "true");
+  return _el$77;
+})();
+// this crash it for some reason- */ const template60 = <div bool:quack>really empty</div>;
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/code.js
@@ -24,3 +24,24 @@ const template4 = (
 );
 
 const template5 = <a is="my-element" />;
+
+const template6 = <my-el bool:quack="">empty string</my-el>;
+const template7 = <my-el bool:quack={""}>js empty</my-el>;
+const template8 = <my-el bool:quack="hola">hola</my-el>;
+const template9 = <my-el bool:quack={"hola"}>hola js</my-el>;
+const template10 = <my-el bool:quack={true}>true</my-el>;
+const template11 = <my-el bool:quack={false}>false</my-el>;
+const template12 = <my-el bool:quack={1}>1</my-el>;
+const template13 = <my-el bool:quack={0}>0</my-el>;
+const template14 = <my-el bool:quack={undefined}>undefined</my-el>;
+const template15 = <my-el bool:quack={null}>null</my-el>;
+const template16 = <my-el bool:quack={boolTest()}>boolTest()</my-el>;
+const template17 = <my-el bool:quack={boolTest}>boolTest</my-el>;
+const template18 = <my-el bool:quack={boolTestBinding}>boolTestBinding</my-el>;
+const template19 = <my-el bool:quack={boolTestObjBinding.value}>boolTestObjBinding.value</my-el>;
+const template20 = <my-el bool:quack={()=>false}>fn</my-el>;
+
+const template21 = <my-el before bool:quack="true">should have space before</my-el>;
+const template22 = <my-el before bool:quack="true" after>should have space before/after</my-el>;
+const template23 = <my-el bool:quack="true" after>should have space before/after</my-el>;
+// this crash it for some reason- */ const template60 = <my-el bool:quack>really empty</my-el>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/code.js
@@ -25,23 +25,30 @@ const template4 = (
 
 const template5 = <a is="my-element" />;
 
-const template6 = <my-el bool:quack="">empty string</my-el>;
-const template7 = <my-el bool:quack={""}>js empty</my-el>;
-const template8 = <my-el bool:quack="hola">hola</my-el>;
-const template9 = <my-el bool:quack={"hola"}>hola js</my-el>;
-const template10 = <my-el bool:quack={true}>true</my-el>;
-const template11 = <my-el bool:quack={false}>false</my-el>;
-const template12 = <my-el bool:quack={1}>1</my-el>;
-const template13 = <my-el bool:quack={0}>0</my-el>;
-const template14 = <my-el bool:quack={undefined}>undefined</my-el>;
-const template15 = <my-el bool:quack={null}>null</my-el>;
-const template16 = <my-el bool:quack={boolTest()}>boolTest()</my-el>;
-const template17 = <my-el bool:quack={boolTest}>boolTest</my-el>;
-const template18 = <my-el bool:quack={boolTestBinding}>boolTestBinding</my-el>;
-const template19 = <my-el bool:quack={boolTestObjBinding.value}>boolTestObjBinding.value</my-el>;
-const template20 = <my-el bool:quack={()=>false}>fn</my-el>;
+// bool:
+function boolTest(){return true}
+const boolTestBinding = false
+const boolTestObjBinding = {value:false}
 
-const template21 = <my-el before bool:quack="true">should have space before</my-el>;
-const template22 = <my-el before bool:quack="true" after>should have space before/after</my-el>;
-const template23 = <my-el bool:quack="true" after>should have space before/after</my-el>;
-// this crash it for some reason- */ const template60 = <my-el bool:quack>really empty</my-el>;
+const template42 = <my-el bool:quack="">empty string</my-el>;
+const template43 = <my-el bool:quack={""}>js empty</my-el>;
+const template44 = <my-el bool:quack="hola">hola</my-el>;
+const template45 = <my-el bool:quack={"hola js"}>"hola js"</my-el>;
+const template46 = <my-el bool:quack={true}>true</my-el>;
+const template47 = <my-el bool:quack={false}>false</my-el>;
+const template48 = <my-el bool:quack={1}>1</my-el>;
+const template49 = <my-el bool:quack={0}>0</my-el>;
+const template50 = <my-el bool:quack={"1"}>"1"</my-el>;
+const template51 = <my-el bool:quack={"0"}>"0"</my-el>;
+const template52 = <my-el bool:quack={undefined}>undefined</my-el>;
+const template53 = <my-el bool:quack={null}>null</my-el>;
+const template54 = <my-el bool:quack={boolTest()}>boolTest()</my-el>;
+const template55 = <my-el bool:quack={boolTest}>boolTest</my-el>;
+const template56 = <my-el bool:quack={boolTestBinding}>boolTestBinding</my-el>;
+const template57 = <my-el bool:quack={boolTestObjBinding.value}>boolTestObjBinding.value</my-el>;
+const template58 = <my-el bool:quack={()=>false}>fn</my-el>;
+
+const template59 = <my-el before bool:quack="true">should have space before</my-el>;
+const template60 = <my-el before bool:quack="true" after>should have space before/after</my-el>;
+const template61 = <my-el bool:quack="true" after>should have space before/after</my-el>;
+// this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -1,8 +1,5 @@
 import { template as _$template } from "r-dom";
-import { createTextNode as _$createTextNode } from "r-dom";
-import { insertNode as _$insertNode } from "r-dom";
-import { setProp as _$setProp } from "r-dom";
-import { createElement as _$createElement } from "r-dom";
+import { setBoolAttribute as _$setBoolAttribute } from "r-dom";
 import { effect as _$effect } from "r-dom";
 import { getOwner as _$getOwner } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
@@ -12,26 +9,32 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<my-element>`, true, false),
   _tmpl$4 = /*#__PURE__*/ _$template(`<a is=my-element>`, true, false),
   _tmpl$5 = /*#__PURE__*/ _$template(`<my-el>empty string`, true, false),
   _tmpl$6 = /*#__PURE__*/ _$template(`<my-el>js empty`, true, false),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<my-el>hola`, true, false),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<my-el>hola js`, true, false),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<my-el>true`, true, false),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<my-el quack>hola`, true, false),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<my-el quack>"hola js"`, true, false),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<my-el quack>true`, true, false),
   _tmpl$10 = /*#__PURE__*/ _$template(`<my-el>false`, true, false),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<my-el>1`, true, false),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<my-el quack>1`, true, false),
   _tmpl$12 = /*#__PURE__*/ _$template(`<my-el>0`, true, false),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<my-el>undefined`, true, false),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<my-el>null`, true, false),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<my-el>boolTest()`, true, false),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<my-el>boolTest`, true, false),
-  _tmpl$17 = /*#__PURE__*/ _$template(`<my-el>boolTestBinding`, true, false),
-  _tmpl$18 = /*#__PURE__*/ _$template(`<my-el>boolTestObjBinding.value`, true, false),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<my-el>fn`, true, false),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<my-el before>should have space before`, true, false),
-  _tmpl$21 = /*#__PURE__*/ _$template(
-    `<my-el before after>should have space before/after`,
+  _tmpl$13 = /*#__PURE__*/ _$template(`<my-el quack>"1"`, true, false),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<my-el>"0"`, true, false),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<my-el>undefined`, true, false),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<my-el>null`, true, false),
+  _tmpl$17 = /*#__PURE__*/ _$template(`<my-el>boolTest()`, true, false),
+  _tmpl$18 = /*#__PURE__*/ _$template(`<my-el>boolTest`, true, false),
+  _tmpl$19 = /*#__PURE__*/ _$template(`<my-el>boolTestBinding`, true, false),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<my-el>boolTestObjBinding.value`, true, false),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<my-el>fn`, true, false),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<my-el before quack>should have space before`, true, false),
+  _tmpl$23 = /*#__PURE__*/ _$template(
+    `<my-el before quack after>should have space before/after`,
     true,
     false
   ),
-  _tmpl$22 = /*#__PURE__*/ _$template(`<my-el after>should have space before/after`, true, false);
+  _tmpl$24 = /*#__PURE__*/ _$template(
+    `<my-el quack after>should have space before/after`,
+    true,
+    false
+  );
 const template = (() => {
   var _el$ = _tmpl$();
   _el$.someAttr = name;
@@ -80,116 +83,119 @@ const template5 = (() => {
   _el$5._$owner = _$getOwner();
   return _el$5;
 })();
-const template6 = (() => {
-  var _el$6 = _$createElement("my-el");
-  _$insertNode(_el$6, _$createTextNode(`empty string`));
-  _$setProp(_el$6, "bool:quack", "");
+
+// bool:
+
+function boolTest() {
+  return true;
+}
+const boolTestBinding = false;
+const boolTestObjBinding = {
+  value: false
+};
+const template42 = (() => {
+  var _el$6 = _tmpl$5();
+  _el$6._$owner = _$getOwner();
   return _el$6;
 })();
-const template7 = (() => {
-  var _el$8 = _$createElement("my-el");
-  _$insertNode(_el$8, _$createTextNode(`js empty`));
-  _$setProp(_el$8, "bool:quack", "");
+const template43 = (() => {
+  var _el$7 = _tmpl$6();
+  _el$7._$owner = _$getOwner();
+  return _el$7;
+})();
+const template44 = (() => {
+  var _el$8 = _tmpl$7();
+  _el$8._$owner = _$getOwner();
   return _el$8;
 })();
-const template8 = (() => {
-  var _el$10 = _$createElement("my-el");
-  _$insertNode(_el$10, _$createTextNode(`hola`));
-  _$setProp(_el$10, "bool:quack", "hola");
+const template45 = (() => {
+  var _el$9 = _tmpl$8();
+  _el$9._$owner = _$getOwner();
+  return _el$9;
+})();
+const template46 = (() => {
+  var _el$10 = _tmpl$9();
+  _el$10._$owner = _$getOwner();
   return _el$10;
 })();
-const template9 = (() => {
-  var _el$12 = _$createElement("my-el");
-  _$insertNode(_el$12, _$createTextNode(`hola js`));
-  _$setProp(_el$12, "bool:quack", "hola");
+const template47 = (() => {
+  var _el$11 = _tmpl$10();
+  _el$11._$owner = _$getOwner();
+  return _el$11;
+})();
+const template48 = (() => {
+  var _el$12 = _tmpl$11();
+  _el$12._$owner = _$getOwner();
   return _el$12;
 })();
-const template10 = (() => {
-  var _el$14 = _$createElement("my-el");
-  _$insertNode(_el$14, _$createTextNode(`true`));
-  _$setProp(_el$14, "bool:quack", true);
+const template49 = (() => {
+  var _el$13 = _tmpl$12();
+  _el$13._$owner = _$getOwner();
+  return _el$13;
+})();
+const template50 = (() => {
+  var _el$14 = _tmpl$13();
+  _el$14._$owner = _$getOwner();
   return _el$14;
 })();
-const template11 = (() => {
-  var _el$16 = _$createElement("my-el");
-  _$insertNode(_el$16, _$createTextNode(`false`));
-  _$setProp(_el$16, "bool:quack", false);
+const template51 = (() => {
+  var _el$15 = _tmpl$14();
+  _el$15._$owner = _$getOwner();
+  return _el$15;
+})();
+const template52 = (() => {
+  var _el$16 = _tmpl$15();
+  _el$16._$owner = _$getOwner();
   return _el$16;
 })();
-const template12 = (() => {
-  var _el$18 = _$createElement("my-el");
-  _$insertNode(_el$18, _$createTextNode(`1`));
-  _$setProp(_el$18, "bool:quack", 1);
+const template53 = (() => {
+  var _el$17 = _tmpl$16();
+  _el$17._$owner = _$getOwner();
+  return _el$17;
+})();
+const template54 = (() => {
+  var _el$18 = _tmpl$17();
+  _el$18._$owner = _$getOwner();
+  _$effect(() => _$setBoolAttribute(_el$18, "quack", boolTest()));
   return _el$18;
 })();
-const template13 = (() => {
-  var _el$20 = _$createElement("my-el");
-  _$insertNode(_el$20, _$createTextNode(`0`));
-  _$setProp(_el$20, "bool:quack", 0);
+const template55 = (() => {
+  var _el$19 = _tmpl$18();
+  _$setBoolAttribute(_el$19, "quack", boolTest);
+  _el$19._$owner = _$getOwner();
+  return _el$19;
+})();
+const template56 = (() => {
+  var _el$20 = _tmpl$19();
+  _$setBoolAttribute(_el$20, "quack", boolTestBinding);
+  _el$20._$owner = _$getOwner();
   return _el$20;
 })();
-const template14 = (() => {
-  var _el$22 = _$createElement("my-el");
-  _$insertNode(_el$22, _$createTextNode(`undefined`));
-  _$setProp(_el$22, "bool:quack", undefined);
+const template57 = (() => {
+  var _el$21 = _tmpl$20();
+  _el$21._$owner = _$getOwner();
+  _$effect(() => _$setBoolAttribute(_el$21, "quack", boolTestObjBinding.value));
+  return _el$21;
+})();
+const template58 = (() => {
+  var _el$22 = _tmpl$21();
+  _$setBoolAttribute(_el$22, "quack", () => false);
+  _el$22._$owner = _$getOwner();
   return _el$22;
 })();
-const template15 = (() => {
-  var _el$24 = _$createElement("my-el");
-  _$insertNode(_el$24, _$createTextNode(`null`));
-  _$setProp(_el$24, "bool:quack", null);
+const template59 = (() => {
+  var _el$23 = _tmpl$22();
+  _el$23._$owner = _$getOwner();
+  return _el$23;
+})();
+const template60 = (() => {
+  var _el$24 = _tmpl$23();
+  _el$24._$owner = _$getOwner();
   return _el$24;
 })();
-const template16 = (() => {
-  var _el$26 = _$createElement("my-el");
-  _$insertNode(_el$26, _$createTextNode(`boolTest()`));
-  _$effect(_$p => _$setProp(_el$26, "bool:quack", boolTest(), _$p));
-  return _el$26;
+const template61 = (() => {
+  var _el$25 = _tmpl$24();
+  _el$25._$owner = _$getOwner();
+  return _el$25;
 })();
-const template17 = (() => {
-  var _el$28 = _$createElement("my-el");
-  _$insertNode(_el$28, _$createTextNode(`boolTest`));
-  _$setProp(_el$28, "bool:quack", boolTest);
-  return _el$28;
-})();
-const template18 = (() => {
-  var _el$30 = _$createElement("my-el");
-  _$insertNode(_el$30, _$createTextNode(`boolTestBinding`));
-  _$setProp(_el$30, "bool:quack", boolTestBinding);
-  return _el$30;
-})();
-const template19 = (() => {
-  var _el$32 = _$createElement("my-el");
-  _$insertNode(_el$32, _$createTextNode(`boolTestObjBinding.value`));
-  _$effect(_$p => _$setProp(_el$32, "bool:quack", boolTestObjBinding.value, _$p));
-  return _el$32;
-})();
-const template20 = (() => {
-  var _el$34 = _$createElement("my-el");
-  _$insertNode(_el$34, _$createTextNode(`fn`));
-  _$setProp(_el$34, "bool:quack", () => false);
-  return _el$34;
-})();
-const template21 = (() => {
-  var _el$36 = _$createElement("my-el");
-  _$insertNode(_el$36, _$createTextNode(`should have space before`));
-  _$setProp(_el$36, "before", true);
-  _$setProp(_el$36, "bool:quack", "true");
-  return _el$36;
-})();
-const template22 = (() => {
-  var _el$38 = _$createElement("my-el");
-  _$insertNode(_el$38, _$createTextNode(`should have space before/after`));
-  _$setProp(_el$38, "before", true);
-  _$setProp(_el$38, "bool:quack", "true");
-  _$setProp(_el$38, "after", true);
-  return _el$38;
-})();
-const template23 = (() => {
-  var _el$40 = _$createElement("my-el");
-  _$insertNode(_el$40, _$createTextNode(`should have space before/after`));
-  _$setProp(_el$40, "bool:quack", "true");
-  _$setProp(_el$40, "after", true);
-  return _el$40;
-})();
-// this crash it for some reason- */ const template60 = <my-el bool:quack>really empty</my-el>;
+// this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -85,7 +85,6 @@ const template5 = (() => {
 })();
 
 // bool:
-
 function boolTest() {
   return true;
 }

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -1,11 +1,37 @@
 import { template as _$template } from "r-dom";
+import { createTextNode as _$createTextNode } from "r-dom";
+import { insertNode as _$insertNode } from "r-dom";
+import { setProp as _$setProp } from "r-dom";
+import { createElement as _$createElement } from "r-dom";
 import { effect as _$effect } from "r-dom";
 import { getOwner as _$getOwner } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
 var _tmpl$ = /*#__PURE__*/ _$template(`<my-element>`, true, false),
   _tmpl$2 = /*#__PURE__*/ _$template(`<my-element><header slot=head>Title`, true, false),
   _tmpl$3 = /*#__PURE__*/ _$template(`<slot name=head>`),
-  _tmpl$4 = /*#__PURE__*/ _$template(`<a is=my-element>`, true, false);
+  _tmpl$4 = /*#__PURE__*/ _$template(`<a is=my-element>`, true, false),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<my-el>empty string`, true, false),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<my-el>js empty`, true, false),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<my-el>hola`, true, false),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<my-el>hola js`, true, false),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<my-el>true`, true, false),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<my-el>false`, true, false),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<my-el>1`, true, false),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<my-el>0`, true, false),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<my-el>undefined`, true, false),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<my-el>null`, true, false),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<my-el>boolTest()`, true, false),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<my-el>boolTest`, true, false),
+  _tmpl$17 = /*#__PURE__*/ _$template(`<my-el>boolTestBinding`, true, false),
+  _tmpl$18 = /*#__PURE__*/ _$template(`<my-el>boolTestObjBinding.value`, true, false),
+  _tmpl$19 = /*#__PURE__*/ _$template(`<my-el>fn`, true, false),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<my-el before>should have space before`, true, false),
+  _tmpl$21 = /*#__PURE__*/ _$template(
+    `<my-el before after>should have space before/after`,
+    true,
+    false
+  ),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<my-el after>should have space before/after`, true, false);
 const template = (() => {
   var _el$ = _tmpl$();
   _el$.someAttr = name;
@@ -54,3 +80,116 @@ const template5 = (() => {
   _el$5._$owner = _$getOwner();
   return _el$5;
 })();
+const template6 = (() => {
+  var _el$6 = _$createElement("my-el");
+  _$insertNode(_el$6, _$createTextNode(`empty string`));
+  _$setProp(_el$6, "bool:quack", "");
+  return _el$6;
+})();
+const template7 = (() => {
+  var _el$8 = _$createElement("my-el");
+  _$insertNode(_el$8, _$createTextNode(`js empty`));
+  _$setProp(_el$8, "bool:quack", "");
+  return _el$8;
+})();
+const template8 = (() => {
+  var _el$10 = _$createElement("my-el");
+  _$insertNode(_el$10, _$createTextNode(`hola`));
+  _$setProp(_el$10, "bool:quack", "hola");
+  return _el$10;
+})();
+const template9 = (() => {
+  var _el$12 = _$createElement("my-el");
+  _$insertNode(_el$12, _$createTextNode(`hola js`));
+  _$setProp(_el$12, "bool:quack", "hola");
+  return _el$12;
+})();
+const template10 = (() => {
+  var _el$14 = _$createElement("my-el");
+  _$insertNode(_el$14, _$createTextNode(`true`));
+  _$setProp(_el$14, "bool:quack", true);
+  return _el$14;
+})();
+const template11 = (() => {
+  var _el$16 = _$createElement("my-el");
+  _$insertNode(_el$16, _$createTextNode(`false`));
+  _$setProp(_el$16, "bool:quack", false);
+  return _el$16;
+})();
+const template12 = (() => {
+  var _el$18 = _$createElement("my-el");
+  _$insertNode(_el$18, _$createTextNode(`1`));
+  _$setProp(_el$18, "bool:quack", 1);
+  return _el$18;
+})();
+const template13 = (() => {
+  var _el$20 = _$createElement("my-el");
+  _$insertNode(_el$20, _$createTextNode(`0`));
+  _$setProp(_el$20, "bool:quack", 0);
+  return _el$20;
+})();
+const template14 = (() => {
+  var _el$22 = _$createElement("my-el");
+  _$insertNode(_el$22, _$createTextNode(`undefined`));
+  _$setProp(_el$22, "bool:quack", undefined);
+  return _el$22;
+})();
+const template15 = (() => {
+  var _el$24 = _$createElement("my-el");
+  _$insertNode(_el$24, _$createTextNode(`null`));
+  _$setProp(_el$24, "bool:quack", null);
+  return _el$24;
+})();
+const template16 = (() => {
+  var _el$26 = _$createElement("my-el");
+  _$insertNode(_el$26, _$createTextNode(`boolTest()`));
+  _$effect(_$p => _$setProp(_el$26, "bool:quack", boolTest(), _$p));
+  return _el$26;
+})();
+const template17 = (() => {
+  var _el$28 = _$createElement("my-el");
+  _$insertNode(_el$28, _$createTextNode(`boolTest`));
+  _$setProp(_el$28, "bool:quack", boolTest);
+  return _el$28;
+})();
+const template18 = (() => {
+  var _el$30 = _$createElement("my-el");
+  _$insertNode(_el$30, _$createTextNode(`boolTestBinding`));
+  _$setProp(_el$30, "bool:quack", boolTestBinding);
+  return _el$30;
+})();
+const template19 = (() => {
+  var _el$32 = _$createElement("my-el");
+  _$insertNode(_el$32, _$createTextNode(`boolTestObjBinding.value`));
+  _$effect(_$p => _$setProp(_el$32, "bool:quack", boolTestObjBinding.value, _$p));
+  return _el$32;
+})();
+const template20 = (() => {
+  var _el$34 = _$createElement("my-el");
+  _$insertNode(_el$34, _$createTextNode(`fn`));
+  _$setProp(_el$34, "bool:quack", () => false);
+  return _el$34;
+})();
+const template21 = (() => {
+  var _el$36 = _$createElement("my-el");
+  _$insertNode(_el$36, _$createTextNode(`should have space before`));
+  _$setProp(_el$36, "before", true);
+  _$setProp(_el$36, "bool:quack", "true");
+  return _el$36;
+})();
+const template22 = (() => {
+  var _el$38 = _$createElement("my-el");
+  _$insertNode(_el$38, _$createTextNode(`should have space before/after`));
+  _$setProp(_el$38, "before", true);
+  _$setProp(_el$38, "bool:quack", "true");
+  _$setProp(_el$38, "after", true);
+  return _el$38;
+})();
+const template23 = (() => {
+  var _el$40 = _$createElement("my-el");
+  _$insertNode(_el$40, _$createTextNode(`should have space before/after`));
+  _$setProp(_el$40, "bool:quack", "true");
+  _$setProp(_el$40, "after", true);
+  return _el$40;
+})();
+// this crash it for some reason- */ const template60 = <my-el bool:quack>really empty</my-el>;

--- a/packages/dom-expressions/src/client.d.ts
+++ b/packages/dom-expressions/src/client.d.ts
@@ -32,6 +32,7 @@ export function spread<T>(
 export function assign(node: Element, props: any, isSVG?: Boolean, skipChildren?: Boolean): void;
 export function setAttribute(node: Element, name: string, value: string): void;
 export function setAttributeNS(node: Element, namespace: string, name: string, value: string): void;
+export function setBoolAttribute(node: Element, name: string, value: any): void;
 export function className(node: Element, value: string): void;
 export function setProperty(node: Element, name: string, value: any): void;
 export function addEventListener(

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -118,6 +118,13 @@ export function setAttributeNS(node, namespace, name, value) {
   else node.setAttributeNS(namespace, name, value);
 }
 
+export function setBoolAttribute(node, name, value) {
+  if (isHydrating(node)) return;
+  value ?
+    node.setAttribute(name, value) :
+    node.removeAttribute(name)
+}
+
 export function className(node, value) {
   if (isHydrating(node)) return;
   if (value == null) node.removeAttribute("class");
@@ -351,6 +358,13 @@ function assignProp(node, prop, value, prev, isSVG, skipRef) {
     }
   } else if (prop.slice(0, 5) === "attr:") {
     setAttribute(node, prop.slice(5), value);
+  } else if (prop.slice(0, 5) === "bool:") {
+    if (isHydrating(node)) return;
+
+    prop = prop.slice(0, 5)
+    value ?
+        node.setAttribute(prop, '') :
+        node.removeAttribute(prop);
   } else if (
     (forceProp = prop.slice(0, 5) === "prop:") ||
     (isChildProp = ChildProperties.has(prop)) ||

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -357,7 +357,7 @@ function assignProp(node, prop, value, prev, isSVG, skipRef) {
   } else if (prop.slice(0, 5) === "attr:") {
     setAttribute(node, prop.slice(5), value);
   } else if (prop.slice(0, 5) === "bool:") {
-    setBoolAttribute(node, prop.slice(0, 5), value);
+    setBoolAttribute(node, prop.slice(5), value);
   } else if (
     (forceProp = prop.slice(0, 5) === "prop:") ||
     (isChildProp = ChildProperties.has(prop)) ||

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -120,7 +120,7 @@ export function setAttributeNS(node, namespace, name, value) {
 
 export function setBoolAttribute(node, name, value) {
   if (isHydrating(node)) return;
-  value ? node.setAttribute(name, value) : node.removeAttribute(name);
+  value ? node.setAttribute(name, "") : node.removeAttribute(name);
 }
 
 export function className(node, value) {

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -120,9 +120,7 @@ export function setAttributeNS(node, namespace, name, value) {
 
 export function setBoolAttribute(node, name, value) {
   if (isHydrating(node)) return;
-  value ?
-    node.setAttribute(name, value) :
-    node.removeAttribute(name)
+  value ? node.setAttribute(name, value) : node.removeAttribute(name);
 }
 
 export function className(node, value) {
@@ -359,12 +357,7 @@ function assignProp(node, prop, value, prev, isSVG, skipRef) {
   } else if (prop.slice(0, 5) === "attr:") {
     setAttribute(node, prop.slice(5), value);
   } else if (prop.slice(0, 5) === "bool:") {
-    if (isHydrating(node)) return;
-
-    prop = prop.slice(0, 5)
-    value ?
-        node.setAttribute(prop, '') :
-        node.removeAttribute(prop);
+    setBoolAttribute(node, prop.slice(0, 5), value);
   } else if (
     (forceProp = prop.slice(0, 5) === "prop:") ||
     (isChildProp = ChildProperties.has(prop)) ||
@@ -480,7 +473,7 @@ function insertExpression(parent, value, current, marker, unwrapArray) {
       if (marker === undefined) return (current = [...parent.childNodes]);
       let node = array[0];
       if (node.parentNode !== parent) return current;
-      const nodes = [node]
+      const nodes = [node];
       while ((node = node.nextSibling) !== marker) nodes.push(node);
       return (current = nodes);
     }

--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -75,6 +75,7 @@ export namespace JSX {
   }
   interface ExplicitProperties {}
   interface ExplicitAttributes {}
+  interface ExplicitBoolAttributes {}
   interface CustomEvents {}
   interface CustomCaptureEvents {}
   type DirectiveAttributes = {
@@ -101,6 +102,9 @@ export namespace JSX {
   };
   type AttrAttributes = {
     [Key in keyof ExplicitAttributes as `attr:${Key}`]?: ExplicitAttributes[Key];
+  };
+  type BoolAttributes = {
+    [Key in keyof ExplicitBoolAttributes as `bool:${Key}`]?: ExplicitBoolAttributes[Key];
   };
   type OnAttributes<T> = {
     [Key in keyof CustomEvents as `on:${Key}`]?: EventHandler<T, CustomEvents[Key]>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -141,6 +141,7 @@ export namespace JSX {
   }
   interface ExplicitProperties {}
   interface ExplicitAttributes {}
+  interface ExplicitBoolAttributes {}
   interface CustomEvents {}
   interface CustomCaptureEvents {}
   type DirectiveAttributes = {
@@ -167,6 +168,9 @@ export namespace JSX {
   };
   type AttrAttributes = {
     [Key in keyof ExplicitAttributes as `attr:${Key}`]?: ExplicitAttributes[Key];
+  };
+  type BoolAttributes = {
+    [Key in keyof ExplicitBoolAttributes as `bool:${Key}`]?: ExplicitBoolAttributes[Key];
   };
   type OnAttributes<T> = {
     [Key in keyof CustomEvents as `on:${Key}`]?: EventHandler<T, CustomEvents[Key]>;

--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -667,7 +667,19 @@ export function ssrSpread(props, isSVG, skipChildren) {
     ) {
       continue;
     } else {
+      // bool:
+      if (prop.slice(0, 5) === "bool:") {
+
+       if(!value) continue
+       prop = prop.slice(5);
+       result += `${escape(prop)}`;
+
+       continue
+      }
+
+      // attr:
       if (prop.slice(0, 5) === "attr:") prop = prop.slice(5);
+
       result += `${Aliases[prop] || escape(prop)}="${escape(value, true)}"`;
     }
     if (i !== keys.length - 1) result += " ";


### PR DESCRIPTION
The idea of the `bool:` namespace is to control if an attribute is present or not by evaluating its value to truthy/falsy. If it is truthy the attribute is added with an empty string as value, and if falsy the attribute is removed.  It's similar to `BooleanAttributes` that dom-expressions already considers but controllable by the user. This is specially relevant in the web components world where names are arbitrary and cannot be known beforehand.

The namespace will make the intention clear and this cannot be done with dom-expressions `setAttribute`.

I am running into an issue trying to implement this feature and your help would be welcome

I have added 1 test for "custom elements" 
`babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/code.js`

When I run `npm run test` it displays two failing tests:
 - FAIL  test/dynamic-dom.spec.js
 - FAIL  test/dom.spec.js

It looks like It's reusing the test I wrote in two different places and expecting for the same test two different outputs, I can't figure out what's going on with this test. Any ideas?

