### PR TITLE
fix: custom elements props case

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -228,7 +228,7 @@ export function toAttributeName(name) {
 }
 
 export function toPropertyName(name) {
-  return name.toLowerCase().replace(/-([a-z])/g, (_, w) => w.toUpperCase());
+  return name.replace(/-([a-z])/g, (_, w) => w.toUpperCase());
 }
 
 export function wrappedByText(list, startIndex) {


### PR DESCRIPTION
Issue:  custom element `props` lose case, example `myFn` becomes `myfn`.

I think this issue is unintentional, there's this function that it's trying **to give case** to custom elements props, for when the prop name comes from a case-insensitive place, ex transforming `the-prop` into `theProp`.  The function is

```js
export function toPropertyName(name) {
  return name.toLowerCase().replace(/-([a-z])/g, (_, w) => w.toUpperCase());
}
```

I would speculate that by trying to guard the case-sensitive regexp, a `toLowerCase` came to mind and it's causing the issue. Because if the prop doesn't have the char `-`, then it won't result into the desire intention.

It is used (as far as I could tell) on custom elements, as every use of `toPropertyName` seems to have a `isCE` check guard.

Here is a repro  https://playground.solidjs.com/anonymous/bfd05199-72f0-405a-a2c6-681afae82fbd 
Inspecting the element, and then from the "properties" tab from the developer tools 

<img width="335" alt="chrome_1E0Xiq9IPO" src="https://github.com/user-attachments/assets/67f71643-6e88-498d-9278-4757af1cab5b">

When using `prop:` namespace it works correctly 

<img width="330" alt="chrome_OJhdTqvgN7" src="https://github.com/user-attachments/assets/70035917-3424-4f83-8f37-264b809bedef">


I tested the fix by manually editing a vite build of "my-solid-project"

This was reported by @chee on solid-docs https://github.com/solidjs/solid-docs/issues/783