### PR TITLE
skip escaping script, style in spread

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/code.js
@@ -204,3 +204,25 @@ const template41 = (
 );
 
 const template42 = <div a a="" a='' checked={true} checked={false} a={true} a={false} a={0} a={''} a={""} a={undefined} a={null} a={void 0} a/>
+
+const css = () => "&{color:red}";
+const template43 = (
+  <>
+    <style>{css()}</style>
+    <style children={css()} />
+    <style innerHTML={css()} />
+    <style innerText={css()} />
+    <style textContent={css()} />
+  </>
+);
+
+const styleProps = { children: css }
+const template44 = (
+  <>
+    <style {...styleProps()}>{css()}</style>
+    <style {...styleProps()} children={css()} />
+    <style {...styleProps()} innerHTML={css()} />
+    <style {...styleProps()} innerText={css()} />
+    <style {...styleProps()} textContent={css()} />
+  </>
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
@@ -28,7 +28,8 @@ var _tmpl$ = ['<a href="/" class="', '">Welcome</a>'],
   _tmpl$21 = ["<button", "></button>"],
   _tmpl$22 = '<input value="10">',
   _tmpl$23 = ["<select", "><option", ">Red</option><option", ">Blue</option></select>"],
-  _tmpl$24 = ['<div a a a checked a="true" a="false" a="0" a a', " a></div>"];
+  _tmpl$24 = ['<div a a a checked a="true" a="false" a="0" a a', " a></div>"],
+  _tmpl$25 = ["<style>", "</style>"];
 import * as styles from "./styles.module.css";
 const selected = true;
 let id = "my-h1";
@@ -239,3 +240,57 @@ const template42 = _$ssr(
     _$ssrAttribute("a", _$escape(null, true), false) +
     _$ssrAttribute("a", void 0, false)
 );
+const css = () => "&{color:red}";
+const template43 = [
+  _$ssr(_tmpl$25, css()),
+  _$ssr(_tmpl$25, css()),
+  _$ssr(_tmpl$25, css()),
+  _$ssr(_tmpl$25, css()),
+  _$ssr(_tmpl$25, css())
+];
+const styleProps = {
+  children: css
+};
+const template44 = [
+  _$ssrElement("style", styleProps(), css(), false),
+  _$ssrElement(
+    "style",
+    _$mergeProps(styleProps, {
+      get children() {
+        return css();
+      }
+    }),
+    undefined,
+    false
+  ),
+  _$ssrElement(
+    "style",
+    _$mergeProps(styleProps, {
+      get innerHTML() {
+        return css();
+      }
+    }),
+    undefined,
+    false
+  ),
+  _$ssrElement(
+    "style",
+    _$mergeProps(styleProps, {
+      get innerText() {
+        return css();
+      }
+    }),
+    undefined,
+    false
+  ),
+  _$ssrElement(
+    "style",
+    _$mergeProps(styleProps, {
+      get textContent() {
+        return css();
+      }
+    }),
+    undefined,
+    false
+  )
+];

--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -360,7 +360,10 @@ export function ssrElement(tag, props, children, needsId) {
     const prop = keys[i];
     if (ChildProperties.has(prop)) {
       if (children === undefined && !skipChildren)
-        children = prop === "innerHTML" ? props[prop] : escape(props[prop]);
+        children =
+          tag === "script" || tag === "style" || prop === "innerHTML"
+            ? props[prop]
+            : escape(props[prop]);
       continue;
     }
     const value = props[prop];


### PR DESCRIPTION
fixes https://github.com/solidjs/solid-start/issues/1598, https://github.com/solidjs/solid-start/issues/1630, https://github.com/solidjs/solid-start/issues/1749

spread is not skipping escaping for script, style tags
this PR handles it

i'll add the tests if this is good to go