### PR TITLE
inline in template boolean literals

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -255,3 +255,8 @@ const template74 = <div ref={refFn} />
 const template75 = <div ref={refConst} />
 
 const template76 = <div ref={refUnknown} />
+
+const template77 = <div true={true} truestr="true" truestrjs={"true"}/>
+const template78 = <div false={false} falsestr="false" falsestrjs={"false"} />
+const template79 = <div prop:true={true} prop:false={false}/>
+const template80 = <div attr:true={true} attr:false={false}/>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -17,52 +17,55 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly=""><input>`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<a>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div><a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div>`),
-  _tmpl$17 = /*#__PURE__*/ _$template(
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox checked>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly=""><input>`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<a>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div><a>`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
+  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div>`),
+  _tmpl$18 = /*#__PURE__*/ _$template(
     `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4">`
   ),
-  _tmpl$18 = /*#__PURE__*/ _$template(`<button>`),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<input value=10>`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
-  _tmpl$21 = /*#__PURE__*/ _$template(`<div>empty string`),
-  _tmpl$22 = /*#__PURE__*/ _$template(`<div>js empty`),
-  _tmpl$23 = /*#__PURE__*/ _$template(`<div quack>hola`),
-  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>"hola js"`),
-  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>true`),
-  _tmpl$26 = /*#__PURE__*/ _$template(`<div>false`),
-  _tmpl$27 = /*#__PURE__*/ _$template(`<div quack>1`),
-  _tmpl$28 = /*#__PURE__*/ _$template(`<div>0`),
-  _tmpl$29 = /*#__PURE__*/ _$template(`<div quack>"1"`),
-  _tmpl$30 = /*#__PURE__*/ _$template(`<div>"0"`),
-  _tmpl$31 = /*#__PURE__*/ _$template(`<div>undefined`),
-  _tmpl$32 = /*#__PURE__*/ _$template(`<div>null`),
-  _tmpl$33 = /*#__PURE__*/ _$template(`<div>boolTest()`),
-  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest`),
-  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
-  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
-  _tmpl$37 = /*#__PURE__*/ _$template(`<div>fn`),
-  _tmpl$38 = /*#__PURE__*/ _$template(`<div before quack>should have space before`),
-  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack after>should have space before/after`),
-  _tmpl$40 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after`),
-  _tmpl$41 = /*#__PURE__*/ _$template(`<img src="">`),
-  _tmpl$42 = /*#__PURE__*/ _$template(`<div><img src="">`),
-  _tmpl$43 = /*#__PURE__*/ _$template(`<img src=""loading=lazy>`, true, false),
-  _tmpl$44 = /*#__PURE__*/ _$template(`<div><img src=""loading=lazy>`, true, false),
-  _tmpl$45 = /*#__PURE__*/ _$template(`<iframe src="">`),
-  _tmpl$46 = /*#__PURE__*/ _$template(`<div><iframe src="">`),
-  _tmpl$47 = /*#__PURE__*/ _$template(`<iframe src=""loading=lazy>`, true, false),
-  _tmpl$48 = /*#__PURE__*/ _$template(`<div><iframe src=""loading=lazy>`, true, false),
-  _tmpl$49 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`);
+  _tmpl$19 = /*#__PURE__*/ _$template(`<button>`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<input value=10>`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<div>empty string`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<div>js empty`),
+  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>hola`),
+  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>"hola js"`),
+  _tmpl$26 = /*#__PURE__*/ _$template(`<div quack>true`),
+  _tmpl$27 = /*#__PURE__*/ _$template(`<div>false`),
+  _tmpl$28 = /*#__PURE__*/ _$template(`<div quack>1`),
+  _tmpl$29 = /*#__PURE__*/ _$template(`<div>0`),
+  _tmpl$30 = /*#__PURE__*/ _$template(`<div quack>"1"`),
+  _tmpl$31 = /*#__PURE__*/ _$template(`<div>"0"`),
+  _tmpl$32 = /*#__PURE__*/ _$template(`<div>undefined`),
+  _tmpl$33 = /*#__PURE__*/ _$template(`<div>null`),
+  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest()`),
+  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTest`),
+  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
+  _tmpl$37 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<div>fn`),
+  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack>should have space before`),
+  _tmpl$40 = /*#__PURE__*/ _$template(`<div before quack after>should have space before/after`),
+  _tmpl$41 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after`),
+  _tmpl$42 = /*#__PURE__*/ _$template(`<img src="">`),
+  _tmpl$43 = /*#__PURE__*/ _$template(`<div><img src="">`),
+  _tmpl$44 = /*#__PURE__*/ _$template(`<img src=""loading=lazy>`, true, false),
+  _tmpl$45 = /*#__PURE__*/ _$template(`<div><img src=""loading=lazy>`, true, false),
+  _tmpl$46 = /*#__PURE__*/ _$template(`<iframe src="">`),
+  _tmpl$47 = /*#__PURE__*/ _$template(`<div><iframe src="">`),
+  _tmpl$48 = /*#__PURE__*/ _$template(`<iframe src=""loading=lazy>`, true, false),
+  _tmpl$49 = /*#__PURE__*/ _$template(`<div><iframe src=""loading=lazy>`, true, false),
+  _tmpl$50 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`),
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div true truestr=true truestrjs=true>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<div falsestr=false falsestrjs=false>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -222,20 +225,16 @@ const template12 = (() => {
   _$setAttribute(_el$18, "onclick", "console.log('hi')");
   return _el$18;
 })();
