### PR TITLE
Improve compatibility with more browser-like environments

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/README.md
+++ b/packages/babel-plugin-jsx-dom-expressions/README.md
@@ -157,9 +157,23 @@ Checks for properly formed HTML by checking for elements that would not be allow
 ### omitNestedClosingTags
 
 - Type: `boolean`
-- Default: `true`
+- Default: `false`
 
 Removes unnecessary closing tags from the template output. This may not work in all browser-like environments the same. The solution has been tested again Chrome/Edge/Firefox/Safari.
+
+### omitLastClosingTag
+
+- Type: `boolean`
+- Default: `true`
+
+Removes tags from the template output if they have no closing parents and are the last element. This may not work in all browser-like environments the same. The solution has been tested again Chrome/Edge/Firefox/Safari.
+
+### omitQuotes
+
+- Type: `boolean`
+- Default: `true`
+
+Removes quotes for html attributes when possible from the template output. This may not work in all browser-like environments the same. The solution has been tested again Chrome/Edge/Firefox/Safari.
 
 ## Special Binding
 

--- a/packages/babel-plugin-jsx-dom-expressions/src/config.ts
+++ b/packages/babel-plugin-jsx-dom-expressions/src/config.ts
@@ -8,6 +8,8 @@ export default {
   requireImportSource: false,
   wrapConditionals: true,
   omitNestedClosingTags: false,
+  omitLastClosingTag: true,
+  omitQuotes: true,
   contextToCustomElements: false,
   staticMarker: "@once",
   effectWrapper: "effect",

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -122,7 +122,7 @@ export function transformElement(path, info) {
   if (!voidTag) {
     // always close tags can still be skipped if they have no closing parents and are the last element
     const toBeClosed =
-      !info.lastElement ||
+      (!info.lastElement || !config.omitLastClosingTag) ||
       (info.toBeClosed && (!config.omitNestedClosingTags || info.toBeClosed.has(tagName)));
     if (toBeClosed) {
       results.toBeClosed = new Set(info.toBeClosed || alwaysClose);
@@ -839,7 +839,7 @@ function transformAttributes(path, results) {
 
           let text = value.value;
           if (typeof text === "number") text = String(text);
-          let needsQuoting = false;
+          let needsQuoting = !config.omitQuotes;
 
           if (key === "style" || key === "class") {
             text = trimWhitespace(text);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/SVG/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/SVG/code.js
@@ -1,0 +1,5 @@
+const template = (
+  <svg width="300" height="130" xmlns="http://www.w3.org/2000/svg">
+    <rect width="200" height="100" x="10" y="10" rx="20" ry="20" fill="blue" />
+  </svg>
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/SVG/output.js
@@ -1,0 +1,5 @@
+import { template as _$template } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(
+  `<svg width="300"height="130"xmlns="http://www.w3.org/2000/svg"><rect width="200"height="100"x="10"y="10"rx="20"ry="20"fill="blue"></rect></svg>`
+);
+const template = _tmpl$();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
@@ -1,0 +1,266 @@
+import * as styles from "./styles.module.css";
+import { binding } from "somewhere";
+
+function refFn() {}
+const refConst = null;
+
+const selected = true;
+let id = "my-h1";
+let link;
+const template = (
+  <div id="main" {...results} classList={{ selected: unknown }} style={{ color }}>
+    <h1
+      class="base"
+      id={id}
+      {...results()}
+      foo
+      disabled
+      title={welcoming()}
+      style={{ "background-color": color(), "margin-right": "40px" }}
+      classList={{ dynamic: dynamic(), selected }}
+    >
+      <a href={"/"} ref={link} classList={{ "ccc ddd": true }}>
+        Welcome
+      </a>
+    </h1>
+  </div>
+);
+
+const template2 = (
+  <div {...getProps("test")}>
+    <div textContent={rowId} />
+    <div textContent={row.label} />
+    <div innerHTML={"<div/>"} />
+  </div>
+);
+
+const template3 = (
+  <div
+    foo
+    id={/*@once*/ state.id}
+    style={/*@once*/ { "background-color": state.color }}
+    name={state.name}
+    textContent={/*@once*/ state.content}
+  />
+);
+
+const template4 = <div class="hi" className={state.class} classList={{ "ccc:ddd": true }} />;
+
+const template5 = <div class="a" className="b"></div>;
+
+const template6 = <div style={someStyle()} textContent="Hi" />;
+
+let undefVar;
+const template7 = (
+  <div
+    style={{ "background-color": color(), "margin-right": "40px", ...props.style }}
+    style:padding-top={props.top}
+    class:my-class={props.active}
+    class:other-class={undefVar}
+    classList={{ "other-class2": undefVar }}
+  />
+);
+
+let refTarget;
+const template8 = <div ref={refTarget} />;
+
+const template9 = <div ref={e => console.log(e)} />;
+
+const template10 = <div ref={refFactory()} />;
+
+const template11 = <div use:something use:another={thing} use:zero={0} />;
+
+const template12 = <div prop:htmlFor={thing} prop:number={123} attr:onclick="console.log('hi')" />;
+
+const template13 = <input type="checkbox" checked={true} />;
+
+const template14 = <input type="checkbox" checked={state.visible} />;
+
+const template15 = <div class="`a">`$`</div>;
+
+const template16 = (
+  <button
+    class="static"
+    classList={{
+      hi: "k"
+    }}
+    type="button"
+  >
+    Write
+  </button>
+);
+
+const template17 = (
+  <button
+    classList={{
+      a: true,
+      b: true,
+      c: true
+    }}
+    onClick={increment}
+  >
+    Hi
+  </button>
+);
+
+const template18 = (
+  <div
+    {...{
+      get [key()]() {
+        return props.value;
+      }
+    }}
+  />
+);
+
+const template19 = <div classList={{ "bg-red-500": true }} class="flex flex-col" />;
+
+const template20 = (
+  <div>
+    <input value={s()} min={min()} max={max()} onInput={doSomething} readonly="" />
+    <input checked={s2()} min={min()} max={max()} onInput={doSomethingElse} readonly={value} />
+  </div>
+);
+
+const template21 = <div style={{ a: "static", ...rest }}></div>;
+
+const template22 = <div data='"hi"' data2={'"'} />;
+
+const template23 = <div disabled={"t" in test}>{"t" in test && "true"}</div>;
+
+const template24 = <a {...props} something />;
+
+const template25 = (
+  <div>
+    {props.children}
+    <a {...props} something />
+  </div>
+);
+
+const template26 = (
+  <div start="Hi" middle={middle} {...spread}>
+    Hi
+  </div>
+);
+
+const template27 = (
+  <div start="Hi" {...first} middle={middle} {...second}>
+    Hi
+  </div>
+);
+
+const template28 = (
+  <label {...api()}>
+    <span {...api()}>Input is {api() ? "checked" : "unchecked"}</span>
+    <input {...api()} />
+    <div {...api()} />
+  </label>
+);
+
+const template29 = <div attribute={!!someValue}>{!!someValue}</div>;
+
+const template30 = (
+  <div
+    class="class1 class2
+    class3 class4
+    class5 class6"
+    style="color: red;
+    background-color: blue !important;
+    border: 1px solid black;
+    font-size: 12px;"
+    random="random1 random2
+    random3 random4"
+  />
+);
+
+const template31 = <div style={{ "background-color": getStore.itemProperties.color }} />;
+
+const template32 = <div style={{ "background-color": undefined }} />;
+
+const template33 = (
+  <>
+    <button class={styles.button}></button>
+    <button class={styles["foo--bar"]}></button>
+    <button class={styles.foo.bar}></button>
+    <button class={styles[foo()]}></button>
+  </>
+);
+
+const template34 = <div use:something {...somethingElse} use:zero={0} />;
+
+const template35 = <div ref={a().b.c} />;
+
+const template36 = <div ref={a().b?.c} />;
+
+const template37 = <div ref={a() ? b : c} />;
+
+const template38 = <div ref={a() ?? b} />;
+
+const template39 = <input value={10} />;
+
+const template40 = <div style={{ color: a() }} />;
+
+const template41 = (
+  <select value={state.color}>
+    <option value={Color.Red}>Red</option>
+    <option value={Color.Blue}>Blue</option>
+  </select>
+);
+
+// bool:
+function boolTest(){return true}
+const boolTestBinding = false
+const boolTestObjBinding = {value:false}
+
+const template42 = <div bool:quack="">empty string</div>;
+const template43 = <div bool:quack={""}>js empty</div>;
+const template44 = <div bool:quack="hola">hola</div>;
+const template45 = <div bool:quack={"hola js"}>"hola js"</div>;
+const template46 = <div bool:quack={true}>true</div>;
+const template47 = <div bool:quack={false}>false</div>;
+const template48 = <div bool:quack={1}>1</div>;
+const template49 = <div bool:quack={0}>0</div>;
+const template50 = <div bool:quack={"1"}>"1"</div>;
+const template51 = <div bool:quack={"0"}>"0"</div>;
+const template52 = <div bool:quack={undefined}>undefined</div>;
+const template53 = <div bool:quack={null}>null</div>;
+const template54 = <div bool:quack={boolTest()}>boolTest()</div>;
+const template55 = <div bool:quack={boolTest}>boolTest</div>;
+const template56 = <div bool:quack={boolTestBinding}>boolTestBinding</div>;
+const template57 = <div bool:quack={boolTestObjBinding.value}>boolTestObjBinding.value</div>;
+const template58 = <div bool:quack={()=>false}>fn</div>;
+
+const template59 = <div before bool:quack="true">should have space before</div>;
+const template60 = <div before bool:quack="true" after>should have space before/after</div>;
+const template61 = <div bool:quack="true" after>should have space before/after</div>;
+// this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;
+
+const template63 = <img src="" />;
+const template64 = <div><img src=""/></div>;
+
+const template65 = <img src="" loading="lazy"/>;
+const template66 = <div><img src="" loading="lazy"/></div>;
+
+const template67 = <iframe src=""></iframe>;
+const template68 = <div><iframe src=""></iframe></div>;
+
+const template69 = <iframe src="" loading="lazy"></iframe>;
+const template70 = <div><iframe src="" loading="lazy"></iframe></div>;
+
+const template71 = <div title="<u>data</u>"/>
+
+const template72 = <div ref={binding} />;
+const template73 = <div ref={binding.prop} />;
+const template74 = <div ref={refFn} />
+const template75 = <div ref={refConst} />
+
+const template76 = <div ref={refUnknown} />
+
+const template77 = <div true={true} truestr="true" truestrjs={"true"}/>
+const template78 = <div false={false} falsestr="false" falsestrjs={"false"} />
+const template79 = <div prop:true={true} prop:false={false}/>
+const template80 = <div attr:true={true} attr:false={false}/>
+
+const template81 = <math display="block"><mrow></mrow></math>
+const template82 = <mrow><mi>x</mi><mo>=</mo></mrow>
+

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -1,0 +1,581 @@
+import { template as _$template } from "r-dom";
+import { delegateEvents as _$delegateEvents } from "r-dom";
+import { setBoolAttribute as _$setBoolAttribute } from "r-dom";
+import { insert as _$insert } from "r-dom";
+import { memo as _$memo } from "r-dom";
+import { addEventListener as _$addEventListener } from "r-dom";
+import { style as _$style } from "r-dom";
+import { className as _$className } from "r-dom";
+import { setAttribute as _$setAttribute } from "r-dom";
+import { effect as _$effect } from "r-dom";
+import { classList as _$classList } from "r-dom";
+import { use as _$use } from "r-dom";
+import { spread as _$spread } from "r-dom";
+import { mergeProps as _$mergeProps } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(
+    `<div id="main"><h1 class="base"id="my-h1"><a href="/">Welcome</a></h1></div>`
+  ),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div></div></div>`),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div foo></div>`),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div></div>`),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b"></div>`),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type="checkbox"checked>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<input type="checkbox">`),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\`</div>`),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type="button">Write</button>`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi</button>`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col"></div>`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly><input></div>`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;"></div>`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<a></a>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div><a></a></div>`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<div start="Hi">Hi</div>`),
+  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div></div></label>`),
+  _tmpl$18 = /*#__PURE__*/ _$template(
+    `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4"></div>`
+  ),
+  _tmpl$19 = /*#__PURE__*/ _$template(`<button></button>`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<input value="10">`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue</option></select>`),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<div>empty string</div>`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<div>js empty</div>`),
+  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>hola</div>`),
+  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>"hola js"</div>`),
+  _tmpl$26 = /*#__PURE__*/ _$template(`<div quack>true</div>`),
+  _tmpl$27 = /*#__PURE__*/ _$template(`<div>false</div>`),
+  _tmpl$28 = /*#__PURE__*/ _$template(`<div quack>1</div>`),
+  _tmpl$29 = /*#__PURE__*/ _$template(`<div>0</div>`),
+  _tmpl$30 = /*#__PURE__*/ _$template(`<div quack>"1"</div>`),
+  _tmpl$31 = /*#__PURE__*/ _$template(`<div>"0"</div>`),
+  _tmpl$32 = /*#__PURE__*/ _$template(`<div>undefined</div>`),
+  _tmpl$33 = /*#__PURE__*/ _$template(`<div>null</div>`),
+  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest()</div>`),
+  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTest</div>`),
+  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestBinding</div>`),
+  _tmpl$37 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value</div>`),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<div>fn</div>`),
+  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack>should have space before</div>`),
+  _tmpl$40 = /*#__PURE__*/ _$template(
+    `<div before quack after>should have space before/after</div>`
+  ),
+  _tmpl$41 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after</div>`),
+  _tmpl$42 = /*#__PURE__*/ _$template(`<img src>`),
+  _tmpl$43 = /*#__PURE__*/ _$template(`<div><img src></div>`),
+  _tmpl$44 = /*#__PURE__*/ _$template(`<img src loading="lazy">`, true, false, false),
+  _tmpl$45 = /*#__PURE__*/ _$template(`<div><img src loading="lazy"></div>`, true, false, false),
+  _tmpl$46 = /*#__PURE__*/ _$template(`<iframe src></iframe>`),
+  _tmpl$47 = /*#__PURE__*/ _$template(`<div><iframe src></iframe></div>`),
+  _tmpl$48 = /*#__PURE__*/ _$template(`<iframe src loading="lazy"></iframe>`, true, false, false),
+  _tmpl$49 = /*#__PURE__*/ _$template(
+    `<div><iframe src loading="lazy"></iframe></div>`,
+    true,
+    false,
+    false
+  ),
+  _tmpl$50 = /*#__PURE__*/ _$template(`<div title="<u>data</u>"></div>`),
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div true truestr="true"truestrjs="true"></div>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<div falsestr="false"falsestrjs="false"></div>`),
+  _tmpl$53 = /*#__PURE__*/ _$template(
+    `<math display="block"><mrow></mrow></math>`,
+    false,
+    false,
+    true
+  ),
+  _tmpl$54 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true);
+import * as styles from "./styles.module.css";
+import { binding } from "somewhere";
+function refFn() {}
+const refConst = null;
+const selected = true;
+let id = "my-h1";
+let link;
+const template = (() => {
+  var _el$ = _tmpl$(),
+    _el$2 = _el$.firstChild,
+    _el$3 = _el$2.firstChild;
+  _$spread(
+    _el$,
+    _$mergeProps(results, {
+      classList: {
+        selected: unknown
+      },
+      style: {
+        color
+      }
+    }),
+    false,
+    true
+  );
+  _$spread(
+    _el$2,
+    _$mergeProps(results, {
+      foo: "",
+      disabled: true,
+      get title() {
+        return welcoming();
+      },
+      get style() {
+        return {
+          "background-color": color(),
+          "margin-right": "40px"
+        };
+      },
+      get classList() {
+        return {
+          dynamic: dynamic(),
+          selected
+        };
+      }
+    }),
+    false,
+    true
+  );
+  var _ref$ = link;
+  typeof _ref$ === "function" ? _$use(_ref$, _el$3) : (link = _el$3);
+  _$classList(_el$3, {
+    "ccc ddd": true
+  });
+  return _el$;
+})();
+const template2 = (() => {
+  var _el$4 = _tmpl$2(),
+    _el$5 = _el$4.firstChild,
+    _el$6 = _el$5.nextSibling,
+    _el$7 = _el$6.firstChild,
+    _el$8 = _el$6.nextSibling;
+  _$spread(
+    _el$4,
+    _$mergeProps(() => getProps("test")),
+    false,
+    true
+  );
+  _el$5.textContent = rowId;
+  _el$8.innerHTML = "<div/>";
+  _$effect(() => (_el$7.data = row.label));
+  return _el$4;
+})();
+const template3 = (() => {
+  var _el$9 = _tmpl$3();
+  _$setAttribute(_el$9, "id", state.id);
+  state.color != null
+    ? _el$9.style.setProperty("background-color", state.color)
+    : _el$9.style.removeProperty("background-color");
+  _el$9.textContent = state.content;
+  _$effect(() => _$setAttribute(_el$9, "name", state.name));
+  return _el$9;
+})();
+const template4 = (() => {
+  var _el$10 = _tmpl$4();
+  _$classList(_el$10, {
+    "ccc:ddd": true
+  });
+  _$effect(() => _$className(_el$10, `hi ${state.class || ""}`));
+  return _el$10;
+})();
+const template5 = _tmpl$5();
+const template6 = (() => {
+  var _el$12 = _tmpl$4();
+  _el$12.textContent = "Hi";
+  _$effect(_$p => _$style(_el$12, someStyle(), _$p));
+  return _el$12;
+})();
+let undefVar;
+const template7 = (() => {
+  var _el$13 = _tmpl$4();
+  _el$13.classList.toggle("other-class", !!undefVar);
+  _el$13.classList.toggle("other-class2", !!undefVar);
+  _$effect(
+    _p$ => {
+      var _v$ = {
+          "background-color": color(),
+          "margin-right": "40px",
+          ...props.style
+        },
+        _v$2 = props.top,
+        _v$3 = !!props.active;
+      _p$.e = _$style(_el$13, _v$, _p$.e);
+      _v$2 !== _p$.t &&
+        ((_p$.t = _v$2) != null
+          ? _el$13.style.setProperty("padding-top", _v$2)
+          : _el$13.style.removeProperty("padding-top"));
+      _v$3 !== _p$.a && _el$13.classList.toggle("my-class", (_p$.a = _v$3));
+      return _p$;
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined
+    }
+  );
+  return _el$13;
+})();
+let refTarget;
+const template8 = (() => {
+  var _el$14 = _tmpl$4();
+  var _ref$2 = refTarget;
+  typeof _ref$2 === "function" ? _$use(_ref$2, _el$14) : (refTarget = _el$14);
+  return _el$14;
+})();
+const template9 = (() => {
+  var _el$15 = _tmpl$4();
+  _$use(e => console.log(e), _el$15);
+  return _el$15;
+})();
+const template10 = (() => {
+  var _el$16 = _tmpl$4();
+  var _ref$3 = refFactory();
+  typeof _ref$3 === "function" && _$use(_ref$3, _el$16);
+  return _el$16;
+})();
+const template11 = (() => {
+  var _el$17 = _tmpl$4();
+  _$use(zero, _el$17, () => 0);
+  _$use(another, _el$17, () => thing);
+  _$use(something, _el$17, () => true);
+  return _el$17;
+})();
+const template12 = (() => {
+  var _el$18 = _tmpl$4();
+  _el$18.htmlFor = thing;
+  _el$18.number = 123;
+  _$setAttribute(_el$18, "onclick", "console.log('hi')");
+  return _el$18;
+})();
+const template13 = _tmpl$6();
+const template14 = (() => {
+  var _el$20 = _tmpl$7();
+  _$effect(() => (_el$20.checked = state.visible));
+  return _el$20;
+})();
+const template15 = _tmpl$8();
+const template16 = _tmpl$9();
+const template17 = (() => {
+  var _el$23 = _tmpl$10();
+  _$addEventListener(_el$23, "click", increment, true);
+  return _el$23;
+})();
+const template18 = (() => {
+  var _el$24 = _tmpl$4();
+  _$spread(
+    _el$24,
+    _$mergeProps(() => ({
+      get [key()]() {
+        return props.value;
+      }
+    })),
+    false,
+    false
+  );
+  return _el$24;
+})();
+const template19 = _tmpl$11();
+const template20 = (() => {
+  var _el$26 = _tmpl$12(),
+    _el$27 = _el$26.firstChild,
+    _el$28 = _el$27.nextSibling;
+  _$addEventListener(_el$27, "input", doSomething, true);
+  _$addEventListener(_el$28, "input", doSomethingElse, true);
+  _el$28.readOnly = value;
+  _$effect(
+    _p$ => {
+      var _v$4 = min(),
+        _v$5 = max(),
+        _v$6 = min(),
+        _v$7 = max();
+      _v$4 !== _p$.e && _$setAttribute(_el$27, "min", (_p$.e = _v$4));
+      _v$5 !== _p$.t && _$setAttribute(_el$27, "max", (_p$.t = _v$5));
+      _v$6 !== _p$.a && _$setAttribute(_el$28, "min", (_p$.a = _v$6));
+      _v$7 !== _p$.o && _$setAttribute(_el$28, "max", (_p$.o = _v$7));
+      return _p$;
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined,
+      o: undefined
+    }
+  );
+  _$effect(() => (_el$27.value = s()));
+  _$effect(() => (_el$28.checked = s2()));
+  return _el$26;
+})();
+const template21 = (() => {
+  var _el$29 = _tmpl$4();
+  _$effect(_$p =>
+    _$style(
+      _el$29,
+      {
+        a: "static",
+        ...rest
+      },
+      _$p
+    )
+  );
+  return _el$29;
+})();
+const template22 = _tmpl$13();
+const template23 = (() => {
+  var _el$31 = _tmpl$4();
+  _$insert(_el$31, () => "t" in test && "true");
+  _$effect(() => (_el$31.disabled = "t" in test));
+  return _el$31;
+})();
+const template24 = (() => {
+  var _el$32 = _tmpl$14();
+  _$spread(
+    _el$32,
+    _$mergeProps(props, {
+      something: ""
+    }),
+    false,
+    false
+  );
+  return _el$32;
+})();
+const template25 = (() => {
+  var _el$33 = _tmpl$15(),
+    _el$34 = _el$33.firstChild;
+  _$insert(_el$33, () => props.children, _el$34);
+  _$spread(
+    _el$34,
+    _$mergeProps(props, {
+      something: ""
+    }),
+    false,
+    false
+  );
+  return _el$33;
+})();
+const template26 = (() => {
+  var _el$35 = _tmpl$16();
+  _$setAttribute(_el$35, "middle", middle);
+  _$spread(_el$35, spread, false, true);
+  return _el$35;
+})();
+const template27 = (() => {
+  var _el$36 = _tmpl$16();
+  _$spread(
+    _el$36,
+    _$mergeProps(
+      first,
+      {
+        middle: middle
+      },
+      second
+    ),
+    false,
+    true
+  );
+  return _el$36;
+})();
+const template28 = (() => {
+  var _el$37 = _tmpl$17(),
+    _el$38 = _el$37.firstChild,
+    _el$39 = _el$38.firstChild,
+    _el$40 = _el$38.nextSibling,
+    _el$41 = _el$40.nextSibling;
+  _$spread(_el$37, _$mergeProps(api), false, true);
+  _$spread(_el$38, _$mergeProps(api), false, true);
+  _$insert(_el$38, () => (api() ? "checked" : "unchecked"), null);
+  _$spread(_el$40, _$mergeProps(api), false, false);
+  _$spread(_el$41, _$mergeProps(api), false, false);
+  return _el$37;
+})();
+const template29 = (() => {
+  var _el$42 = _tmpl$4();
+  _$setAttribute(_el$42, "attribute", !!someValue);
+  _$insert(_el$42, !!someValue);
+  return _el$42;
+})();
+const template30 = _tmpl$18();
+const template31 = (() => {
+  var _el$44 = _tmpl$4();
+  _$effect(_$p =>
+    (_$p = getStore.itemProperties.color) != null
+      ? _el$44.style.setProperty("background-color", _$p)
+      : _el$44.style.removeProperty("background-color")
+  );
+  return _el$44;
+})();
+const template32 = (() => {
+  var _el$45 = _tmpl$4();
+  _el$45.style.removeProperty("background-color");
+  return _el$45;
+})();
+const template33 = [
+  (() => {
+    var _el$46 = _tmpl$19();
+    _$className(_el$46, styles.button);
+    return _el$46;
+  })(),
+  (() => {
+    var _el$47 = _tmpl$19();
+    _$className(_el$47, styles["foo--bar"]);
+    return _el$47;
+  })(),
+  (() => {
+    var _el$48 = _tmpl$19();
+    _$effect(() => _$className(_el$48, styles.foo.bar));
+    return _el$48;
+  })(),
+  (() => {
+    var _el$49 = _tmpl$19();
+    _$effect(() => _$className(_el$49, styles[foo()]));
+    return _el$49;
+  })()
+];
+const template34 = (() => {
+  var _el$50 = _tmpl$4();
+  _$use(zero, _el$50, () => 0);
+  _$use(something, _el$50, () => true);
+  _$spread(_el$50, somethingElse, false, false);
+  return _el$50;
+})();
+const template35 = (() => {
+  var _el$51 = _tmpl$4();
+  var _ref$4 = a().b.c;
+  typeof _ref$4 === "function" ? _$use(_ref$4, _el$51) : (a().b.c = _el$51);
+  return _el$51;
+})();
+const template36 = (() => {
+  var _el$52 = _tmpl$4();
+  var _ref$5 = a().b?.c;
+  typeof _ref$5 === "function" && _$use(_ref$5, _el$52);
+  return _el$52;
+})();
+const template37 = (() => {
+  var _el$53 = _tmpl$4();
+  var _ref$6 = a() ? b : c;
+  typeof _ref$6 === "function" && _$use(_ref$6, _el$53);
+  return _el$53;
+})();
+const template38 = (() => {
+  var _el$54 = _tmpl$4();
+  var _ref$7 = a() ?? b;
+  typeof _ref$7 === "function" && _$use(_ref$7, _el$54);
+  return _el$54;
+})();
+const template39 = _tmpl$20();
+const template40 = (() => {
+  var _el$56 = _tmpl$4();
+  _$effect(_$p =>
+    (_$p = a()) != null
+      ? _el$56.style.setProperty("color", _$p)
+      : _el$56.style.removeProperty("color")
+  );
+  return _el$56;
+})();
+const template41 = (() => {
+  var _el$57 = _tmpl$21(),
+    _el$58 = _el$57.firstChild,
+    _el$59 = _el$58.nextSibling;
+  _$effect(() => (_el$58.value = Color.Red));
+  _$effect(() => (_el$59.value = Color.Blue));
+  _$effect(() => (_el$57.value = state.color));
+  return _el$57;
+})();
+
+// bool:
+function boolTest() {
+  return true;
+}
+const boolTestBinding = false;
+const boolTestObjBinding = {
+  value: false
+};
+const template42 = _tmpl$22();
+const template43 = _tmpl$23();
+const template44 = _tmpl$24();
+const template45 = _tmpl$25();
+const template46 = _tmpl$26();
+const template47 = _tmpl$27();
+const template48 = _tmpl$28();
+const template49 = _tmpl$29();
+const template50 = _tmpl$30();
+const template51 = _tmpl$31();
+const template52 = _tmpl$32();
+const template53 = _tmpl$33();
+const template54 = (() => {
+  var _el$72 = _tmpl$34();
+  _$effect(() => _$setBoolAttribute(_el$72, "quack", boolTest()));
+  return _el$72;
+})();
+const template55 = (() => {
+  var _el$73 = _tmpl$35();
+  _$setBoolAttribute(_el$73, "quack", boolTest);
+  return _el$73;
+})();
+const template56 = (() => {
+  var _el$74 = _tmpl$36();
+  _$setBoolAttribute(_el$74, "quack", boolTestBinding);
+  return _el$74;
+})();
+const template57 = (() => {
+  var _el$75 = _tmpl$37();
+  _$effect(() => _$setBoolAttribute(_el$75, "quack", boolTestObjBinding.value));
+  return _el$75;
+})();
+const template58 = (() => {
+  var _el$76 = _tmpl$38();
+  _$setBoolAttribute(_el$76, "quack", () => false);
+  return _el$76;
+})();
+const template59 = _tmpl$39();
+const template60 = _tmpl$40();
+const template61 = _tmpl$41();
+// this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;
+
+const template63 = _tmpl$42();
+const template64 = _tmpl$43();
+const template65 = _tmpl$44();
+const template66 = _tmpl$45();
+const template67 = _tmpl$46();
+const template68 = _tmpl$47();
+const template69 = _tmpl$48();
+const template70 = _tmpl$49();
+const template71 = _tmpl$50();
+const template72 = (() => {
+  var _el$89 = _tmpl$4();
+  _$use(binding, _el$89);
+  return _el$89;
+})();
+const template73 = (() => {
+  var _el$90 = _tmpl$4();
+  var _ref$8 = binding.prop;
+  typeof _ref$8 === "function" ? _$use(_ref$8, _el$90) : (binding.prop = _el$90);
+  return _el$90;
+})();
+const template74 = (() => {
+  var _el$91 = _tmpl$4();
+  var _ref$9 = refFn;
+  typeof _ref$9 === "function" ? _$use(_ref$9, _el$91) : (refFn = _el$91);
+  return _el$91;
+})();
+const template75 = (() => {
+  var _el$92 = _tmpl$4();
+  _$use(refConst, _el$92);
+  return _el$92;
+})();
+const template76 = (() => {
+  var _el$93 = _tmpl$4();
+  var _ref$10 = refUnknown;
+  typeof _ref$10 === "function" ? _$use(_ref$10, _el$93) : (refUnknown = _el$93);
+  return _el$93;
+})();
+const template77 = _tmpl$51();
+const template78 = _tmpl$52();
+const template79 = (() => {
+  var _el$96 = _tmpl$4();
+  _el$96.true = true;
+  _el$96.false = false;
+  return _el$96;
+})();
+const template80 = (() => {
+  var _el$97 = _tmpl$4();
+  _$setAttribute(_el$97, "true", true);
+  _$setAttribute(_el$97, "false", false);
+  return _el$97;
+})();
+const template81 = _tmpl$53();
+const template82 = _tmpl$54();
+_$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/simpleElements/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/simpleElements/code.js
@@ -1,0 +1,53 @@
+const template = (
+  <div id="main">
+    <style>{"div { color: red; }"}</style>
+    <h1>Welcome</h1>
+    <label for={"entry"}>Edit:</label>
+    <input id="entry" type="text" />
+    {/* Comment Node */}
+  </div>
+);
+
+const template2 = (
+  <div>
+    <span>
+      <a></a>
+    </span>
+    <span />
+  </div>
+);
+
+const template3 = (
+  <div>
+    <div>
+      <table>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div></div>
+  </div>
+);
+
+const template4 = (
+  <div>
+    <div>
+      <footer>
+        <div />
+      </footer>
+    </div>
+    <div>
+      <button>
+        <span>{0}</span>
+      </button>
+    </div>
+  </div>
+);
+
+const template5 = (
+  <div>
+    <noscript>
+      No JS!!
+      <style>{"div { color: red; }"}</style>
+    </noscript>
+  </div>
+)

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/simpleElements/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/simpleElements/output.js
@@ -1,0 +1,17 @@
+import { template as _$template } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(
+    `<div id="main"><style>div \{ color: red; }</style><h1>Welcome</h1><label for="entry">Edit:</label><input id="entry"type="text"></div>`
+  ),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div><span><a></a></span><span></span></div>`),
+  _tmpl$3 = /*#__PURE__*/ _$template(
+    `<div><div><table><tbody></tbody></table></div><div></div></div>`
+  ),
+  _tmpl$4 = /*#__PURE__*/ _$template(
+    `<div><div><footer><div></div></footer></div><div><button><span>0</span></button></div></div>`
+  ),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<div><noscript></noscript></div>`);
+const template = _tmpl$();
+const template2 = _tmpl$2();
+const template3 = _tmpl$3();
+const template4 = _tmpl$4();
+const template5 = _tmpl$5();

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-compatible.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-compatible.spec.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const pluginTester = require('babel-plugin-tester').default;
+const plugin = require('../index');
+
+pluginTester({
+  plugin,
+  pluginOptions: {
+    moduleName: 'r-dom',
+    builtIns: ['For', 'Show'],
+    generate: "dom",
+    wrapConditionals: true,
+    contextToCustomElements: true,
+    staticMarker: "@once",
+    requireImportSource: false,
+    omitLastClosingTag: false,
+    omitQuotes: false,
+  },
+  title: 'Convert JSX',
+  fixtures: path.join(__dirname, '__dom_compatible_fixtures__'),
+  snapshot: true
+});


