### PR TITLE
main: undo inline in template boolean literals #385

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -122,7 +122,8 @@ export function transformElement(path, info) {
   if (!voidTag) {
     // always close tags can still be skipped if they have no closing parents and are the last element
     const toBeClosed =
-      (!info.lastElement || !config.omitLastClosingTag) ||
+      !info.lastElement ||
+      !config.omitLastClosingTag ||
       (info.toBeClosed && (!config.omitNestedClosingTags || info.toBeClosed.has(tagName)));
     if (toBeClosed) {
       results.toBeClosed = new Set(info.toBeClosed || alwaysClose);
@@ -487,12 +488,7 @@ function transformAttributes(path, results) {
       if (
         t.isJSXExpressionContainer(value) &&
         (reservedNameSpace ||
-          !(
-            t.isStringLiteral(value.expression) ||
-            t.isNumericLiteral(value.expression) ||
-            // remove `!isCE` when custom elements start defaulting to attributes
-            (t.isBooleanLiteral(value.expression) && !isCE)
-          ))
+          !(t.isStringLiteral(value.expression) || t.isNumericLiteral(value.expression)))
       ) {
         if (key === "ref") {
           // Normalize expressions for non-null and type-as
@@ -809,17 +805,6 @@ function transformAttributes(path, results) {
           return;
         }
         if (t.isJSXExpressionContainer(value)) value = value.expression;
-
-        // boolean as `<el attr={true | false}/>`, not as `<el attr={"true" | "false"}/>`
-        // `<el attr={true}/>` becomes `<el attr/>`
-        // `<el attr={false}/>` becomes `<el/>`
-        if (t.isBooleanLiteral(value)) {
-          if (value.value === true) {
-            results.template += `${needsSpacing ? " " : ""}${key}`;
-            needsSpacing = true;
-          }
-          return;
-        }
 
         // properties
         key = Aliases[key] || key;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -19,69 +19,68 @@ var _tmpl$ = /*#__PURE__*/ _$template(
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo></div>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div></div>`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b"></div>`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type="checkbox"checked>`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<input type="checkbox">`),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\`</div>`),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type="button">Write</button>`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi</button>`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col"></div>`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly><input></div>`),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;"></div>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<a></a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div><a></a></div>`),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<div start="Hi">Hi</div>`),
-  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div></div></label>`),
-  _tmpl$18 = /*#__PURE__*/ _$template(
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type="checkbox">`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\`</div>`),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi"type="button">Write</button>`),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi</button>`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col"></div>`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly><input></div>`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;"></div>`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<a></a>`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<div><a></a></div>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div start="Hi">Hi</div>`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div></div></label>`),
+  _tmpl$17 = /*#__PURE__*/ _$template(
     `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4"></div>`
   ),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<button></button>`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<input value="10">`),
-  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue</option></select>`),
-  _tmpl$22 = /*#__PURE__*/ _$template(`<div>empty string</div>`),
-  _tmpl$23 = /*#__PURE__*/ _$template(`<div>js empty</div>`),
-  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>hola</div>`),
-  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>"hola js"</div>`),
-  _tmpl$26 = /*#__PURE__*/ _$template(`<div quack>true</div>`),
-  _tmpl$27 = /*#__PURE__*/ _$template(`<div>false</div>`),
-  _tmpl$28 = /*#__PURE__*/ _$template(`<div quack>1</div>`),
-  _tmpl$29 = /*#__PURE__*/ _$template(`<div>0</div>`),
-  _tmpl$30 = /*#__PURE__*/ _$template(`<div quack>"1"</div>`),
-  _tmpl$31 = /*#__PURE__*/ _$template(`<div>"0"</div>`),
-  _tmpl$32 = /*#__PURE__*/ _$template(`<div>undefined</div>`),
-  _tmpl$33 = /*#__PURE__*/ _$template(`<div>null</div>`),
-  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest()</div>`),
-  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTest</div>`),
-  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestBinding</div>`),
-  _tmpl$37 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value</div>`),
-  _tmpl$38 = /*#__PURE__*/ _$template(`<div>fn</div>`),
-  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack>should have space before</div>`),
-  _tmpl$40 = /*#__PURE__*/ _$template(
+  _tmpl$18 = /*#__PURE__*/ _$template(`<button></button>`),
+  _tmpl$19 = /*#__PURE__*/ _$template(`<input value="10">`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue</option></select>`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<div>empty string</div>`),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<div>js empty</div>`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<div quack>hola</div>`),
+  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>"hola js"</div>`),
+  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>true</div>`),
+  _tmpl$26 = /*#__PURE__*/ _$template(`<div>false</div>`),
+  _tmpl$27 = /*#__PURE__*/ _$template(`<div quack>1</div>`),
+  _tmpl$28 = /*#__PURE__*/ _$template(`<div>0</div>`),
+  _tmpl$29 = /*#__PURE__*/ _$template(`<div quack>"1"</div>`),
+  _tmpl$30 = /*#__PURE__*/ _$template(`<div>"0"</div>`),
+  _tmpl$31 = /*#__PURE__*/ _$template(`<div>undefined</div>`),
+  _tmpl$32 = /*#__PURE__*/ _$template(`<div>null</div>`),
+  _tmpl$33 = /*#__PURE__*/ _$template(`<div>boolTest()</div>`),
+  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest</div>`),
+  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTestBinding</div>`),
+  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value</div>`),
+  _tmpl$37 = /*#__PURE__*/ _$template(`<div>fn</div>`),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<div before quack>should have space before</div>`),
+  _tmpl$39 = /*#__PURE__*/ _$template(
     `<div before quack after>should have space before/after</div>`
   ),
