### PR TITLE
Add disablepictureinpicture attribute to <video> JSX types

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1246,6 +1246,7 @@ export namespace JSX {
     playsinline?: FunctionMaybe<boolean>;
     poster?: FunctionMaybe<string>;
     width?: FunctionMaybe<number | string>;
+    disablepictureinpicture?: FunctionMaybe<boolean>;
   }
   type SVGPreserveAspectRatio =
     | "none"

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1366,6 +1366,7 @@ export namespace JSX {
     playsinline?: boolean | undefined;
     poster?: string | undefined;
     width?: number | string | undefined;
+    disablepictureinpicture?: boolean;
   }
   type SVGPreserveAspectRatio =
     | "none"


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/disablePictureInPicture

And the list of attributes here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video

<img width="1512" alt="Screenshot 2024-10-21 at 12 11 58" src="https://github.com/user-attachments/assets/d5b5f1f3-7f93-4437-bf4e-f90fa44d8209">
