### PR TITLE
add default namespaced events

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -91,9 +91,7 @@ export namespace JSX {
   interface ExplicitAttributes {}
   interface ExplicitBoolAttributes {}
   interface CustomEvents {}
-  /**
-   * @deprecated Replaced by CustomEvents
-  */
+  /** @deprecated Replaced by CustomEvents */
   interface CustomCaptureEvents {}
   type DirectiveAttributes = {
     [Key in keyof Directives as `use:${Key}`]?: Directives[Key];
@@ -141,7 +139,8 @@ export namespace JSX {
       OnAttributes<T>,
       OnCaptureAttributes<T>,
       CustomEventHandlersCamelCase<T>,
-      CustomEventHandlersLowerCase<T> {
+      CustomEventHandlersLowerCase<T>,
+      CustomEventHandlersNamespaced<T> {
     children?: Element;
     innerHTML?: string;
     innerText?: string | number;
@@ -168,6 +167,17 @@ export namespace JSX {
     onfocusin?: EventHandlerUnion<T, FocusEvent>;
     onencrypted?: EventHandlerUnion<T, Event>;
     ondragexit?: EventHandlerUnion<T, DragEvent>;
+    // namespaced events
+    "on:copy"?: EventHandlerUnion<T, ClipboardEvent>;
+    "on:cut"?: EventHandlerUnion<T, ClipboardEvent>;
+    "on:paste"?: EventHandlerUnion<T, ClipboardEvent>;
+    "on:compositionend"?: EventHandlerUnion<T, CompositionEvent>;
+    "on:compositionstart"?: EventHandlerUnion<T, CompositionEvent>;
+    "on:compositionupdate"?: EventHandlerUnion<T, CompositionEvent>;
+    "on:focusout"?: EventHandlerUnion<T, FocusEvent>;
+    "on:focusin"?: EventHandlerUnion<T, FocusEvent>;
+    "on:encrypted"?: EventHandlerUnion<T, Event>;
+    "on:dragexit"?: EventHandlerUnion<T, DragEvent>;
   }
   interface CustomEventHandlersCamelCase<T> {
     onAbort?: EventHandlerUnion<T, Event>;
@@ -234,12 +244,7 @@ export namespace JSX {
     onSeeking?: EventHandlerUnion<T, Event>;
     onSelect?: EventHandlerUnion<T, UIEvent>;
     onStalled?: EventHandlerUnion<T, Event>;
-    onSubmit?: EventHandlerUnion<
-      T,
-      Event & {
-        submitter: HTMLElement;
-      }
-    >;
+    onSubmit?: EventHandlerUnion<T, SubmitEvent>;
     onSuspend?: EventHandlerUnion<T, Event>;
     onTimeUpdate?: EventHandlerUnion<T, Event>;
     onToggle?: EventHandlerUnion<T, ToggleEvent>;
@@ -255,9 +260,7 @@ export namespace JSX {
     onWaiting?: EventHandlerUnion<T, Event>;
     onWheel?: EventHandlerUnion<T, WheelEvent>;
   }
-  /**
-   * @type {GlobalEventHandlers}
-   */
+  /** @type {GlobalEventHandlers} */
   interface CustomEventHandlersLowerCase<T> {
     onabort?: EventHandlerUnion<T, Event>;
     onanimationend?: EventHandlerUnion<T, AnimationEvent>;
@@ -323,12 +326,7 @@ export namespace JSX {
     onseeking?: EventHandlerUnion<T, Event>;
     onselect?: EventHandlerUnion<T, UIEvent>;
     onstalled?: EventHandlerUnion<T, Event>;
-    onsubmit?: EventHandlerUnion<
-      T,
-      Event & {
-        submitter: HTMLElement;
-      }
-    >;
+    onsubmit?: EventHandlerUnion<T, SubmitEvent>;
     onsuspend?: EventHandlerUnion<T, Event>;
     ontimeupdate?: EventHandlerUnion<T, Event>;
     ontoggle?: EventHandlerUnion<T, ToggleEvent>;
@@ -343,6 +341,87 @@ export namespace JSX {
     onvolumechange?: EventHandlerUnion<T, Event>;
     onwaiting?: EventHandlerUnion<T, Event>;
     onwheel?: EventHandlerUnion<T, WheelEvent>;
+  }
+  interface CustomEventHandlersNamespaced<T> {
+    "on:abort"?: EventHandlerUnion<T, Event>;
+    "on:animationend"?: EventHandlerUnion<T, AnimationEvent>;
+    "on:animationiteration"?: EventHandlerUnion<T, AnimationEvent>;
+    "on:animationstart"?: EventHandlerUnion<T, AnimationEvent>;
+    "on:auxclick"?: EventHandlerUnion<T, MouseEvent>;
+    "on:beforeinput"?: EventHandlerUnion<T, InputEvent>;
+    "on:beforetoggle"?: EventHandlerUnion<T, ToggleEvent>;
+    "on:blur"?: EventHandlerUnion<T, FocusEvent>;
+    "on:canplay"?: EventHandlerUnion<T, Event>;
+    "on:canplaythrough"?: EventHandlerUnion<T, Event>;
+    "on:change"?: EventHandlerUnion<T, Event>;
+    "on:click"?: EventHandlerUnion<T, MouseEvent>;
+    "on:contextmenu"?: EventHandlerUnion<T, MouseEvent>;
+    "on:dblclick"?: EventHandlerUnion<T, MouseEvent>;
+    "on:drag"?: EventHandlerUnion<T, DragEvent>;
+    "on:dragend"?: EventHandlerUnion<T, DragEvent>;
+    "on:dragenter"?: EventHandlerUnion<T, DragEvent>;
+    "on:dragleave"?: EventHandlerUnion<T, DragEvent>;
+    "on:dragover"?: EventHandlerUnion<T, DragEvent>;
+    "on:dragstart"?: EventHandlerUnion<T, DragEvent>;
+    "on:drop"?: EventHandlerUnion<T, DragEvent>;
+    "on:durationchange"?: EventHandlerUnion<T, Event>;
+    "on:emptied"?: EventHandlerUnion<T, Event>;
+    "on:ended"?: EventHandlerUnion<T, Event>;
+    "on:error"?: EventHandlerUnion<T, Event>;
+    "on:focus"?: EventHandlerUnion<T, FocusEvent>;
+    "on:gotpointercapture"?: EventHandlerUnion<T, PointerEvent>;
+    "on:input"?: EventHandlerUnion<T, InputEvent>;
+    "on:invalid"?: EventHandlerUnion<T, Event>;
+    "on:keydown"?: EventHandlerUnion<T, KeyboardEvent>;
+    "on:keypress"?: EventHandlerUnion<T, KeyboardEvent>;
+    "on:keyup"?: EventHandlerUnion<T, KeyboardEvent>;
+    "on:load"?: EventHandlerUnion<T, Event>;
+    "on:loadeddata"?: EventHandlerUnion<T, Event>;
+    "on:loadedmetadata"?: EventHandlerUnion<T, Event>;
+    "on:loadstart"?: EventHandlerUnion<T, Event>;
+    "on:lostpointercapture"?: EventHandlerUnion<T, PointerEvent>;
+    "on:mousedown"?: EventHandlerUnion<T, MouseEvent>;
+    "on:mouseenter"?: EventHandlerUnion<T, MouseEvent>;
+    "on:mouseleave"?: EventHandlerUnion<T, MouseEvent>;
+    "on:mousemove"?: EventHandlerUnion<T, MouseEvent>;
+    "on:mouseout"?: EventHandlerUnion<T, MouseEvent>;
+    "on:mouseover"?: EventHandlerUnion<T, MouseEvent>;
+    "on:mouseup"?: EventHandlerUnion<T, MouseEvent>;
+    "on:pause"?: EventHandlerUnion<T, Event>;
+    "on:play"?: EventHandlerUnion<T, Event>;
+    "on:playing"?: EventHandlerUnion<T, Event>;
+    "on:pointercancel"?: EventHandlerUnion<T, PointerEvent>;
+    "on:pointerdown"?: EventHandlerUnion<T, PointerEvent>;
+    "on:pointerenter"?: EventHandlerUnion<T, PointerEvent>;
+    "on:pointerleave"?: EventHandlerUnion<T, PointerEvent>;
+    "on:pointermove"?: EventHandlerUnion<T, PointerEvent>;
+    "on:pointerout"?: EventHandlerUnion<T, PointerEvent>;
+    "on:pointerover"?: EventHandlerUnion<T, PointerEvent>;
+    "on:pointerup"?: EventHandlerUnion<T, PointerEvent>;
+    "on:progress"?: EventHandlerUnion<T, Event>;
+    "on:ratechange"?: EventHandlerUnion<T, Event>;
+    "on:reset"?: EventHandlerUnion<T, Event>;
+    "on:scroll"?: EventHandlerUnion<T, Event>;
+    "on:scrollend"?: EventHandlerUnion<T, Event>;
+    "on:seeked"?: EventHandlerUnion<T, Event>;
+    "on:seeking"?: EventHandlerUnion<T, Event>;
+    "on:select"?: EventHandlerUnion<T, UIEvent>;
+    "on:stalled"?: EventHandlerUnion<T, Event>;
+    "on:submit"?: EventHandlerUnion<T, SubmitEvent>;
+    "on:suspend"?: EventHandlerUnion<T, Event>;
+    "on:timeupdate"?: EventHandlerUnion<T, Event>;
+    "on:toggle"?: EventHandlerUnion<T, ToggleEvent>;
+    "on:touchcancel"?: EventHandlerUnion<T, TouchEvent>;
+    "on:touchend"?: EventHandlerUnion<T, TouchEvent>;
+    "on:touchmove"?: EventHandlerUnion<T, TouchEvent>;
+    "on:touchstart"?: EventHandlerUnion<T, TouchEvent>;
+    "on:transitionstart"?: EventHandlerUnion<T, TransitionEvent>;
+    "on:transitionend"?: EventHandlerUnion<T, TransitionEvent>;
+    "on:transitionrun"?: EventHandlerUnion<T, TransitionEvent>;
+    "on:transitioncancel"?: EventHandlerUnion<T, TransitionEvent>;
+    "on:volumechange"?: EventHandlerUnion<T, Event>;
+    "on:waiting"?: EventHandlerUnion<T, Event>;
+    "on:wheel"?: EventHandlerUnion<T, WheelEvent>;
   }
 
   interface CSSProperties extends csstype.PropertiesHyphen {
@@ -395,145 +474,203 @@ export namespace JSX {
 
   // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
   interface AriaAttributes {
-    /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
+    /**
+     * Identifies the currently active element when DOM focus is on a composite widget, textbox,
+     * group, or application.
+     */
     "aria-activedescendant"?: string;
-    /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
+    /**
+     * Indicates whether assistive technologies will present all, or only parts of, the changed
+     * region based on the change notifications defined by the aria-relevant attribute.
+     */
     "aria-atomic"?: boolean | "false" | "true";
     /**
-     * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
-     * presented if they are made.
+     * Indicates whether inputting text could trigger display of one or more predictions of the
+     * user's intended value for an input and specifies how predictions would be presented if they
+     * are made.
      */
     "aria-autocomplete"?: "none" | "inline" | "list" | "both";
-    /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
+    /**
+     * Indicates an element is being modified and that assistive technologies MAY want to wait until
+     * the modifications are complete before exposing them to the user.
+     */
     "aria-busy"?: boolean | "false" | "true";
     /**
      * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+     *
      * @see aria-pressed @see aria-selected.
      */
     "aria-checked"?: boolean | "false" | "mixed" | "true";
     /**
      * Defines the total number of columns in a table, grid, or treegrid.
+     *
      * @see aria-colindex.
      */
     "aria-colcount"?: number | string;
     /**
-     * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+     * Defines an element's column index or position with respect to the total number of columns
+     * within a table, grid, or treegrid.
+     *
      * @see aria-colcount @see aria-colspan.
      */
     "aria-colindex"?: number | string;
     /**
-     * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+     * Defines the number of columns spanned by a cell or gridcell within a table, grid, or
+     * treegrid.
+     *
      * @see aria-colindex @see aria-rowspan.
      */
     "aria-colspan"?: number | string;
     /**
-     * Identifies the element (or elements) whose contents or presence are controlled by the current element.
+     * Identifies the element (or elements) whose contents or presence are controlled by the current
+     * element.
+     *
      * @see aria-owns.
      */
     "aria-controls"?: string;
-    /** Indicates the element that represents the current item within a container or set of related elements. */
+    /**
+     * Indicates the element that represents the current item within a container or set of related
+     * elements.
+     */
     "aria-current"?: boolean | "false" | "true" | "page" | "step" | "location" | "date" | "time";
     /**
      * Identifies the element (or elements) that describes the object.
+     *
      * @see aria-labelledby
      */
     "aria-describedby"?: string;
     /**
      * Identifies the element that provides a detailed, extended description for the object.
+     *
      * @see aria-describedby.
      */
     "aria-details"?: string;
     /**
-     * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+     * Indicates that the element is perceivable but disabled, so it is not editable or otherwise
+     * operable.
+     *
      * @see aria-hidden @see aria-readonly.
      */
     "aria-disabled"?: boolean | "false" | "true";
     /**
-     * Indicates what functions can be performed when a dragged object is released on the drop target.
-     * @deprecated in ARIA 1.1
+     * Indicates what functions can be performed when a dragged object is released on the drop
+     * target.
+     *
+     * @deprecated In ARIA 1.1
      */
     "aria-dropeffect"?: "none" | "copy" | "execute" | "link" | "move" | "popup";
     /**
      * Identifies the element that provides an error message for the object.
+     *
      * @see aria-invalid @see aria-describedby.
      */
     "aria-errormessage"?: string;
-    /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
+    /**
+     * Indicates whether the element, or another grouping element it controls, is currently expanded
+     * or collapsed.
+     */
     "aria-expanded"?: boolean | "false" | "true";
     /**
-     * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
-     * allows assistive technology to override the general default of reading in document source order.
+     * Identifies the next element (or elements) in an alternate reading order of content which, at
+     * the user's discretion, allows assistive technology to override the general default of reading
+     * in document source order.
      */
     "aria-flowto"?: string;
     /**
      * Indicates an element's "grabbed" state in a drag-and-drop operation.
-     * @deprecated in ARIA 1.1
+     *
+     * @deprecated In ARIA 1.1
      */
     "aria-grabbed"?: boolean | "false" | "true";
-    /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
+    /**
+     * Indicates the availability and type of interactive popup element, such as menu or dialog,
+     * that can be triggered by an element.
+     */
     "aria-haspopup"?: boolean | "false" | "true" | "menu" | "listbox" | "tree" | "grid" | "dialog";
     /**
      * Indicates whether the element is exposed to an accessibility API.
+     *
      * @see aria-disabled.
      */
     "aria-hidden"?: boolean | "false" | "true";
     /**
      * Indicates the entered value does not conform to the format expected by the application.
+     *
      * @see aria-errormessage.
      */
     "aria-invalid"?: boolean | "false" | "true" | "grammar" | "spelling";
-    /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
+    /**
+     * Indicates keyboard shortcuts that an author has implemented to activate or give focus to an
+     * element.
+     */
     "aria-keyshortcuts"?: string;
     /**
      * Defines a string value that labels the current element.
+     *
      * @see aria-labelledby.
      */
     "aria-label"?: string;
     /**
      * Identifies the element (or elements) that labels the current element.
+     *
      * @see aria-describedby.
      */
     "aria-labelledby"?: string;
     /** Defines the hierarchical level of an element within a structure. */
     "aria-level"?: number | string;
-    /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
+    /**
+     * Indicates that an element will be updated, and describes the types of updates the user
+     * agents, assistive technologies, and user can expect from the live region.
+     */
     "aria-live"?: "off" | "assertive" | "polite";
     /** Indicates whether an element is modal when displayed. */
     "aria-modal"?: boolean | "false" | "true";
     /** Indicates whether a text box accepts multiple lines of input or only a single line. */
     "aria-multiline"?: boolean | "false" | "true";
-    /** Indicates that the user may select more than one item from the current selectable descendants. */
+    /**
+     * Indicates that the user may select more than one item from the current selectable
+     * descendants.
+     */
     "aria-multiselectable"?: boolean | "false" | "true";
     /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
     "aria-orientation"?: "horizontal" | "vertical";
     /**
-     * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
-     * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+     * Identifies an element (or elements) in order to define a visual, functional, or contextual
+     * parent/child relationship between DOM elements where the DOM hierarchy cannot be used to
+     * represent the relationship.
+     *
      * @see aria-controls.
      */
     "aria-owns"?: string;
     /**
-     * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
-     * A hint could be a sample value or a brief description of the expected format.
+     * Defines a short hint (a word or short phrase) intended to aid the user with data entry when
+     * the control has no value. A hint could be a sample value or a brief description of the
+     * expected format.
      */
     "aria-placeholder"?: string;
     /**
-     * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+     * Defines an element's number or position in the current set of listitems or treeitems. Not
+     * required if all elements in the set are present in the DOM.
+     *
      * @see aria-setsize.
      */
     "aria-posinset"?: number | string;
     /**
      * Indicates the current "pressed" state of toggle buttons.
+     *
      * @see aria-checked @see aria-selected.
      */
     "aria-pressed"?: boolean | "false" | "mixed" | "true";
     /**
      * Indicates that the element is not editable, but is otherwise operable.
+     *
      * @see aria-disabled.
      */
     "aria-readonly"?: boolean | "false" | "true";
     /**
-     * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+     * Indicates what notifications the user agent will trigger when the accessibility tree within a
+     * live region is modified.
+     *
      * @see aria-atomic.
      */
     "aria-relevant"?:
@@ -553,26 +690,33 @@ export namespace JSX {
     "aria-roledescription"?: string;
     /**
      * Defines the total number of rows in a table, grid, or treegrid.
+     *
      * @see aria-rowindex.
      */
     "aria-rowcount"?: number | string;
     /**
-     * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+     * Defines an element's row index or position with respect to the total number of rows within a
+     * table, grid, or treegrid.
+     *
      * @see aria-rowcount @see aria-rowspan.
      */
     "aria-rowindex"?: number | string;
     /**
      * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+     *
      * @see aria-rowindex @see aria-colspan.
      */
     "aria-rowspan"?: number | string;
     /**
      * Indicates the current "selected" state of various widgets.
+     *
      * @see aria-checked @see aria-pressed.
      */
     "aria-selected"?: boolean | "false" | "true";
     /**
-     * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+     * Defines the number of items in the current set of listitems or treeitems. Not required if all
+     * elements in the set are present in the DOM.
+     *
      * @see aria-posinset.
      */
     "aria-setsize"?: number | string;
@@ -584,6 +728,7 @@ export namespace JSX {
     "aria-valuemin"?: number | string;
     /**
      * Defines the current value for a range widget.
+     *
      * @see aria-valuetext.
      */
     "aria-valuenow"?: number | string;
@@ -1918,9 +2063,7 @@ export namespace JSX {
     textLength?: FunctionMaybe<number | string>;
     lengthAdjust?: FunctionMaybe<"spacing" | "spacingAndGlyphs">;
   }
-  /**
-   * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
-   */
+  /** @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use */
   interface UseSVGAttributes<T>
     extends CoreSVGAttributes<T>,
       StylableSVGAttributes,
@@ -1942,9 +2085,7 @@ export namespace JSX {
       ZoomAndPanSVGAttributes {
     viewTarget?: FunctionMaybe<string>;
   }
-  /**
-   * @type {HTMLElementTagNameMap}
-   */
+  /** @type {HTMLElementTagNameMap} */
   interface HTMLElementTags {
     a: AnchorHTMLAttributes<HTMLAnchorElement>;
     abbr: HTMLAttributes<HTMLElement>;
@@ -2059,9 +2200,7 @@ export namespace JSX {
     video: VideoHTMLAttributes<HTMLVideoElement>;
     wbr: HTMLAttributes<HTMLElement>;
   }
-  /**
-   * @type {HTMLElementDeprecatedTagNameMap}
-   */
+  /** @type {HTMLElementDeprecatedTagNameMap} */
   interface HTMLElementDeprecatedTags {
     big: HTMLAttributes<HTMLElement>;
     keygen: KeygenHTMLAttributes<HTMLElement>;
@@ -2069,9 +2208,7 @@ export namespace JSX {
     noindex: HTMLAttributes<HTMLElement>;
     param: ParamHTMLAttributes<HTMLParamElement>;
   }
-  /**
-   * @type {SVGElementTagNameMap}
-   */
+  /** @type {SVGElementTagNameMap} */
   interface SVGElementTags {
     animate: AnimateSVGAttributes<SVGAnimateElement>;
     animateMotion: AnimateMotionSVGAttributes<SVGAnimateMotionElement>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -157,9 +157,7 @@ export namespace JSX {
   interface ExplicitAttributes {}
   interface ExplicitBoolAttributes {}
   interface CustomEvents {}
-  /**
-   * @deprecated Replaced by CustomEvents
-  */
+  /** @deprecated Replaced by CustomEvents */
   interface CustomCaptureEvents {}
   type DirectiveAttributes = {
     [Key in keyof Directives as `use:${Key}`]?: Directives[Key];
@@ -316,9 +314,7 @@ export namespace JSX {
     onWaiting?: EventHandlerUnion<T, Event> | undefined;
     onWheel?: EventHandlerUnion<T, WheelEvent> | undefined;
   }
-  /**
-   * @type {GlobalEventHandlers}
-   */
+  /** @type {GlobalEventHandlers} */
   interface CustomEventHandlersLowerCase<T> {
     onabort?: EventHandlerUnion<T, Event> | undefined;
     onanimationend?: EventHandlerUnion<T, AnimationEvent> | undefined;
@@ -452,43 +448,64 @@ export namespace JSX {
 
   // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
   interface AriaAttributes {
-    /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
+    /**
+     * Identifies the currently active element when DOM focus is on a composite widget, textbox,
+     * group, or application.
+     */
     "aria-activedescendant"?: string | undefined;
-    /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
+    /**
+     * Indicates whether assistive technologies will present all, or only parts of, the changed
+     * region based on the change notifications defined by the aria-relevant attribute.
+     */
     "aria-atomic"?: boolean | "false" | "true" | undefined;
     /**
-     * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
-     * presented if they are made.
+     * Indicates whether inputting text could trigger display of one or more predictions of the
+     * user's intended value for an input and specifies how predictions would be presented if they
+     * are made.
      */
     "aria-autocomplete"?: "none" | "inline" | "list" | "both" | undefined;
-    /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
+    /**
+     * Indicates an element is being modified and that assistive technologies MAY want to wait until
+     * the modifications are complete before exposing them to the user.
+     */
     "aria-busy"?: boolean | "false" | "true" | undefined;
     /**
      * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+     *
      * @see aria-pressed @see aria-selected.
      */
     "aria-checked"?: boolean | "false" | "mixed" | "true" | undefined;
     /**
      * Defines the total number of columns in a table, grid, or treegrid.
+     *
      * @see aria-colindex.
      */
     "aria-colcount"?: number | string | undefined;
     /**
-     * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+     * Defines an element's column index or position with respect to the total number of columns
+     * within a table, grid, or treegrid.
+     *
      * @see aria-colcount @see aria-colspan.
      */
     "aria-colindex"?: number | string | undefined;
     /**
-     * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+     * Defines the number of columns spanned by a cell or gridcell within a table, grid, or
+     * treegrid.
+     *
      * @see aria-colindex @see aria-rowspan.
      */
     "aria-colspan"?: number | string | undefined;
     /**
-     * Identifies the element (or elements) whose contents or presence are controlled by the current element.
+     * Identifies the element (or elements) whose contents or presence are controlled by the current
+     * element.
+     *
      * @see aria-owns.
      */
     "aria-controls"?: string | undefined;
-    /** Indicates the element that represents the current item within a container or set of related elements. */
+    /**
+     * Indicates the element that represents the current item within a container or set of related
+     * elements.
+     */
     "aria-current"?:
       | boolean
       | "false"
@@ -501,42 +518,57 @@ export namespace JSX {
       | undefined;
     /**
      * Identifies the element (or elements) that describes the object.
+     *
      * @see aria-labelledby
      */
     "aria-describedby"?: string | undefined;
     /**
      * Identifies the element that provides a detailed, extended description for the object.
+     *
      * @see aria-describedby.
      */
     "aria-details"?: string | undefined;
     /**
-     * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+     * Indicates that the element is perceivable but disabled, so it is not editable or otherwise
+     * operable.
+     *
      * @see aria-hidden @see aria-readonly.
      */
     "aria-disabled"?: boolean | "false" | "true" | undefined;
     /**
-     * Indicates what functions can be performed when a dragged object is released on the drop target.
-     * @deprecated in ARIA 1.1
+     * Indicates what functions can be performed when a dragged object is released on the drop
+     * target.
+     *
+     * @deprecated In ARIA 1.1
      */
     "aria-dropeffect"?: "none" | "copy" | "execute" | "link" | "move" | "popup" | undefined;
     /**
      * Identifies the element that provides an error message for the object.
+     *
      * @see aria-invalid @see aria-describedby.
      */
     "aria-errormessage"?: string | undefined;
-    /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
+    /**
+     * Indicates whether the element, or another grouping element it controls, is currently expanded
+     * or collapsed.
+     */
     "aria-expanded"?: boolean | "false" | "true" | undefined;
     /**
-     * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
-     * allows assistive technology to override the general default of reading in document source order.
+     * Identifies the next element (or elements) in an alternate reading order of content which, at
+     * the user's discretion, allows assistive technology to override the general default of reading
+     * in document source order.
      */
     "aria-flowto"?: string | undefined;
     /**
      * Indicates an element's "grabbed" state in a drag-and-drop operation.
-     * @deprecated in ARIA 1.1
+     *
+     * @deprecated In ARIA 1.1
      */
     "aria-grabbed"?: boolean | "false" | "true" | undefined;
-    /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
+    /**
+     * Indicates the availability and type of interactive popup element, such as menu or dialog,
+     * that can be triggered by an element.
+     */
     "aria-haspopup"?:
       | boolean
       | "false"
@@ -549,66 +581,88 @@ export namespace JSX {
       | undefined;
     /**
      * Indicates whether the element is exposed to an accessibility API.
+     *
      * @see aria-disabled.
      */
     "aria-hidden"?: boolean | "false" | "true" | undefined;
     /**
      * Indicates the entered value does not conform to the format expected by the application.
+     *
      * @see aria-errormessage.
      */
     "aria-invalid"?: boolean | "false" | "true" | "grammar" | "spelling" | undefined;
-    /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
+    /**
+     * Indicates keyboard shortcuts that an author has implemented to activate or give focus to an
+     * element.
+     */
     "aria-keyshortcuts"?: string | undefined;
     /**
      * Defines a string value that labels the current element.
+     *
      * @see aria-labelledby.
      */
     "aria-label"?: string | undefined;
     /**
      * Identifies the element (or elements) that labels the current element.
+     *
      * @see aria-describedby.
      */
     "aria-labelledby"?: string | undefined;
     /** Defines the hierarchical level of an element within a structure. */
     "aria-level"?: number | string | undefined;
-    /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
+    /**
+     * Indicates that an element will be updated, and describes the types of updates the user
+     * agents, assistive technologies, and user can expect from the live region.
+     */
     "aria-live"?: "off" | "assertive" | "polite" | undefined;
     /** Indicates whether an element is modal when displayed. */
     "aria-modal"?: boolean | "false" | "true" | undefined;
     /** Indicates whether a text box accepts multiple lines of input or only a single line. */
     "aria-multiline"?: boolean | "false" | "true" | undefined;
-    /** Indicates that the user may select more than one item from the current selectable descendants. */
+    /**
+     * Indicates that the user may select more than one item from the current selectable
+     * descendants.
+     */
     "aria-multiselectable"?: boolean | "false" | "true" | undefined;
     /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
     "aria-orientation"?: "horizontal" | "vertical" | undefined;
     /**
-     * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
-     * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+     * Identifies an element (or elements) in order to define a visual, functional, or contextual
+     * parent/child relationship between DOM elements where the DOM hierarchy cannot be used to
+     * represent the relationship.
+     *
      * @see aria-controls.
      */
     "aria-owns"?: string | undefined;
     /**
-     * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
-     * A hint could be a sample value or a brief description of the expected format.
+     * Defines a short hint (a word or short phrase) intended to aid the user with data entry when
+     * the control has no value. A hint could be a sample value or a brief description of the
+     * expected format.
      */
     "aria-placeholder"?: string | undefined;
     /**
-     * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+     * Defines an element's number or position in the current set of listitems or treeitems. Not
+     * required if all elements in the set are present in the DOM.
+     *
      * @see aria-setsize.
      */
     "aria-posinset"?: number | string | undefined;
     /**
      * Indicates the current "pressed" state of toggle buttons.
+     *
      * @see aria-checked @see aria-selected.
      */
     "aria-pressed"?: boolean | "false" | "mixed" | "true" | undefined;
     /**
      * Indicates that the element is not editable, but is otherwise operable.
+     *
      * @see aria-disabled.
      */
     "aria-readonly"?: boolean | "false" | "true" | undefined;
     /**
-     * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+     * Indicates what notifications the user agent will trigger when the accessibility tree within a
+     * live region is modified.
+     *
      * @see aria-atomic.
      */
     "aria-relevant"?:
@@ -629,26 +683,33 @@ export namespace JSX {
     "aria-roledescription"?: string | undefined;
     /**
      * Defines the total number of rows in a table, grid, or treegrid.
+     *
      * @see aria-rowindex.
      */
     "aria-rowcount"?: number | string | undefined;
     /**
-     * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+     * Defines an element's row index or position with respect to the total number of rows within a
+     * table, grid, or treegrid.
+     *
      * @see aria-rowcount @see aria-rowspan.
      */
     "aria-rowindex"?: number | string | undefined;
     /**
      * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+     *
      * @see aria-rowindex @see aria-colspan.
      */
     "aria-rowspan"?: number | string | undefined;
     /**
      * Indicates the current "selected" state of various widgets.
+     *
      * @see aria-checked @see aria-pressed.
      */
     "aria-selected"?: boolean | "false" | "true" | undefined;
     /**
-     * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+     * Defines the number of items in the current set of listitems or treeitems. Not required if all
+     * elements in the set are present in the DOM.
+     *
      * @see aria-posinset.
      */
     "aria-setsize"?: number | string | undefined;
@@ -660,6 +721,7 @@ export namespace JSX {
     "aria-valuemin"?: number | string | undefined;
     /**
      * Defines the current value for a range widget.
+     *
      * @see aria-valuetext.
      */
     "aria-valuenow"?: number | string | undefined;
@@ -2040,9 +2102,7 @@ export namespace JSX {
     textLength?: number | string | undefined;
     lengthAdjust?: "spacing" | "spacingAndGlyphs" | undefined;
   }
-  /**
-   * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
-   */
+  /** @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use */
   interface UseSVGAttributes<T>
     extends CoreSVGAttributes<T>,
       StylableSVGAttributes,
@@ -2064,9 +2124,7 @@ export namespace JSX {
       ZoomAndPanSVGAttributes {
     viewTarget?: string | undefined;
   }
-  /**
-   * @type {HTMLElementTagNameMap}
-   */
+  /** @type {HTMLElementTagNameMap} */
   interface HTMLElementTags {
     a: AnchorHTMLAttributes<HTMLAnchorElement>;
     abbr: HTMLAttributes<HTMLElement>;
@@ -2181,9 +2239,7 @@ export namespace JSX {
     video: VideoHTMLAttributes<HTMLVideoElement>;
     wbr: HTMLAttributes<HTMLElement>;
   }
-  /**
-   * @type {HTMLElementDeprecatedTagNameMap}
-   */
+  /** @type {HTMLElementDeprecatedTagNameMap} */
   interface HTMLElementDeprecatedTags {
     big: HTMLAttributes<HTMLElement>;
     keygen: KeygenHTMLAttributes<HTMLElement>;
@@ -2191,9 +2247,7 @@ export namespace JSX {
     noindex: HTMLAttributes<HTMLElement>;
     param: ParamHTMLAttributes<HTMLParamElement>;
   }
-  /**
-   * @type {SVGElementTagNameMap}
-   */
+  /** @type {SVGElementTagNameMap} */
   interface SVGElementTags {
     animate: AnimateSVGAttributes<SVGAnimateElement>;
     animateMotion: AnimateMotionSVGAttributes<SVGAnimateMotionElement>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -205,7 +205,8 @@ export namespace JSX {
       OnAttributes<T>,
       OnCaptureAttributes<T>,
       CustomEventHandlersCamelCase<T>,
-      CustomEventHandlersLowerCase<T> {
+      CustomEventHandlersLowerCase<T>,
+      CustomEventHandlersNamespaced<T> {
     children?: Element | undefined;
     innerHTML?: string | undefined;
     innerText?: string | number | undefined;
@@ -232,6 +233,17 @@ export namespace JSX {
     onfocusin?: FocusEventHandlerUnion<T, FocusEvent> | undefined;
     onencrypted?: EventHandlerUnion<T, Event> | undefined;
     ondragexit?: EventHandlerUnion<T, DragEvent> | undefined;
+    // lower case events
+    "on:copy"?: EventHandlerUnion<T, ClipboardEvent> | undefined;
+    "on:cut"?: EventHandlerUnion<T, ClipboardEvent> | undefined;
+    "on:paste"?: EventHandlerUnion<T, ClipboardEvent> | undefined;
+    "on:compositionend"?: EventHandlerUnion<T, CompositionEvent> | undefined;
+    "on:compositionstart"?: EventHandlerUnion<T, CompositionEvent> | undefined;
+    "on:compositionupdate"?: EventHandlerUnion<T, CompositionEvent> | undefined;
+    "on:focusout"?: FocusEventHandlerUnion<T, FocusEvent> | undefined;
+    "on:focusin"?: FocusEventHandlerUnion<T, FocusEvent> | undefined;
+    "on:encrypted"?: EventHandlerUnion<T, Event> | undefined;
+    "on:dragexit"?: EventHandlerUnion<T, DragEvent> | undefined;
   }
   interface CustomEventHandlersCamelCase<T> {
     onAbort?: EventHandlerUnion<T, Event> | undefined;
@@ -395,6 +407,87 @@ export namespace JSX {
     onvolumechange?: EventHandlerUnion<T, Event> | undefined;
     onwaiting?: EventHandlerUnion<T, Event> | undefined;
     onwheel?: EventHandlerUnion<T, WheelEvent> | undefined;
+  }
+  interface CustomEventHandlersNamespaced<T> {
+    "on:abort"?: EventHandlerUnion<T, Event> | undefined;
+    "on:animationend"?: EventHandlerUnion<T, AnimationEvent> | undefined;
+    "on:animationiteration"?: EventHandlerUnion<T, AnimationEvent> | undefined;
+    "on:animationstart"?: EventHandlerUnion<T, AnimationEvent> | undefined;
+    "on:auxclick"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:beforeinput"?: InputEventHandlerUnion<T, InputEvent> | undefined;
+    "on:beforetoggle"?: EventHandlerUnion<T, ToggleEvent> | undefined;
+    "on:blur"?: FocusEventHandlerUnion<T, FocusEvent> | undefined;
+    "on:canplay"?: EventHandlerUnion<T, Event> | undefined;
+    "on:canplaythrough"?: EventHandlerUnion<T, Event> | undefined;
+    "on:change"?: ChangeEventHandlerUnion<T, Event> | undefined;
+    "on:click"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:contextmenu"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:dblclick"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:drag"?: EventHandlerUnion<T, DragEvent> | undefined;
+    "on:dragend"?: EventHandlerUnion<T, DragEvent> | undefined;
+    "on:dragenter"?: EventHandlerUnion<T, DragEvent> | undefined;
+    "on:dragleave"?: EventHandlerUnion<T, DragEvent> | undefined;
+    "on:dragover"?: EventHandlerUnion<T, DragEvent> | undefined;
+    "on:dragstart"?: EventHandlerUnion<T, DragEvent> | undefined;
+    "on:drop"?: EventHandlerUnion<T, DragEvent> | undefined;
+    "on:durationchange"?: EventHandlerUnion<T, Event> | undefined;
+    "on:emptied"?: EventHandlerUnion<T, Event> | undefined;
+    "on:ended"?: EventHandlerUnion<T, Event> | undefined;
+    "on:error"?: EventHandlerUnion<T, Event> | undefined;
+    "on:focus"?: FocusEventHandlerUnion<T, FocusEvent> | undefined;
+    "on:gotpointercapture"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:input"?: InputEventHandlerUnion<T, InputEvent> | undefined;
+    "on:invalid"?: EventHandlerUnion<T, Event> | undefined;
+    "on:keydown"?: EventHandlerUnion<T, KeyboardEvent> | undefined;
+    "on:keypress"?: EventHandlerUnion<T, KeyboardEvent> | undefined;
+    "on:keyup"?: EventHandlerUnion<T, KeyboardEvent> | undefined;
+    "on:load"?: EventHandlerUnion<T, Event> | undefined;
+    "on:loadeddata"?: EventHandlerUnion<T, Event> | undefined;
+    "on:loadedmetadata"?: EventHandlerUnion<T, Event> | undefined;
+    "on:loadstart"?: EventHandlerUnion<T, Event> | undefined;
+    "on:lostpointercapture"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:mousedown"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:mouseenter"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:mouseleave"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:mousemove"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:mouseout"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:mouseover"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:mouseup"?: EventHandlerUnion<T, MouseEvent> | undefined;
+    "on:pause"?: EventHandlerUnion<T, Event> | undefined;
+    "on:play"?: EventHandlerUnion<T, Event> | undefined;
+    "on:playing"?: EventHandlerUnion<T, Event> | undefined;
+    "on:pointercancel"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:pointerdown"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:pointerenter"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:pointerleave"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:pointermove"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:pointerout"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:pointerover"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:pointerup"?: EventHandlerUnion<T, PointerEvent> | undefined;
+    "on:progress"?: EventHandlerUnion<T, ProgressEvent> | undefined;
+    "on:ratechange"?: EventHandlerUnion<T, Event> | undefined;
+    "on:reset"?: EventHandlerUnion<T, Event> | undefined;
+    "on:scroll"?: EventHandlerUnion<T, Event> | undefined;
+    "on:scrollend"?: EventHandlerUnion<T, Event> | undefined;
+    "on:seeked"?: EventHandlerUnion<T, Event> | undefined;
+    "on:seeking"?: EventHandlerUnion<T, Event> | undefined;
+    "on:select"?: EventHandlerUnion<T, Event> | undefined;
+    "on:stalled"?: EventHandlerUnion<T, Event> | undefined;
+    "on:submit"?: EventHandlerUnion<T, SubmitEvent> | undefined;
+    "on:suspend"?: EventHandlerUnion<T, Event> | undefined;
+    "on:timeupdate"?: EventHandlerUnion<T, Event> | undefined;
+    "on:toggle"?: EventHandlerUnion<T, ToggleEvent> | undefined;
+    "on:touchcancel"?: EventHandlerUnion<T, TouchEvent> | undefined;
+    "on:touchend"?: EventHandlerUnion<T, TouchEvent> | undefined;
+    "on:touchmove"?: EventHandlerUnion<T, TouchEvent> | undefined;
+    "on:touchstart"?: EventHandlerUnion<T, TouchEvent> | undefined;
+    "on:transitionstart"?: EventHandlerUnion<T, TransitionEvent> | undefined;
+    "on:transitionend"?: EventHandlerUnion<T, TransitionEvent> | undefined;
+    "on:transitionrun"?: EventHandlerUnion<T, TransitionEvent> | undefined;
+    "on:transitioncancel"?: EventHandlerUnion<T, TransitionEvent> | undefined;
+    "on:volumechange"?: EventHandlerUnion<T, Event> | undefined;
+    "on:waiting"?: EventHandlerUnion<T, Event> | undefined;
+    "on:wheel"?: EventHandlerUnion<T, WheelEvent> | undefined;
   }
 
   interface CSSProperties extends csstype.PropertiesHyphen {


### PR DESCRIPTION
It adds the namespaced version of the default events. such `on:click`. There is probably some clever way to avoid duplication, but I preferred to follow how is it done. 

I'm not sure what will happen if someone tries to define an event with the same name, I suppose we can move the location of the `extends CustomEventHandlersNamespaced<T>` if that's reported as an issue.. and that will fix it? 🤔 

Somehow prettier formatted the jsdoc comments, I suspect a plugin I have installed, it shouldn't cause issues with the regular formatting as it won't touch comment contents.

closes https://github.com/solidjs/solid/issues/1939

asked for input in the TS channel and seems like a good idea to include this https://discord.com/channels/722131463138705510/783844647528955931/1291147473011736613