### PR TITLE
Update special cases for tables

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
@@ -34,7 +34,7 @@ export function isInvalidMarkup(html) {
     .replace(/>[^<]+</gi, ">#text<")
 
     // remove attributes (the lack of quotes will make it mismatch)
-    .replace(/<([a-z0-9-:]+)\s+[^>]+>/gi, "<$1>")
+    .replace(/<([a-z0-9-]+)\s+[^>]+>/gi, "<$1>")
 
     // fix escaping, so doesnt mess up the validation
     // `&lt;script>a();&lt;/script>` -> `&lt;script&gt;a();&lt;/script&gt;`

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
@@ -46,7 +46,25 @@ export function isInvalidMarkup(html) {
     .replace(/<\/tr>$/i, "</tr></tbody></table>")
     // fix tables cells
     .replace(/^<td>/i, "<table><tbody><tr><td>")
-    .replace(/<\/td>$/i, "</td></tr></tbody></table>");
+    .replace(/<\/td>$/i, "</td></tr></tbody></table>")
+    .replace(/^<th>/i, "<table><thead><tr><th>")
+    .replace(/<\/th>$/i, "</th></tr></thead></table>")
+    // fix table components
+    .replace(/^<thead>/i, "<table><thead>")
+    .replace(/<\/thead>$/i, "</thead></table>")
+    .replace(/^<tbody>/i, "<table><tbody>")
+    .replace(/<\/tbody>$/i, "</tbody></table>");
+
+  // skip when equal to:
+  switch (html) {
+    // empty table components
+    case "<table></table>":
+    case "<table><thead></thead></table>":
+    case "<table><tbody></tbody></table>":
+    case "<table><thead></thead><tbody></tbody></table>": {
+      return;
+    }
+  }
 
   // parse
   Element.innerHTML = html;

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
@@ -34,7 +34,7 @@ export function isInvalidMarkup(html) {
     .replace(/>[^<]+</gi, ">#text<")
 
     // remove attributes (the lack of quotes will make it mismatch)
-    .replace(/<([a-z0-9-]+)\s+[^>]+>/gi, "<$1>")
+    .replace(/<([a-z0-9-:]+)\s+[^>]+>/gi, "<$1>")
 
     // fix escaping, so doesnt mess up the validation
     // `&lt;script>a();&lt;/script>` -> `&lt;script&gt;a();&lt;/script&gt;`


### PR DESCRIPTION
Adds to the validation `th/thead/tbody` which were missing.

Then, we were considering the inner bits as `tr/td`, but didn't consider the outer bits as empty `table/thead/body`, so this is now considered.

The switch case is probably not needed, as it will validate, but maybe could be nice to have a section of skips, it could improve performance.

A bit verbose, but I hope that's all for tables