### PR DESCRIPTION
We're building a UI in a browser-like environment for game engines named [Gameface by Coherent Labs](https://coherent-labs.com/) which [powers many popular titles with millions of players worldwide](https://coherent-labs.com/powered-by-coherent-labs/). Coherent Labs is trying to make Solid the recommended choice for in-game UI developed using Gameface via their [open source UI component library](https://github.com/CoherentLabs/Gameface-UI).

Unfortunately, `dom-expressions` currently makes some omissions when generating templates from JSX that aren't digestible by that browser. Namely, omitting closing tags and quotes, which while [OK according to the HTML spec](https://html.spec.whatwg.org/#attribute-value-(unquoted)-state), [isn't acceptable under the XML spec](https://www.w3.org/TR/xml/) which governs SVG in that browser's implementation.

This created unforeseen issues when migrating our own UI from React to Solid, causing all sorts of issues with our SVG usage in JSX.

There are two potential solutions to this problem:
1. Adding more backwards compatible configuration to `dom-expressions` to allow for such environments
2. Breaking backwards compatibility with past behavior by always following the more strict XML spec in case of SVG tags and attributes

This PR opts for the former, less disruptive solution (also fixing an incorrect documentation of the default value for `omitNestedClosingTags`), while recommending for a future version of `dom-expressions` to implement the latter solution (2) and make sure that SVG code, being XML and often parsed with a stricter parser, have different behavior when it comes to the omissions.

It adds the following configuration parameters (with corresponding tests) while keeping the default values true to pre-existing behavior:
```

### omitLastClosingTag

- Type: `boolean`
- Default: `true`

Removes tags from the template output if they have no closing parents and are the last element. This may not work in all browser-like environments the same. The solution has been tested again Chrome/Edge/Firefox/Safari.

### omitQuotes

- Type: `boolean`
- Default: `true`

Removes quotes for html attributes when possible from the template output. This may not work in all browser-like environments the same. The solution has been tested again Chrome/Edge/Firefox/Safari.
```