### PR TITLE
attributes/properties transformation & custom elements defaulting to attributes

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -16,7 +16,6 @@ import {
   registerImportMethod,
   filterChildren,
   toEventName,
-  toPropertyName,
   checkLength,
   getStaticExpression,
   reservedNameSpaces,
@@ -238,8 +237,7 @@ export function setAttr(path, elem, name, value, { isSVG, dynamic, prevId, isCE,
   const isChildProp = ChildProperties.has(name);
   const isProp = Properties.has(name);
   const alias = getPropAlias(name, tagName.toUpperCase());
-  if (namespace !== "attr" && (isChildProp || (!isSVG && isProp) || isCE || namespace === "prop")) {
-    if (isCE && !isChildProp && !isProp && namespace !== "prop") name = toPropertyName(name);
+  if (namespace !== "attr" && (isChildProp || (!isSVG && isProp) || namespace === "prop")) {
     if (config.hydratable && namespace !== "prop") {
       return t.callExpression(registerImportMethod(path, "setProperty"), [elem, t.stringLiteral(name), value]);
     }
@@ -252,7 +250,7 @@ export function setAttr(path, elem, name, value, { isSVG, dynamic, prevId, isCE,
 
   let isNameSpaced = name.indexOf(":") > -1;
   name = Aliases[name] || name;
-  !isSVG && (name = name.toLowerCase());
+  /*!isSVG && (name = name.toLowerCase());*/
   const ns = isNameSpaced && SVGNamespace[name.split(":")[0]];
   if (ns) {
     return t.callExpression(
@@ -797,7 +795,7 @@ function transformAttributes(path, results) {
             t.expressionStatement(setAttr(attribute, elem, key, value, { isSVG, isCE, tagName }))
           );
         } else {
-          !isSVG && (key = key.toLowerCase());
+          /*!isSVG && (key = key.toLowerCase());*/
           results.template += `${needsSpacing ? ' ' : ''}${key}`;
           // https://github.com/solidjs/solid/issues/2338
           // results.templateWithClosingTags += `${needsSpacing ? ' ' : ''}${key}`;

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -224,14 +224,6 @@ export function toEventName(name) {
   return name.slice(2).toLowerCase();
 }
 
-export function toAttributeName(name) {
-  return name.replace(/([A-Z])/g, g => `-${g[0].toLowerCase()}`);
-}
-
-export function toPropertyName(name) {
-  return name.toLowerCase().replace(/-([a-z])/g, (_, w) => w.toUpperCase());
-}
-
 export function wrappedByText(list, startIndex) {
   let index = startIndex,
     wrapped;

--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
@@ -90,7 +90,7 @@ export function transformElement(path, info) {
 
 function toAttribute(key, isSVG) {
   key = Aliases[key] || key;
-  !isSVG && (key = key.toLowerCase());
+  /*!isSVG && (key = key.toLowerCase());*/
   return key;
 }
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/customElements/output.js
@@ -37,8 +37,8 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<my-element>`, true, false),
   );
 const template = (() => {
   var _el$ = _tmpl$();
-  _el$.someAttr = name;
-  _el$.notprop = data;
+  _$setAttribute(_el$, "some-attr", name);
+  _$setAttribute(_el$, "notProp", data);
   _$setAttribute(_el$, "my-attr", data);
   _el$.someProp = data;
   _el$._$owner = _$getOwner();
@@ -53,8 +53,8 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$.e && (_el$2.someAttr = _p$.e = _v$);
-      _v$2 !== _p$.t && (_el$2.notprop = _p$.t = _v$2);
+      _v$ !== _p$.e && _$setAttribute(_el$2, "some-attr", (_p$.e = _v$));
+      _v$2 !== _p$.t && _$setAttribute(_el$2, "notProp", (_p$.t = _v$2));
       _v$3 !== _p$.a && _$setAttribute(_el$2, "my-attr", (_p$.a = _v$3));
       _v$4 !== _p$.o && (_el$2.someProp = _p$.o = _v$4);
       return _p$;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/customElements/output.js
@@ -3,15 +3,14 @@ import { effect as _$effect } from "r-dom";
 import { getNextElement as _$getNextElement } from "r-dom";
 import { getOwner as _$getOwner } from "r-dom";
 import { setAttribute as _$setAttribute } from "r-dom";
-import { setProperty as _$setProperty } from "r-dom";
 var _tmpl$ = /*#__PURE__*/ _$template(`<my-element>`, true, false),
   _tmpl$2 = /*#__PURE__*/ _$template(`<my-element><header slot=head>Title`, true, false),
   _tmpl$3 = /*#__PURE__*/ _$template(`<slot name=head>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<a is=my-element>`, true, false);
 const template = (() => {
   var _el$ = _$getNextElement(_tmpl$);
-  _$setProperty(_el$, "someAttr", name);
-  _$setProperty(_el$, "notprop", data);
+  _$setAttribute(_el$, "some-attr", name);
+  _$setAttribute(_el$, "notProp", data);
   _$setAttribute(_el$, "my-attr", data);
   _el$.someProp = data;
   _el$._$owner = _$getOwner();
@@ -26,8 +25,8 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$.e && _$setProperty(_el$2, "someAttr", (_p$.e = _v$));
-      _v$2 !== _p$.t && _$setProperty(_el$2, "notprop", (_p$.t = _v$2));
+      _v$ !== _p$.e && _$setAttribute(_el$2, "some-attr", (_p$.e = _v$));
+      _v$2 !== _p$.t && _$setAttribute(_el$2, "notProp", (_p$.t = _v$2));
       _v$3 !== _p$.a && _$setAttribute(_el$2, "my-attr", (_p$.a = _v$3));
       _v$4 !== _p$.o && (_el$2.someProp = _p$.o = _v$4);
       return _p$;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/customElements/output.js
@@ -8,8 +8,8 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<my-element>`, true, false),
   _tmpl$4 = /*#__PURE__*/ _$template(`<a is=my-element>`, true, false);
 const template = (() => {
   var _el$ = _tmpl$();
-  _el$.someAttr = name;
-  _el$.notprop = data;
+  _$setAttribute(_el$, "some-attr", name);
+  _$setAttribute(_el$, "notProp", data);
   _$setAttribute(_el$, "my-attr", data);
   _el$.someProp = data;
   _el$._$owner = _$getOwner();
@@ -24,8 +24,8 @@ const template2 = (() => {
         _v$2 = state.data,
         _v$3 = state.data,
         _v$4 = state.data;
-      _v$ !== _p$.e && (_el$2.someAttr = _p$.e = _v$);
-      _v$2 !== _p$.t && (_el$2.notprop = _p$.t = _v$2);
+      _v$ !== _p$.e && _$setAttribute(_el$2, "some-attr", (_p$.e = _v$));
+      _v$2 !== _p$.t && _$setAttribute(_el$2, "notProp", (_p$.t = _v$2));
       _v$3 !== _p$.a && _$setAttribute(_el$2, "my-attr", (_p$.a = _v$3));
       _v$4 !== _p$.o && (_el$2.someProp = _p$.o = _v$4);
       return _p$;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/hybrid/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/hybrid/output.js
@@ -32,7 +32,7 @@ const Child = props => {
           "element",
           (() => {
             var _el$10 = _tmpl$4();
-            _$effect(() => _$setAttribute(_el$10, "backgroundcolor", s() ? "red" : "green"));
+            _$effect(() => _$setAttribute(_el$10, "backgroundColor", s() ? "red" : "green"));
             return _el$10;
           })()
         )
@@ -94,7 +94,7 @@ const Child = props => {
                           (() => {
                             var _el$13 = _tmpl$4();
                             _$effect(() =>
-                              _$setAttribute(_el$13, "backgroundcolor", s() ? "red" : "green")
+                              _$setAttribute(_el$13, "backgroundColor", s() ? "red" : "green")
                             );
                             return _el$13;
                           })()

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/customElements/output.js
@@ -8,13 +8,13 @@ var _tmpl$ = ["<my-element", "></my-element>"],
 const template = _$ssr(
   _tmpl$,
   _$ssrAttribute("some-attr", _$escape(name, true), false) +
-    _$ssrAttribute("notprop", _$escape(data, true), false) +
+    _$ssrAttribute("notProp", _$escape(data, true), false) +
     _$ssrAttribute("my-attr", _$escape(data, true), false)
 );
 const template2 = _$ssr(
   _tmpl$,
   _$ssrAttribute("some-attr", _$escape(state.name, true), false) +
-    _$ssrAttribute("notprop", _$escape(state.data, true), false) +
+    _$ssrAttribute("notProp", _$escape(state.data, true), false) +
     _$ssrAttribute("my-attr", _$escape(state.data, true), false)
 );
 const template3 = _$ssr(_tmpl$2);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/customElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/customElements/output.js
@@ -10,14 +10,14 @@ const template = _$ssr(
   _tmpl$,
   _$ssrHydrationKey() +
     _$ssrAttribute("some-attr", _$escape(name, true), false) +
-    _$ssrAttribute("notprop", _$escape(data, true), false) +
+    _$ssrAttribute("notProp", _$escape(data, true), false) +
     _$ssrAttribute("my-attr", _$escape(data, true), false)
 );
 const template2 = _$ssr(
   _tmpl$,
   _$ssrHydrationKey() +
     _$ssrAttribute("some-attr", _$escape(state.name, true), false) +
-    _$ssrAttribute("notprop", _$escape(state.data, true), false) +
+    _$ssrAttribute("notProp", _$escape(state.data, true), false) +
     _$ssrAttribute("my-attr", _$escape(state.data, true), false)
 );
 const template3 = _$ssr(_tmpl$2, _$ssrHydrationKey());

--- a/packages/lit-dom-expressions/src/index.ts
+++ b/packages/lit-dom-expressions/src/index.ts
@@ -78,10 +78,6 @@ function fullClosing($0: string, $1: string, $2: string) {
   return VOID_ELEMENTS.test($1) ? $0 : "<" + $1 + $2 + "></" + $1 + ">";
 }
 
-function toPropertyName(name: string) {
-  return name.toLowerCase().replace(/-([a-z])/g, (_, w) => w.toUpperCase());
-}
-
 function parseDirective(name: string, value: string, tag: string, options: Options) {
   if (name === 'use:###' && value === '###') {
     const count = options.counter++;
@@ -194,9 +190,8 @@ export function createHTML(r: Runtime, { delegateEvents = true, functionBuilder 
       options.exprs.push(`r.classList(${tag},${expr},${prev})`);
     } else if (
       namespace !== "attr" &&
-      (isChildProp || (!isSVG && (r.getPropAlias(name, node.name.toUpperCase()) || isProp)) || isCE || namespace === "prop")
+      (isChildProp || (!isSVG && (r.getPropAlias(name, node.name.toUpperCase()) || isProp)) ||  namespace === "prop")
     ) {
-      if (isCE && !isChildProp && !isProp && namespace !== "prop") name = toPropertyName(name);
       options.exprs.push(`${tag}.${r.getPropAlias(name, node.name.toUpperCase()) || name} = ${expr}`);
     } else {
       const ns = isSVG && name.indexOf(":") > -1 && r.SVGNamespace[name.split(":")[0]];


### PR DESCRIPTION
It includes two changes:

1. avoids transforming case and dashes for attributes/properties.
2. It doesn't default to `properties` in custom elements. It defaults to `attributes`.

Rationality: Seems like numerous people expect custom elements to just receive attributes  [1](https://discord.com/channels/722131463138705510/1297146159202046003), [2](https://github.com/solidjs/solid/issues/2339), [3](https://github.com/solidjs/solid/discussions/2322#discussion-7274338), [4](https://github.com/solidjs/solid/issues/2321), and they will use `prop:` when they want to set a property. It seems strange wanting to use `prop:`, but it looks to me, they are used to dealing with this sort of problem. Kind of makes sense as attributes can only receive strings.

Avoiding transformation of case and dashes, makes the issue easier to deal with it. I do not think this will cause any problem, as one won't mix up case when using attr/props, so normalizing it is unnecessary and could cause some other [issues](https://github.com/ryansolid/dom-expressions/pull/351) 

If I do not miss anything, this only affects custom-elements.  I suggest merging it whenever possible, as this is something people seem to expect to behave this way. I also would like to recommend merging it as `v1.10.0` to not break and alienate people using the previous behaviour.