### PR TITLE
tagName could have `:` such `<kilo:svg>` 

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
@@ -34,7 +34,7 @@ export function isInvalidMarkup(html) {
     .replace(/>[^<]+</gi, ">#text<")
 
     // remove attributes (the lack of quotes will make it mismatch)
-    .replace(/<([a-z0-9-]+)\s+[^>]+>/gi, "<$1>")
+    .replace(/<([a-z0-9-:]+)\s+[^>]+>/gi, "<$1>")
 
     // fix escaping, so doesnt mess up the validation
     // `&lt;script>a();&lt;/script>` -> `&lt;script&gt;a();&lt;/script&gt;`


### PR DESCRIPTION
This is a small change, but tagNames could contain `:` such `<kilo:svg/>`, this is used sometimes in XML documents, and such a tagName will cause a fail on the removal of attributes and therefore validation as a whole.