-  _tmpl$41 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after</div>`),
-  _tmpl$42 = /*#__PURE__*/ _$template(`<img src>`),
-  _tmpl$43 = /*#__PURE__*/ _$template(`<div><img src></div>`),
-  _tmpl$44 = /*#__PURE__*/ _$template(`<img src loading="lazy">`, true, false, false),
-  _tmpl$45 = /*#__PURE__*/ _$template(`<div><img src loading="lazy"></div>`, true, false, false),
-  _tmpl$46 = /*#__PURE__*/ _$template(`<iframe src></iframe>`),
-  _tmpl$47 = /*#__PURE__*/ _$template(`<div><iframe src></iframe></div>`),
-  _tmpl$48 = /*#__PURE__*/ _$template(`<iframe src loading="lazy"></iframe>`, true, false, false),
-  _tmpl$49 = /*#__PURE__*/ _$template(
+  _tmpl$40 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after</div>`),
+  _tmpl$41 = /*#__PURE__*/ _$template(`<img src>`),
+  _tmpl$42 = /*#__PURE__*/ _$template(`<div><img src></div>`),
+  _tmpl$43 = /*#__PURE__*/ _$template(`<img src loading="lazy">`, true, false, false),
+  _tmpl$44 = /*#__PURE__*/ _$template(`<div><img src loading="lazy"></div>`, true, false, false),
+  _tmpl$45 = /*#__PURE__*/ _$template(`<iframe src></iframe>`),
+  _tmpl$46 = /*#__PURE__*/ _$template(`<div><iframe src></iframe></div>`),
+  _tmpl$47 = /*#__PURE__*/ _$template(`<iframe src loading="lazy"></iframe>`, true, false, false),
+  _tmpl$48 = /*#__PURE__*/ _$template(
     `<div><iframe src loading="lazy"></iframe></div>`,
     true,
     false,
     false
   ),
-  _tmpl$50 = /*#__PURE__*/ _$template(`<div title="<u>data</u>"></div>`),
-  _tmpl$51 = /*#__PURE__*/ _$template(`<div true truestr="true"truestrjs="true"></div>`),
-  _tmpl$52 = /*#__PURE__*/ _$template(`<div falsestr="false"falsestrjs="false"></div>`),
-  _tmpl$53 = /*#__PURE__*/ _$template(
+  _tmpl$49 = /*#__PURE__*/ _$template(`<div title="<u>data</u>"></div>`),
+  _tmpl$50 = /*#__PURE__*/ _$template(`<div truestr="true"truestrjs="true"></div>`),
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div falsestr="false"falsestrjs="false"></div>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(
     `<math display="block"><mrow></mrow></math>`,
     false,
     false,
     true
   ),
-  _tmpl$54 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true);
+  _tmpl$53 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -241,16 +240,20 @@ const template12 = (() => {
   _$setAttribute(_el$18, "onclick", "console.log('hi')");
   return _el$18;
 })();
-const template13 = _tmpl$6();
+const template13 = (() => {
+  var _el$19 = _tmpl$6();
+  _el$19.checked = true;
+  return _el$19;
+})();
 const template14 = (() => {
-  var _el$20 = _tmpl$7();
+  var _el$20 = _tmpl$6();
   _$effect(() => (_el$20.checked = state.visible));
   return _el$20;
 })();
-const template15 = _tmpl$8();
-const template16 = _tmpl$9();
+const template15 = _tmpl$7();
+const template16 = _tmpl$8();
 const template17 = (() => {
-  var _el$23 = _tmpl$10();
+  var _el$23 = _tmpl$9();
   _$addEventListener(_el$23, "click", increment, true);
   return _el$23;
 })();
@@ -268,9 +271,9 @@ const template18 = (() => {
   );
   return _el$24;
 })();
