### PR TITLE
slim down `jsdom` dependency to `parse5`

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/package.json
+++ b/packages/babel-plugin-jsx-dom-expressions/package.json
@@ -24,7 +24,7 @@
     "@babel/types": "^7.20.7",
     "html-entities": "2.3.3",
     "jest-diff": "^29.7.0",
-    "jsdom": "^25.0.0",
+    "parse5": "^7.1.2",
     "validate-html-nesting": "^1.2.1"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
@@ -1,10 +1,19 @@
-// fix me: jsdom crashes without this
-const util = require("util");
-const { TextEncoder, TextDecoder } = util;
-Object.assign(global, { TextDecoder, TextEncoder });
+// import parse5 from "parse5";
+const parse5 = require("parse5");
 
-const JSDOM = require("jsdom").JSDOM;
-const Element = new JSDOM(`<!DOCTYPE html>`).window.document.body;
+/** `bodyElement` will be used as a `context` (The place where we run `innerHTML`) */
+const bodyElement = parse5.parse(
+  `<!DOCTYPE html><html><head></head><body></body></html>`
+  // @ts-ignore
+).childNodes[1].childNodes[1];
+
+function innerHTML(htmlFragment) {
+  /** `htmlFragment` will be parsed as if it was set to the `bodyElement`'s `innerHTML` property. */
+  const parsedFragment = parse5.parseFragment(bodyElement, htmlFragment);
+
+  /** `serialize` returns back a string from the parsed nodes */
+  return parse5.serialize(parsedFragment);
+}
 
 /**
  * Returns an object with information when the markup is invalid
@@ -48,10 +57,8 @@ export function isInvalidMarkup(html) {
     .replace(/^<td>/i, "<table><tbody><tr><td>")
     .replace(/<\/td>$/i, "</td></tr></tbody></table>");
 
-  // parse
-  Element.innerHTML = html;
-  // result
-  const browser = Element.innerHTML;
+  /** Parse HTML. `browser` is a string with the supposed resulting html of a real `innerHTML` call */
+  const browser = innerHTML(html);
 
   if (html !== browser) {
     return {


### PR DESCRIPTION
Issue: jsdom imports a ton of stuff. This is usually not a problem as it's been treeshaked from the different build tools. But it causes an issue when you are trying to use the `babel-solid-preset` entirely in the browser. For example `jsdom` imports `child_process`, that just doesn't exist in the browser, and places like `esm.sh` cannot treeshake it because it doesn't know if it is going to be used or not. This is causing problems to projects like https://github.com/bigmistqke/repl and possibly some others.
 
Upon investigation, it seems that `jsdom` it's using behind the scenes `parse5`. So trying to slim down the dependencies I replaced it with that.  This also gives me more confidence into the approach taken to validate the HTML because the functions from `parse5` actually claim they are mirroring `innerHTML` behaviour.

Links:
jsdom importing parse5
https://github.com/jsdom/jsdom/blob/04541b377d9949d6ab56866760b7883a23db0577/lib/jsdom/browser/parser/html.js#L3

claim that should do the same as `innerHTML`
https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/index.ts#L64

I have updated my transform to use parse5 too, so its been tested on my stuff besides `npm run test` on the babel plugin
https://github.com/potahtml/pota/blob/master/babel-preset/transform/validate.js

We will appreciate please a patch release(whenever there's time and that's possible) so projects like https://github.com/bigmistqke/repl can continue development.

~~Lastly, we are not entirely sure if this will actually fix the "use in browser issue", but it will narrow it greatly to investigate further in case that's necessary.~~ I can confirm it works entirely in the browser

Thanks!
