### PR TITLE
loosen `classList` attribute type

### DIFF
--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -145,7 +145,7 @@ export namespace JSX {
     ref?: T | ((el: T) => void) | undefined;
     classList?: {
       [k: string]: boolean | undefined;
-    };
+    } | undefined;
     $ServerOnly?: boolean | undefined;
   }
   type Accessor<T> = () => T;


### PR DESCRIPTION
This just makes the `classList` attribute a little more convenient to work with for those who have `exactOptionalPropertyTypes` turned on in their `tsconfig.json`.