### PR TITLE
Add more video attributes

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1079,6 +1079,7 @@ export namespace JSX {
   interface MediaHTMLAttributes<T> extends HTMLAttributes<T> {
     autoplay?: FunctionMaybe<boolean>;
     controls?: FunctionMaybe<boolean>;
+    controlslist?: FunctionMaybe<string>;
     crossorigin?: FunctionMaybe<HTMLCrossorigin>;
     loop?: FunctionMaybe<boolean>;
     mediagroup?: FunctionMaybe<string>;
@@ -1248,6 +1249,7 @@ export namespace JSX {
     poster?: FunctionMaybe<string>;
     width?: FunctionMaybe<number | string>;
     disablepictureinpicture?: FunctionMaybe<boolean>;
+    disableremoteplayback?: FunctionMaybe<boolean>;
   }
   type SVGPreserveAspectRatio =
     | "none"

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1163,6 +1163,7 @@ export namespace JSX {
   interface MediaHTMLAttributes<T> extends HTMLAttributes<T> {
     autoplay?: boolean | undefined;
     controls?: boolean | undefined;
+    controlslist?: string | undefined;
     crossorigin?: HTMLCrossorigin | undefined;
     loop?: boolean | undefined;
     mediagroup?: string | undefined;
@@ -1333,6 +1334,7 @@ export namespace JSX {
     poster?: string | undefined;
     width?: number | string | undefined;
     disablepictureinpicture?: boolean;
+    disableremoteplayback?: boolean;
   }
   type SVGPreserveAspectRatio =
     | "none"


### PR DESCRIPTION
Added some more of these attributes that were lacking https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video

I added them in all lower case but as a user I'd prefer the camel cased version.

I can see some attributes are both all lower case and camelCase like here: https://github.com/danieltroger/dom-expressions/blob/0d5c46b24c9fba2d62dee8bc1acbf98c733fa633/packages/dom-expressions/src/jsx.d.ts#L1173-L1174

What's solid-js' convention?