### PR TITLE
Handle `<col>` components in in validate.js

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
@@ -79,6 +79,7 @@ export function isInvalidMarkup(html) {
     case "<table></table>":
     case "<table><thead></thead></table>":
     case "<table><tbody></tbody></table>":
+    case "<table><colgroup><col></colgroup></table>":
     case "<table><thead></thead><tbody></tbody></table>": {
       return;
     }


### PR DESCRIPTION
Looks like one edge for `<col>` case was missed in https://github.com/ryansolid/dom-expressions/pull/360

When I try to compile a solid-js `col` like this:

```tsx
export const TableCol: Component<TableColProps> = (props) => {
  const [local, others] = splitProps(props, [
    "hasBorderLeft",
    "hasBorderRight",
  ]);

  return (
    <col
      class="m-table__col"
      classList={{
        "m-table__col-border-l": local.hasBorderLeft,
        "m-table__col-border-r": local.hasBorderRight,
      }}
      {...others}
    />
  );
};
```
I get this warning when compiling with esbuild:

```shell
The HTML provided is malformed and will yield unexpected output when evaluated by a browser.

User HTML:
 <table><colgroup><col>
Browser HTML:
 <table><colgroup><col></colgroup></table>
Original HTML:
 <col>
```

I *think* this case is all that's missing?