### PR TITLE
fix throwing an error when using `<NoHydration>` before `sharedConfig.context` is initialised

### DIFF
--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -536,7 +536,8 @@ export function Hydration(props) {
 }
 
 export function NoHydration(props) {
-  sharedConfig.context.noHydrate = true;
+  if (sharedConfig.context)
+    sharedConfig.context.noHydrate = true;
   return props.children;
 }
 


### PR DESCRIPTION
We are using Solid to generate internal emails and to avoid the unnecessary `data-hk` attributes I wrap them in `<NoHydration>`. This sometimes caused errors to be thrown so we are using this patch in production to avoid that.