-const template19 = _tmpl$11();
+const template19 = _tmpl$10();
 const template20 = (() => {
-  var _el$26 = _tmpl$12(),
+  var _el$26 = _tmpl$11(),
     _el$27 = _el$26.firstChild,
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
@@ -313,7 +316,7 @@ const template21 = (() => {
   );
   return _el$29;
 })();
-const template22 = _tmpl$13();
+const template22 = _tmpl$12();
 const template23 = (() => {
   var _el$31 = _tmpl$4();
   _$insert(_el$31, () => "t" in test && "true");
@@ -321,7 +324,7 @@ const template23 = (() => {
   return _el$31;
 })();
 const template24 = (() => {
-  var _el$32 = _tmpl$14();
+  var _el$32 = _tmpl$13();
   _$spread(
     _el$32,
     _$mergeProps(props, {
@@ -333,7 +336,7 @@ const template24 = (() => {
   return _el$32;
 })();
 const template25 = (() => {
-  var _el$33 = _tmpl$15(),
+  var _el$33 = _tmpl$14(),
     _el$34 = _el$33.firstChild;
   _$insert(_el$33, () => props.children, _el$34);
   _$spread(
@@ -347,13 +350,13 @@ const template25 = (() => {
   return _el$33;
 })();
 const template26 = (() => {
-  var _el$35 = _tmpl$16();
+  var _el$35 = _tmpl$15();
   _$setAttribute(_el$35, "middle", middle);
   _$spread(_el$35, spread, false, true);
   return _el$35;
 })();
 const template27 = (() => {
-  var _el$36 = _tmpl$16();
+  var _el$36 = _tmpl$15();
   _$spread(
     _el$36,
     _$mergeProps(
@@ -369,7 +372,7 @@ const template27 = (() => {
   return _el$36;
 })();
 const template28 = (() => {
-  var _el$37 = _tmpl$17(),
+  var _el$37 = _tmpl$16(),
     _el$38 = _el$37.firstChild,
     _el$39 = _el$38.firstChild,
     _el$40 = _el$38.nextSibling,
@@ -387,7 +390,7 @@ const template29 = (() => {
   _$insert(_el$42, !!someValue);
   return _el$42;
 })();
-const template30 = _tmpl$18();
+const template30 = _tmpl$17();
 const template31 = (() => {
   var _el$44 = _tmpl$4();
   _$effect(_$p =>
@@ -404,22 +407,22 @@ const template32 = (() => {
 })();
 const template33 = [
   (() => {
-    var _el$46 = _tmpl$19();
+    var _el$46 = _tmpl$18();
     _$className(_el$46, styles.button);
     return _el$46;
   })(),
   (() => {
-    var _el$47 = _tmpl$19();
+    var _el$47 = _tmpl$18();
     _$className(_el$47, styles["foo--bar"]);
     return _el$47;
   })(),
   (() => {
-    var _el$48 = _tmpl$19();
+    var _el$48 = _tmpl$18();
     _$effect(() => _$className(_el$48, styles.foo.bar));
     return _el$48;
   })(),
   (() => {
-    var _el$49 = _tmpl$19();
+    var _el$49 = _tmpl$18();
     _$effect(() => _$className(_el$49, styles[foo()]));
     return _el$49;
   })()
@@ -455,7 +458,7 @@ const template38 = (() => {
   typeof _ref$7 === "function" && _$use(_ref$7, _el$54);
   return _el$54;
 })();
-const template39 = _tmpl$20();
+const template39 = _tmpl$19();
 const template40 = (() => {
   var _el$56 = _tmpl$4();
   _$effect(_$p =>
@@ -466,7 +469,7 @@ const template40 = (() => {
   return _el$56;
 })();
 const template41 = (() => {
-  var _el$57 = _tmpl$21(),
+  var _el$57 = _tmpl$20(),
     _el$58 = _el$57.firstChild,
     _el$59 = _el$58.nextSibling;
   _$effect(() => (_el$58.value = Color.Red));
@@ -483,57 +486,57 @@ const boolTestBinding = false;
 const boolTestObjBinding = {
   value: false
 };
-const template42 = _tmpl$22();
-const template43 = _tmpl$23();
-const template44 = _tmpl$24();
-const template45 = _tmpl$25();
-const template46 = _tmpl$26();
-const template47 = _tmpl$27();
-const template48 = _tmpl$28();
-const template49 = _tmpl$29();
-const template50 = _tmpl$30();
-const template51 = _tmpl$31();
-const template52 = _tmpl$32();
-const template53 = _tmpl$33();
+const template42 = _tmpl$21();
+const template43 = _tmpl$22();
+const template44 = _tmpl$23();
+const template45 = _tmpl$24();
+const template46 = _tmpl$25();
+const template47 = _tmpl$26();
+const template48 = _tmpl$27();
+const template49 = _tmpl$28();
+const template50 = _tmpl$29();
+const template51 = _tmpl$30();
+const template52 = _tmpl$31();
+const template53 = _tmpl$32();
 const template54 = (() => {
-  var _el$72 = _tmpl$34();
+  var _el$72 = _tmpl$33();
   _$effect(() => _$setBoolAttribute(_el$72, "quack", boolTest()));
   return _el$72;
 })();
 const template55 = (() => {
-  var _el$73 = _tmpl$35();
+  var _el$73 = _tmpl$34();
   _$setBoolAttribute(_el$73, "quack", boolTest);
   return _el$73;
 })();
 const template56 = (() => {
-  var _el$74 = _tmpl$36();
+  var _el$74 = _tmpl$35();
   _$setBoolAttribute(_el$74, "quack", boolTestBinding);
   return _el$74;
 })();
 const template57 = (() => {
-  var _el$75 = _tmpl$37();
+  var _el$75 = _tmpl$36();
   _$effect(() => _$setBoolAttribute(_el$75, "quack", boolTestObjBinding.value));
   return _el$75;
 })();
 const template58 = (() => {
-  var _el$76 = _tmpl$38();
+  var _el$76 = _tmpl$37();
   _$setBoolAttribute(_el$76, "quack", () => false);
   return _el$76;
 })();
-const template59 = _tmpl$39();
-const template60 = _tmpl$40();
-const template61 = _tmpl$41();
+const template59 = _tmpl$38();
+const template60 = _tmpl$39();
+const template61 = _tmpl$40();
 // this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;
 
-const template63 = _tmpl$42();
-const template64 = _tmpl$43();
-const template65 = _tmpl$44();
-const template66 = _tmpl$45();
-const template67 = _tmpl$46();
-const template68 = _tmpl$47();
-const template69 = _tmpl$48();
-const template70 = _tmpl$49();
-const template71 = _tmpl$50();
+const template63 = _tmpl$41();
+const template64 = _tmpl$42();
+const template65 = _tmpl$43();
+const template66 = _tmpl$44();
+const template67 = _tmpl$45();
+const template68 = _tmpl$46();
+const template69 = _tmpl$47();
+const template70 = _tmpl$48();
+const template71 = _tmpl$49();
 const template72 = (() => {
   var _el$89 = _tmpl$4();
   _$use(binding, _el$89);
@@ -562,8 +565,16 @@ const template76 = (() => {
   typeof _ref$10 === "function" ? _$use(_ref$10, _el$93) : (refUnknown = _el$93);
   return _el$93;
 })();
-const template77 = _tmpl$51();
-const template78 = _tmpl$52();
+const template77 = (() => {
+  var _el$94 = _tmpl$50();
+  _$setAttribute(_el$94, "true", true);
+  return _el$94;
+})();
+const template78 = (() => {
+  var _el$95 = _tmpl$51();
+  _$setAttribute(_el$95, "false", false);
+  return _el$95;
+})();
 const template79 = (() => {
   var _el$96 = _tmpl$4();
   _el$96.true = true;
@@ -576,6 +587,6 @@ const template80 = (() => {
   _$setAttribute(_el$97, "false", false);
   return _el$97;
 })();
-const template81 = _tmpl$53();
-const template82 = _tmpl$54();
+const template81 = _tmpl$52();
+const template82 = _tmpl$53();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -17,57 +17,56 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox checked>`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly><input>`),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div><a>`),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
-  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div>`),
-  _tmpl$18 = /*#__PURE__*/ _$template(
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly><input>`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<a>`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<div><a>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div>`),
+  _tmpl$17 = /*#__PURE__*/ _$template(
     `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4">`
   ),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<button>`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<input value=10>`),
-  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
-  _tmpl$22 = /*#__PURE__*/ _$template(`<div>empty string`),
-  _tmpl$23 = /*#__PURE__*/ _$template(`<div>js empty`),
-  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>hola`),
-  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>"hola js"`),
-  _tmpl$26 = /*#__PURE__*/ _$template(`<div quack>true`),
-  _tmpl$27 = /*#__PURE__*/ _$template(`<div>false`),
-  _tmpl$28 = /*#__PURE__*/ _$template(`<div quack>1`),
-  _tmpl$29 = /*#__PURE__*/ _$template(`<div>0`),
-  _tmpl$30 = /*#__PURE__*/ _$template(`<div quack>"1"`),
-  _tmpl$31 = /*#__PURE__*/ _$template(`<div>"0"`),
-  _tmpl$32 = /*#__PURE__*/ _$template(`<div>undefined`),
-  _tmpl$33 = /*#__PURE__*/ _$template(`<div>null`),
-  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest()`),
-  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTest`),
-  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
-  _tmpl$37 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
-  _tmpl$38 = /*#__PURE__*/ _$template(`<div>fn`),
-  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack>should have space before`),
-  _tmpl$40 = /*#__PURE__*/ _$template(`<div before quack after>should have space before/after`),
-  _tmpl$41 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after`),
-  _tmpl$42 = /*#__PURE__*/ _$template(`<img src>`),
-  _tmpl$43 = /*#__PURE__*/ _$template(`<div><img src>`),
-  _tmpl$44 = /*#__PURE__*/ _$template(`<img src loading=lazy>`, true, false, false),
-  _tmpl$45 = /*#__PURE__*/ _$template(`<div><img src loading=lazy>`, true, false, false),
-  _tmpl$46 = /*#__PURE__*/ _$template(`<iframe src>`),
-  _tmpl$47 = /*#__PURE__*/ _$template(`<div><iframe src>`),
-  _tmpl$48 = /*#__PURE__*/ _$template(`<iframe src loading=lazy>`, true, false, false),
-  _tmpl$49 = /*#__PURE__*/ _$template(`<div><iframe src loading=lazy>`, true, false, false),
-  _tmpl$50 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`),
-  _tmpl$51 = /*#__PURE__*/ _$template(`<div true truestr=true truestrjs=true>`),
-  _tmpl$52 = /*#__PURE__*/ _$template(`<div falsestr=false falsestrjs=false>`),
-  _tmpl$53 = /*#__PURE__*/ _$template(`<math display=block><mrow>`, false, false, true),
-  _tmpl$54 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=`, false, false, true);
+  _tmpl$18 = /*#__PURE__*/ _$template(`<button>`),
+  _tmpl$19 = /*#__PURE__*/ _$template(`<input value=10>`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<div>empty string`),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<div>js empty`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<div quack>hola`),
+  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>"hola js"`),
+  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>true`),
+  _tmpl$26 = /*#__PURE__*/ _$template(`<div>false`),
+  _tmpl$27 = /*#__PURE__*/ _$template(`<div quack>1`),
+  _tmpl$28 = /*#__PURE__*/ _$template(`<div>0`),
+  _tmpl$29 = /*#__PURE__*/ _$template(`<div quack>"1"`),
+  _tmpl$30 = /*#__PURE__*/ _$template(`<div>"0"`),
+  _tmpl$31 = /*#__PURE__*/ _$template(`<div>undefined`),
+  _tmpl$32 = /*#__PURE__*/ _$template(`<div>null`),
+  _tmpl$33 = /*#__PURE__*/ _$template(`<div>boolTest()`),
+  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest`),
+  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
+  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
+  _tmpl$37 = /*#__PURE__*/ _$template(`<div>fn`),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<div before quack>should have space before`),
+  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack after>should have space before/after`),
+  _tmpl$40 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after`),
+  _tmpl$41 = /*#__PURE__*/ _$template(`<img src>`),
+  _tmpl$42 = /*#__PURE__*/ _$template(`<div><img src>`),
+  _tmpl$43 = /*#__PURE__*/ _$template(`<img src loading=lazy>`, true, false, false),
+  _tmpl$44 = /*#__PURE__*/ _$template(`<div><img src loading=lazy>`, true, false, false),
+  _tmpl$45 = /*#__PURE__*/ _$template(`<iframe src>`),
+  _tmpl$46 = /*#__PURE__*/ _$template(`<div><iframe src>`),
+  _tmpl$47 = /*#__PURE__*/ _$template(`<iframe src loading=lazy>`, true, false, false),
+  _tmpl$48 = /*#__PURE__*/ _$template(`<div><iframe src loading=lazy>`, true, false, false),
+  _tmpl$49 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`),
+  _tmpl$50 = /*#__PURE__*/ _$template(`<div truestr=true truestrjs=true>`),
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div falsestr=false falsestrjs=false>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<math display=block><mrow>`, false, false, true),
+  _tmpl$53 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=`, false, false, true);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -227,16 +226,20 @@ const template12 = (() => {
   _$setAttribute(_el$18, "onclick", "console.log('hi')");
   return _el$18;
 })();
-const template13 = _tmpl$6();
+const template13 = (() => {
+  var _el$19 = _tmpl$6();
+  _el$19.checked = true;
+  return _el$19;
+})();
 const template14 = (() => {
-  var _el$20 = _tmpl$7();
+  var _el$20 = _tmpl$6();
   _$effect(() => (_el$20.checked = state.visible));
   return _el$20;
 })();
-const template15 = _tmpl$8();
-const template16 = _tmpl$9();
+const template15 = _tmpl$7();
+const template16 = _tmpl$8();
 const template17 = (() => {
-  var _el$23 = _tmpl$10();
+  var _el$23 = _tmpl$9();
   _$addEventListener(_el$23, "click", increment, true);
   return _el$23;
 })();
@@ -254,9 +257,9 @@ const template18 = (() => {
   );
   return _el$24;
 })();
-const template19 = _tmpl$11();
+const template19 = _tmpl$10();
 const template20 = (() => {
-  var _el$26 = _tmpl$12(),
+  var _el$26 = _tmpl$11(),
     _el$27 = _el$26.firstChild,
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
@@ -299,7 +302,7 @@ const template21 = (() => {
   );
   return _el$29;
 })();
-const template22 = _tmpl$13();
+const template22 = _tmpl$12();
 const template23 = (() => {
   var _el$31 = _tmpl$4();
   _$insert(_el$31, () => "t" in test && "true");
@@ -307,7 +310,7 @@ const template23 = (() => {
   return _el$31;
 })();
 const template24 = (() => {
-  var _el$32 = _tmpl$14();
+  var _el$32 = _tmpl$13();
   _$spread(
     _el$32,
     _$mergeProps(props, {
@@ -319,7 +322,7 @@ const template24 = (() => {
   return _el$32;
 })();
 const template25 = (() => {
-  var _el$33 = _tmpl$15(),
+  var _el$33 = _tmpl$14(),
     _el$34 = _el$33.firstChild;
   _$insert(_el$33, () => props.children, _el$34);
   _$spread(
@@ -333,13 +336,13 @@ const template25 = (() => {
   return _el$33;
 })();
 const template26 = (() => {
-  var _el$35 = _tmpl$16();
+  var _el$35 = _tmpl$15();
   _$setAttribute(_el$35, "middle", middle);
   _$spread(_el$35, spread, false, true);
   return _el$35;
 })();
 const template27 = (() => {
-  var _el$36 = _tmpl$16();
+  var _el$36 = _tmpl$15();
   _$spread(
     _el$36,
     _$mergeProps(
@@ -355,7 +358,7 @@ const template27 = (() => {
   return _el$36;
 })();
 const template28 = (() => {
-  var _el$37 = _tmpl$17(),
+  var _el$37 = _tmpl$16(),
     _el$38 = _el$37.firstChild,
     _el$39 = _el$38.firstChild,
     _el$40 = _el$38.nextSibling,
@@ -373,7 +376,7 @@ const template29 = (() => {
   _$insert(_el$42, !!someValue);
   return _el$42;
 })();
-const template30 = _tmpl$18();
+const template30 = _tmpl$17();
 const template31 = (() => {
   var _el$44 = _tmpl$4();
   _$effect(_$p =>
@@ -390,22 +393,22 @@ const template32 = (() => {
 })();
 const template33 = [
   (() => {
-    var _el$46 = _tmpl$19();
+    var _el$46 = _tmpl$18();
     _$className(_el$46, styles.button);
     return _el$46;
   })(),
   (() => {
-    var _el$47 = _tmpl$19();
+    var _el$47 = _tmpl$18();
     _$className(_el$47, styles["foo--bar"]);
     return _el$47;
   })(),
   (() => {
-    var _el$48 = _tmpl$19();
+    var _el$48 = _tmpl$18();
     _$effect(() => _$className(_el$48, styles.foo.bar));
     return _el$48;
   })(),
   (() => {
-    var _el$49 = _tmpl$19();
+    var _el$49 = _tmpl$18();
     _$effect(() => _$className(_el$49, styles[foo()]));
     return _el$49;
   })()
@@ -441,7 +444,7 @@ const template38 = (() => {
   typeof _ref$7 === "function" && _$use(_ref$7, _el$54);
   return _el$54;
 })();
-const template39 = _tmpl$20();
+const template39 = _tmpl$19();
 const template40 = (() => {
   var _el$56 = _tmpl$4();
   _$effect(_$p =>
@@ -452,7 +455,7 @@ const template40 = (() => {
   return _el$56;
 })();
 const template41 = (() => {
-  var _el$57 = _tmpl$21(),
+  var _el$57 = _tmpl$20(),
     _el$58 = _el$57.firstChild,
     _el$59 = _el$58.nextSibling;
   _$effect(() => (_el$58.value = Color.Red));
@@ -469,57 +472,57 @@ const boolTestBinding = false;
 const boolTestObjBinding = {
   value: false
 };
-const template42 = _tmpl$22();
-const template43 = _tmpl$23();
-const template44 = _tmpl$24();
-const template45 = _tmpl$25();
-const template46 = _tmpl$26();
-const template47 = _tmpl$27();
-const template48 = _tmpl$28();
-const template49 = _tmpl$29();
-const template50 = _tmpl$30();
-const template51 = _tmpl$31();
-const template52 = _tmpl$32();
-const template53 = _tmpl$33();
+const template42 = _tmpl$21();
+const template43 = _tmpl$22();
+const template44 = _tmpl$23();
+const template45 = _tmpl$24();
+const template46 = _tmpl$25();
+const template47 = _tmpl$26();
+const template48 = _tmpl$27();
+const template49 = _tmpl$28();
+const template50 = _tmpl$29();
+const template51 = _tmpl$30();
+const template52 = _tmpl$31();
+const template53 = _tmpl$32();
 const template54 = (() => {
-  var _el$72 = _tmpl$34();
+  var _el$72 = _tmpl$33();
   _$effect(() => _$setBoolAttribute(_el$72, "quack", boolTest()));
   return _el$72;
 })();
 const template55 = (() => {
-  var _el$73 = _tmpl$35();
+  var _el$73 = _tmpl$34();
   _$setBoolAttribute(_el$73, "quack", boolTest);
   return _el$73;
 })();
 const template56 = (() => {
-  var _el$74 = _tmpl$36();
+  var _el$74 = _tmpl$35();
   _$setBoolAttribute(_el$74, "quack", boolTestBinding);
   return _el$74;
 })();
 const template57 = (() => {
-  var _el$75 = _tmpl$37();
+  var _el$75 = _tmpl$36();
   _$effect(() => _$setBoolAttribute(_el$75, "quack", boolTestObjBinding.value));
   return _el$75;
 })();
 const template58 = (() => {
-  var _el$76 = _tmpl$38();
+  var _el$76 = _tmpl$37();
   _$setBoolAttribute(_el$76, "quack", () => false);
   return _el$76;
 })();
-const template59 = _tmpl$39();
-const template60 = _tmpl$40();
-const template61 = _tmpl$41();
+const template59 = _tmpl$38();
+const template60 = _tmpl$39();
+const template61 = _tmpl$40();
 // this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;
 
-const template63 = _tmpl$42();
-const template64 = _tmpl$43();
-const template65 = _tmpl$44();
-const template66 = _tmpl$45();
-const template67 = _tmpl$46();
-const template68 = _tmpl$47();
-const template69 = _tmpl$48();
-const template70 = _tmpl$49();
-const template71 = _tmpl$50();
+const template63 = _tmpl$41();
+const template64 = _tmpl$42();
+const template65 = _tmpl$43();
+const template66 = _tmpl$44();
+const template67 = _tmpl$45();
+const template68 = _tmpl$46();
+const template69 = _tmpl$47();
+const template70 = _tmpl$48();
+const template71 = _tmpl$49();
 const template72 = (() => {
   var _el$89 = _tmpl$4();
   _$use(binding, _el$89);
@@ -548,8 +551,16 @@ const template76 = (() => {
   typeof _ref$10 === "function" ? _$use(_ref$10, _el$93) : (refUnknown = _el$93);
   return _el$93;
 })();
-const template77 = _tmpl$51();
-const template78 = _tmpl$52();
+const template77 = (() => {
+  var _el$94 = _tmpl$50();
+  _$setAttribute(_el$94, "true", true);
+  return _el$94;
+})();
+const template78 = (() => {
+  var _el$95 = _tmpl$51();
+  _$setAttribute(_el$95, "false", false);
+  return _el$95;
+})();
 const template79 = (() => {
   var _el$96 = _tmpl$4();
   _el$96.true = true;
@@ -562,6 +573,6 @@ const template80 = (() => {
   _$setAttribute(_el$97, "false", false);
   return _el$97;
 })();
-const template81 = _tmpl$53();
-const template82 = _tmpl$54();
+const template81 = _tmpl$52();
+const template82 = _tmpl$53();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -20,25 +20,24 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox checked>`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly><input>`),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div><!$><!/><a>`),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
-  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is <!$><!/></span><input><div>`),
-  _tmpl$18 = /*#__PURE__*/ _$template(
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly><input>`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<a>`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<div><!$><!/><a>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is <!$><!/></span><input><div>`),
+  _tmpl$17 = /*#__PURE__*/ _$template(
     `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4">`
   ),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<button>`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<input value=10>`),
-  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
-  _tmpl$22 = /*#__PURE__*/ _$template(`<div a a a a a=0 a a a>`);
+  _tmpl$18 = /*#__PURE__*/ _$template(`<button>`),
+  _tmpl$19 = /*#__PURE__*/ _$template(`<input value=10>`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<div a a a a=0 a a a>`);
 import * as styles from "./styles.module.css";
 const selected = true;
 let id = "my-h1";
@@ -197,16 +196,20 @@ const template12 = (() => {
   _$setAttribute(_el$18, "onclick", "console.log('hi')");
   return _el$18;
 })();
-const template13 = _$getNextElement(_tmpl$6);
+const template13 = (() => {
+  var _el$19 = _$getNextElement(_tmpl$6);
+  _$setProperty(_el$19, "checked", true);
+  return _el$19;
+})();
 const template14 = (() => {
-  var _el$20 = _$getNextElement(_tmpl$7);
+  var _el$20 = _$getNextElement(_tmpl$6);
   _$effect(() => _$setProperty(_el$20, "checked", state.visible));
   return _el$20;
 })();
-const template15 = _$getNextElement(_tmpl$8);
-const template16 = _$getNextElement(_tmpl$9);
+const template15 = _$getNextElement(_tmpl$7);
+const template16 = _$getNextElement(_tmpl$8);
 const template17 = (() => {
-  var _el$23 = _$getNextElement(_tmpl$10);
+  var _el$23 = _$getNextElement(_tmpl$9);
   _$addEventListener(_el$23, "click", increment, true);
   _$runHydrationEvents();
   return _el$23;
@@ -226,9 +229,9 @@ const template18 = (() => {
   _$runHydrationEvents();
   return _el$24;
 })();
-const template19 = _$getNextElement(_tmpl$11);
+const template19 = _$getNextElement(_tmpl$10);
 const template20 = (() => {
-  var _el$26 = _$getNextElement(_tmpl$12),
+  var _el$26 = _$getNextElement(_tmpl$11),
     _el$27 = _el$26.firstChild,
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
@@ -272,7 +275,7 @@ const template21 = (() => {
   );
   return _el$29;
 })();
-const template22 = _$getNextElement(_tmpl$13);
+const template22 = _$getNextElement(_tmpl$12);
 const template23 = (() => {
   var _el$31 = _$getNextElement(_tmpl$4);
   _$insert(_el$31, () => "t" in test && "true");
@@ -280,7 +283,7 @@ const template23 = (() => {
   return _el$31;
 })();
 const template24 = (() => {
-  var _el$32 = _$getNextElement(_tmpl$14);
+  var _el$32 = _$getNextElement(_tmpl$13);
   _$spread(
     _el$32,
     _$mergeProps(props, {
@@ -293,7 +296,7 @@ const template24 = (() => {
   return _el$32;
 })();
 const template25 = (() => {
-  var _el$33 = _$getNextElement(_tmpl$15),
+  var _el$33 = _$getNextElement(_tmpl$14),
     _el$35 = _el$33.firstChild,
     [_el$36, _co$] = _$getNextMarker(_el$35.nextSibling),
     _el$34 = _el$36.nextSibling;
@@ -310,14 +313,14 @@ const template25 = (() => {
   return _el$33;
 })();
 const template26 = (() => {
-  var _el$37 = _$getNextElement(_tmpl$16);
+  var _el$37 = _$getNextElement(_tmpl$15);
   _$setAttribute(_el$37, "middle", middle);
   _$spread(_el$37, spread, false, true);
   _$runHydrationEvents();
   return _el$37;
 })();
 const template27 = (() => {
-  var _el$38 = _$getNextElement(_tmpl$16);
+  var _el$38 = _$getNextElement(_tmpl$15);
   _$spread(
     _el$38,
     _$mergeProps(
@@ -334,7 +337,7 @@ const template27 = (() => {
   return _el$38;
 })();
 const template28 = (() => {
-  var _el$39 = _$getNextElement(_tmpl$17),
+  var _el$39 = _$getNextElement(_tmpl$16),
     _el$40 = _el$39.firstChild,
     _el$41 = _el$40.firstChild,
     _el$42 = _el$41.nextSibling,
@@ -355,7 +358,7 @@ const template29 = (() => {
   _$insert(_el$46, !!someValue);
   return _el$46;
 })();
-const template30 = _$getNextElement(_tmpl$18);
+const template30 = _$getNextElement(_tmpl$17);
 const template31 = (() => {
   var _el$48 = _$getNextElement(_tmpl$4);
   _$effect(_$p =>
@@ -372,22 +375,22 @@ const template32 = (() => {
 })();
 const template33 = [
   (() => {
-    var _el$50 = _$getNextElement(_tmpl$19);
+    var _el$50 = _$getNextElement(_tmpl$18);
     _$className(_el$50, styles.button);
     return _el$50;
   })(),
   (() => {
-    var _el$51 = _$getNextElement(_tmpl$19);
+    var _el$51 = _$getNextElement(_tmpl$18);
     _$className(_el$51, styles["foo--bar"]);
     return _el$51;
   })(),
   (() => {
-    var _el$52 = _$getNextElement(_tmpl$19);
+    var _el$52 = _$getNextElement(_tmpl$18);
     _$effect(() => _$className(_el$52, styles.foo.bar));
     return _el$52;
   })(),
   (() => {
-    var _el$53 = _$getNextElement(_tmpl$19);
+    var _el$53 = _$getNextElement(_tmpl$18);
     _$effect(() => _$className(_el$53, styles[foo()]));
     return _el$53;
   })()
@@ -424,7 +427,7 @@ const template38 = (() => {
   typeof _ref$7 === "function" && _$use(_ref$7, _el$58);
   return _el$58;
 })();
-const template39 = _$getNextElement(_tmpl$20);
+const template39 = _$getNextElement(_tmpl$19);
 const template40 = (() => {
   var _el$60 = _$getNextElement(_tmpl$4);
   _$effect(_$p =>
@@ -435,7 +438,7 @@ const template40 = (() => {
   return _el$60;
 })();
 const template41 = (() => {
-  var _el$61 = _$getNextElement(_tmpl$21),
+  var _el$61 = _$getNextElement(_tmpl$20),
     _el$62 = _el$61.firstChild,
     _el$63 = _el$62.nextSibling;
   _$effect(() => _$setProperty(_el$62, "value", Color.Red));
@@ -444,7 +447,9 @@ const template41 = (() => {
   return _el$61;
 })();
 const template42 = (() => {
-  var _el$64 = _$getNextElement(_tmpl$22);
+  var _el$64 = _$getNextElement(_tmpl$21);
+  _$setAttribute(_el$64, "a", true);
+  _$setAttribute(_el$64, "a", false);
   _$setAttribute(_el$64, "a", undefined);
   _$setAttribute(_el$64, "a", null);
   _$setAttribute(_el$64, "a", void 0);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -13,7 +13,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$5 = /*#__PURE__*/ _$template(`<input type=checkbox checked readonly>`),
+  _tmpl$5 = /*#__PURE__*/ _$template(`<input type=checkbox readonly>`),
   _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`);
 const selected = true;
 let id = "my-h1";
@@ -163,7 +163,11 @@ const template12 = (() => {
   _el$18.htmlFor = thing;
   return _el$18;
 })();
-const template13 = _tmpl$5();
+const template13 = (() => {
+  var _el$19 = _tmpl$5();
+  _el$19.checked = true;
+  return _el$19;
+})();
 const template14 = (() => {
   var _el$20 = _tmpl$6();
   _el$20.readOnly = value;


### PR DESCRIPTION
Undo #385 that inadvertently introduced a breaking change for 1.9.x, by changing the behaviour of things like `<div draggable={true}/>` to be `<div draggable/>` instead of the current `<div draggable="true"/>`., this also affects other attributes as `aria-hidden`, etc.


However, the change undid here is already applied and desired in `next`, as that's the behaviour we want for Solid 2.0