-const template13 = (() => {
-  var _el$19 = _tmpl$6();
-  _el$19.checked = true;
-  return _el$19;
-})();
+const template13 = _tmpl$6();
 const template14 = (() => {
-  var _el$20 = _tmpl$6();
+  var _el$20 = _tmpl$7();
   _$effect(() => (_el$20.checked = state.visible));
   return _el$20;
 })();
-const template15 = _tmpl$7();
-const template16 = _tmpl$8();
+const template15 = _tmpl$8();
+const template16 = _tmpl$9();
 const template17 = (() => {
-  var _el$23 = _tmpl$9();
+  var _el$23 = _tmpl$10();
   _$addEventListener(_el$23, "click", increment, true);
   return _el$23;
 })();
@@ -253,9 +252,9 @@ const template18 = (() => {
   );
   return _el$24;
 })();
-const template19 = _tmpl$10();
+const template19 = _tmpl$11();
 const template20 = (() => {
-  var _el$26 = _tmpl$11(),
+  var _el$26 = _tmpl$12(),
     _el$27 = _el$26.firstChild,
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
@@ -298,7 +297,7 @@ const template21 = (() => {
   );
   return _el$29;
 })();
-const template22 = _tmpl$12();
+const template22 = _tmpl$13();
 const template23 = (() => {
   var _el$31 = _tmpl$4();
   _$insert(_el$31, () => "t" in test && "true");
@@ -306,7 +305,7 @@ const template23 = (() => {
   return _el$31;
 })();
 const template24 = (() => {
-  var _el$32 = _tmpl$13();
+  var _el$32 = _tmpl$14();
   _$spread(
     _el$32,
     _$mergeProps(props, {
@@ -318,7 +317,7 @@ const template24 = (() => {
   return _el$32;
 })();
 const template25 = (() => {
-  var _el$33 = _tmpl$14(),
+  var _el$33 = _tmpl$15(),
     _el$34 = _el$33.firstChild;
   _$insert(_el$33, () => props.children, _el$34);
   _$spread(
@@ -332,13 +331,13 @@ const template25 = (() => {
   return _el$33;
 })();
 const template26 = (() => {
-  var _el$35 = _tmpl$15();
+  var _el$35 = _tmpl$16();
   _$setAttribute(_el$35, "middle", middle);
   _$spread(_el$35, spread, false, true);
   return _el$35;
 })();
 const template27 = (() => {
-  var _el$36 = _tmpl$15();
+  var _el$36 = _tmpl$16();
   _$spread(
     _el$36,
     _$mergeProps(
@@ -354,7 +353,7 @@ const template27 = (() => {
   return _el$36;
 })();
 const template28 = (() => {
-  var _el$37 = _tmpl$16(),
+  var _el$37 = _tmpl$17(),
     _el$38 = _el$37.firstChild,
     _el$39 = _el$38.firstChild,
     _el$40 = _el$38.nextSibling,
@@ -372,7 +371,7 @@ const template29 = (() => {
   _$insert(_el$42, !!someValue);
   return _el$42;
 })();
-const template30 = _tmpl$17();
+const template30 = _tmpl$18();
 const template31 = (() => {
   var _el$44 = _tmpl$4();
   _$effect(_$p =>
@@ -389,22 +388,22 @@ const template32 = (() => {
 })();
 const template33 = [
   (() => {
-    var _el$46 = _tmpl$18();
+    var _el$46 = _tmpl$19();
     _$className(_el$46, styles.button);
     return _el$46;
   })(),
   (() => {
-    var _el$47 = _tmpl$18();
+    var _el$47 = _tmpl$19();
     _$className(_el$47, styles["foo--bar"]);
     return _el$47;
   })(),
   (() => {
-    var _el$48 = _tmpl$18();
+    var _el$48 = _tmpl$19();
     _$effect(() => _$className(_el$48, styles.foo.bar));
     return _el$48;
   })(),
   (() => {
-    var _el$49 = _tmpl$18();
+    var _el$49 = _tmpl$19();
     _$effect(() => _$className(_el$49, styles[foo()]));
     return _el$49;
   })()
@@ -440,7 +439,7 @@ const template38 = (() => {
   typeof _ref$7 === "function" && _$use(_ref$7, _el$54);
   return _el$54;
 })();
-const template39 = _tmpl$19();
+const template39 = _tmpl$20();
 const template40 = (() => {
   var _el$56 = _tmpl$4();
   _$effect(_$p =>
@@ -451,7 +450,7 @@ const template40 = (() => {
   return _el$56;
 })();
 const template41 = (() => {
-  var _el$57 = _tmpl$20(),
+  var _el$57 = _tmpl$21(),
     _el$58 = _el$57.firstChild,
     _el$59 = _el$58.nextSibling;
   _$effect(() => (_el$58.value = Color.Red));
@@ -468,57 +467,57 @@ const boolTestBinding = false;
 const boolTestObjBinding = {
   value: false
 };
-const template42 = _tmpl$21();
-const template43 = _tmpl$22();
-const template44 = _tmpl$23();
-const template45 = _tmpl$24();
-const template46 = _tmpl$25();
-const template47 = _tmpl$26();
-const template48 = _tmpl$27();
-const template49 = _tmpl$28();
-const template50 = _tmpl$29();
-const template51 = _tmpl$30();
-const template52 = _tmpl$31();
-const template53 = _tmpl$32();
+const template42 = _tmpl$22();
+const template43 = _tmpl$23();
+const template44 = _tmpl$24();
+const template45 = _tmpl$25();
+const template46 = _tmpl$26();
+const template47 = _tmpl$27();
+const template48 = _tmpl$28();
+const template49 = _tmpl$29();
+const template50 = _tmpl$30();
+const template51 = _tmpl$31();
+const template52 = _tmpl$32();
+const template53 = _tmpl$33();
 const template54 = (() => {
-  var _el$72 = _tmpl$33();
+  var _el$72 = _tmpl$34();
   _$effect(() => _$setBoolAttribute(_el$72, "quack", boolTest()));
   return _el$72;
 })();
 const template55 = (() => {
-  var _el$73 = _tmpl$34();
+  var _el$73 = _tmpl$35();
   _$setBoolAttribute(_el$73, "quack", boolTest);
   return _el$73;
 })();
 const template56 = (() => {
-  var _el$74 = _tmpl$35();
+  var _el$74 = _tmpl$36();
   _$setBoolAttribute(_el$74, "quack", boolTestBinding);
   return _el$74;
 })();
 const template57 = (() => {
-  var _el$75 = _tmpl$36();
+  var _el$75 = _tmpl$37();
   _$effect(() => _$setBoolAttribute(_el$75, "quack", boolTestObjBinding.value));
   return _el$75;
 })();
 const template58 = (() => {
-  var _el$76 = _tmpl$37();
+  var _el$76 = _tmpl$38();
   _$setBoolAttribute(_el$76, "quack", () => false);
   return _el$76;
 })();
-const template59 = _tmpl$38();
-const template60 = _tmpl$39();
-const template61 = _tmpl$40();
+const template59 = _tmpl$39();
+const template60 = _tmpl$40();
+const template61 = _tmpl$41();
 // this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;
 
-const template63 = _tmpl$41();
-const template64 = _tmpl$42();
-const template65 = _tmpl$43();
-const template66 = _tmpl$44();
-const template67 = _tmpl$45();
-const template68 = _tmpl$46();
-const template69 = _tmpl$47();
-const template70 = _tmpl$48();
-const template71 = _tmpl$49();
+const template63 = _tmpl$42();
+const template64 = _tmpl$43();
+const template65 = _tmpl$44();
+const template66 = _tmpl$45();
+const template67 = _tmpl$46();
+const template68 = _tmpl$47();
+const template69 = _tmpl$48();
+const template70 = _tmpl$49();
+const template71 = _tmpl$50();
 const template72 = (() => {
   var _el$89 = _tmpl$4();
   _$use(binding, _el$89);
@@ -546,5 +545,19 @@ const template76 = (() => {
   var _ref$10 = refUnknown;
   typeof _ref$10 === "function" ? _$use(_ref$10, _el$93) : (refUnknown = _el$93);
   return _el$93;
+})();
+const template77 = _tmpl$51();
+const template78 = _tmpl$52();
+const template79 = (() => {
+  var _el$96 = _tmpl$4();
+  _el$96.true = true;
+  _el$96.false = false;
+  return _el$96;
+})();
+const template80 = (() => {
+  var _el$97 = _tmpl$4();
+  _$setAttribute(_el$97, "true", true);
+  _$setAttribute(_el$97, "false", false);
+  return _el$97;
 })();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -20,23 +20,24 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly=""><input>`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<a>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div><!$><!/><a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is <!$><!/></span><input><div>`),
-  _tmpl$17 = /*#__PURE__*/ _$template(
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox checked>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly=""><input>`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<a>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div><!$><!/><a>`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
+  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is <!$><!/></span><input><div>`),
+  _tmpl$18 = /*#__PURE__*/ _$template(
     `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4">`
   ),
-  _tmpl$18 = /*#__PURE__*/ _$template(`<button>`),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<input value=10>`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`);
+  _tmpl$19 = /*#__PURE__*/ _$template(`<button>`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<input value=10>`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`);
 import * as styles from "./styles.module.css";
 const selected = true;
 let id = "my-h1";
@@ -195,20 +196,16 @@ const template12 = (() => {
   _$setAttribute(_el$18, "onclick", "console.log('hi')");
   return _el$18;
 })();
-const template13 = (() => {
-  var _el$19 = _$getNextElement(_tmpl$6);
-  _$setProperty(_el$19, "checked", true);
-  return _el$19;
-})();
+const template13 = _$getNextElement(_tmpl$6);
 const template14 = (() => {
-  var _el$20 = _$getNextElement(_tmpl$6);
+  var _el$20 = _$getNextElement(_tmpl$7);
   _$effect(() => _$setProperty(_el$20, "checked", state.visible));
   return _el$20;
 })();
-const template15 = _$getNextElement(_tmpl$7);
-const template16 = _$getNextElement(_tmpl$8);
+const template15 = _$getNextElement(_tmpl$8);
+const template16 = _$getNextElement(_tmpl$9);
 const template17 = (() => {
-  var _el$23 = _$getNextElement(_tmpl$9);
+  var _el$23 = _$getNextElement(_tmpl$10);
   _$addEventListener(_el$23, "click", increment, true);
   _$runHydrationEvents();
   return _el$23;
@@ -228,9 +225,9 @@ const template18 = (() => {
   _$runHydrationEvents();
   return _el$24;
 })();
-const template19 = _$getNextElement(_tmpl$10);
+const template19 = _$getNextElement(_tmpl$11);
 const template20 = (() => {
-  var _el$26 = _$getNextElement(_tmpl$11),
+  var _el$26 = _$getNextElement(_tmpl$12),
     _el$27 = _el$26.firstChild,
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
@@ -274,7 +271,7 @@ const template21 = (() => {
   );
   return _el$29;
 })();
-const template22 = _$getNextElement(_tmpl$12);
+const template22 = _$getNextElement(_tmpl$13);
 const template23 = (() => {
   var _el$31 = _$getNextElement(_tmpl$4);
   _$insert(_el$31, () => "t" in test && "true");
@@ -282,7 +279,7 @@ const template23 = (() => {
   return _el$31;
 })();
 const template24 = (() => {
-  var _el$32 = _$getNextElement(_tmpl$13);
+  var _el$32 = _$getNextElement(_tmpl$14);
   _$spread(
     _el$32,
     _$mergeProps(props, {
@@ -295,7 +292,7 @@ const template24 = (() => {
   return _el$32;
 })();
 const template25 = (() => {
-  var _el$33 = _$getNextElement(_tmpl$14),
+  var _el$33 = _$getNextElement(_tmpl$15),
     _el$35 = _el$33.firstChild,
     [_el$36, _co$] = _$getNextMarker(_el$35.nextSibling),
     _el$34 = _el$36.nextSibling;
@@ -312,14 +309,14 @@ const template25 = (() => {
   return _el$33;
 })();
 const template26 = (() => {
-  var _el$37 = _$getNextElement(_tmpl$15);
+  var _el$37 = _$getNextElement(_tmpl$16);
   _$setAttribute(_el$37, "middle", middle);
   _$spread(_el$37, spread, false, true);
   _$runHydrationEvents();
   return _el$37;
 })();
 const template27 = (() => {
-  var _el$38 = _$getNextElement(_tmpl$15);
+  var _el$38 = _$getNextElement(_tmpl$16);
   _$spread(
     _el$38,
     _$mergeProps(
@@ -336,7 +333,7 @@ const template27 = (() => {
   return _el$38;
 })();
 const template28 = (() => {
-  var _el$39 = _$getNextElement(_tmpl$16),
+  var _el$39 = _$getNextElement(_tmpl$17),
     _el$40 = _el$39.firstChild,
     _el$41 = _el$40.firstChild,
     _el$42 = _el$41.nextSibling,
@@ -357,7 +354,7 @@ const template29 = (() => {
   _$insert(_el$46, !!someValue);
   return _el$46;
 })();
-const template30 = _$getNextElement(_tmpl$17);
+const template30 = _$getNextElement(_tmpl$18);
 const template31 = (() => {
   var _el$48 = _$getNextElement(_tmpl$4);
   _$effect(_$p =>
@@ -374,22 +371,22 @@ const template32 = (() => {
 })();
 const template33 = [
   (() => {
-    var _el$50 = _$getNextElement(_tmpl$18);
+    var _el$50 = _$getNextElement(_tmpl$19);
     _$className(_el$50, styles.button);
     return _el$50;
   })(),
   (() => {
-    var _el$51 = _$getNextElement(_tmpl$18);
+    var _el$51 = _$getNextElement(_tmpl$19);
     _$className(_el$51, styles["foo--bar"]);
     return _el$51;
   })(),
   (() => {
-    var _el$52 = _$getNextElement(_tmpl$18);
+    var _el$52 = _$getNextElement(_tmpl$19);
     _$effect(() => _$className(_el$52, styles.foo.bar));
     return _el$52;
   })(),
   (() => {
-    var _el$53 = _$getNextElement(_tmpl$18);
+    var _el$53 = _$getNextElement(_tmpl$19);
     _$effect(() => _$className(_el$53, styles[foo()]));
     return _el$53;
   })()
@@ -426,7 +423,7 @@ const template38 = (() => {
   typeof _ref$7 === "function" && _$use(_ref$7, _el$58);
   return _el$58;
 })();
-const template39 = _$getNextElement(_tmpl$19);
+const template39 = _$getNextElement(_tmpl$20);
 const template40 = (() => {
   var _el$60 = _$getNextElement(_tmpl$4);
   _$effect(_$p =>
@@ -437,7 +434,7 @@ const template40 = (() => {
   return _el$60;
 })();
 const template41 = (() => {
-  var _el$61 = _$getNextElement(_tmpl$20),
+  var _el$61 = _$getNextElement(_tmpl$21),
     _el$62 = _el$61.firstChild,
     _el$63 = _el$62.nextSibling;
   _$effect(() => _$setProperty(_el$62, "value", Color.Red));

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -13,7 +13,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$5 = /*#__PURE__*/ _$template(`<input type=checkbox readonly="">`),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<input type=checkbox checked readonly="">`),
   _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`);
 const selected = true;
 let id = "my-h1";
@@ -163,11 +163,7 @@ const template12 = (() => {
   _el$18.htmlFor = thing;
   return _el$18;
 })();
-const template13 = (() => {
-  var _el$19 = _tmpl$5();
-  _el$19.checked = true;
-  return _el$19;
-})();
+const template13 = _tmpl$5();
 const template14 = (() => {
   var _el$20 = _tmpl$6();
   _el$20.readOnly = value;


### PR DESCRIPTION
This change, inlines in the template boolean literals. For example

`<el attr={true}/>` becomes  `<el attr/>`
and 
`<el attr={false}/>` becomes  `<el/>`

Considerations:
- this change skips doing this transformation for "custom elements", because as we are defaulting to properties I suspect something will break.
- I do not think this is a breaking change, at least from my tests I didn't see anything that could cause problems.
- this is related to an effort to fix the attributes vs properties problem

The most recent issue illustrating this props vs attr problem comes from https://github.com/ryansolid/dom-expressions/issues/384 In there they are doing `<video playsinline={true} />;`, in production code currently:
- client side works because compiles it to `_el$.playsInline = true;`
- in ssr is inlined in the template
- ssr with hydration fails because it tries to add the property with the lowercase name as `_$setProperty(_el$, "playsinline", true);`

With this change, 
- boolean attributes will always be inlined for the `true` case and skipped for the `false` case
- once the pr with the types gets merged it will only accept `"true" | boolean`, so trying to do `"false"`` as a string should be a type error

I am hoping before solid 2.0 we can get rid of the hardcoded list of properties 

Thanks!



