### PR TITLE
Treat tagged templates as function calls

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -94,7 +94,7 @@ export function isDynamic(path, { checkMember, checkTags, checkCallExpressions =
     return false;
   }
 
-  if (checkCallExpressions && (t.isCallExpression(expr) || t.isOptionalCallExpression(expr))) {
+  if (checkCallExpressions && (t.isCallExpression(expr) || t.isOptionalCallExpression(expr) || t.isTaggedTemplateExpression(expr))) {
     return true;
   }
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/fragments/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/fragments/code.js
@@ -27,6 +27,9 @@ const singleExpression = <>{inserted}</>;
 
 const singleDynamic = <>{inserted()}</>;
 
+const greeting = (x) => "Hello " + x;
+const singleTemplateLiteral = <>{greeting`world`}</>
+
 const firstStatic = (
   <>
     {inserted}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/fragments/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/fragments/output.js
@@ -27,6 +27,8 @@ const multiDynamic = [
 ];
 const singleExpression = inserted;
 const singleDynamic = _$memo(inserted);
+const greeting = x => "Hello " + x;
+const singleTemplateLiteral = _$memo(() => greeting`world`);
 const firstStatic = [inserted, _tmpl$3()];
 const firstDynamic = [_$memo(inserted), _tmpl$3()];
 const firstComponent = [_$createComponent(Component, {}), _tmpl$3()];


### PR DESCRIPTION
Fixes https://github.com/solidjs/solid/issues/2377

Without the change, the test compiles to the incorrect

```js
const singleTemplateLiteral = greeting`world`
```