### PR TITLE
fix prop/attr namespace error on children when value is a string

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -1106,7 +1106,6 @@ function detectExpressions(children, index, config) {
             ["textContent", "innerHTML", "innerText"].includes(attr.name.name) ||
             (attr.name.namespace &&
               (attr.name.namespace.name === "use" ||
-                attr.name.namespace.name === "bool" ||
                 attr.name.namespace.name === "attr" ||
                 attr.name.namespace.name === "prop")) ||
             (t.isJSXExpressionContainer(attr.value) &&

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -457,6 +457,64 @@ function transformAttributes(path, results) {
 
   let needsSpacing = true;
 
+  // scoped because of `needsSpacing`
+  function inlineAttributeOnTemplate(isSVG, key, results, value, customAttribute) {
+    !isSVG && (key = key.toLowerCase());
+    results.template += `${needsSpacing ? " " : ""}${key}`;
+
+    if (!value) {
+      needsSpacing = true;
+      return;
+    }
+
+    let text = value.value;
+    if (typeof text === "number") text = String(text);
+    let needsQuoting = !config.omitQuotes;
+
+    // `attr:style=";;strange::code;"` shouldn't be changed, as it's custom
+    if (!customAttribute) {
+      if (key === "style" || key === "class") {
+        text = trimWhitespace(text);
+        if (key === "style") {
+          text = text.replace(/; /g, ";").replace(/: /g, ":");
+        }
+      }
+    }
+
+    if (!text.length) {
+      needsSpacing = true;
+      results.template += ``;
+      return;
+    }
+
+    for (let i = 0, len = text.length; i < len; i++) {
+      let char = text[i];
+
+      if (
+        char === "'" ||
+        char === '"' ||
+        char === " " ||
+        char === "\t" ||
+        char === "\n" ||
+        char === "\r" ||
+        char === "`" ||
+        char === "=" ||
+        char === "<" ||
+        char === ">"
+      ) {
+        needsQuoting = true;
+      }
+    }
+
+    if (needsQuoting) {
+      needsSpacing = false;
+      results.template += `="${escapeHTML(text, true)}"`;
+    } else {
+      needsSpacing = true;
+      results.template += `=${escapeHTML(text, true)}`;
+    }
+  }
+
   path
     .get("openingElement")
     .get("attributes")
@@ -747,6 +805,24 @@ function transformAttributes(path, results) {
             isCE,
             tagName
           });
+        } else if (key.slice(0, 5) === "attr:") {
+          if (t.isJSXExpressionContainer(value)) value = value.expression;
+
+          /**
+           * TODO: Unfortunately, `attr:onclick` changes too many tests, as we are working in
+           * `minor/next` it will mess up merging. This condition `key !== "onclick" &&` to be
+           * removed once we reach Solid 2.0, which will change a lot of tests.
+           */
+
+          if (key !== "attr:onclick" && (t.isStringLiteral(value) || t.isNumericLiteral(value))) {
+            // inlined  "attr:"
+            inlineAttributeOnTemplate(isSVG, key.slice(5), results, value, true);
+          } else {
+            // dynamic "attr:"
+            results.exprs.push(
+              t.expressionStatement(setAttr(attribute, elem, key, value, { isSVG, isCE, tagName }))
+            );
+          }
         } else if (key.slice(0, 5) === "bool:") {
           // inline it on the template when possible
           let content = value;
@@ -815,62 +891,7 @@ function transformAttributes(path, results) {
             t.expressionStatement(setAttr(attribute, elem, key, value, { isSVG, isCE, tagName }))
           );
         } else {
-          !isSVG && (key = key.toLowerCase());
-          results.template += `${needsSpacing ? " " : ""}${key}`;
-          // https://github.com/solidjs/solid/issues/2338
-          // results.templateWithClosingTags += `${needsSpacing ? ' ' : ''}${key}`;
-          if (!value) {
-            needsSpacing = true;
-            return;
-          }
-
-          let text = value.value;
-          if (typeof text === "number") text = String(text);
-          let needsQuoting = !config.omitQuotes;
-
-          if (key === "style" || key === "class") {
-            text = trimWhitespace(text);
-            if (key === "style") {
-              text = text.replace(/; /g, ";").replace(/: /g, ":");
-            }
-          }
-
-          if (!text.length) {
-            needsSpacing = true;
-            results.template += ``;
-            return;
-          }
-
-          for (let i = 0, len = text.length; i < len; i++) {
-            let char = text[i];
-
-            if (
-              char === "'" ||
-              char === '"' ||
-              char === " " ||
-              char === "\t" ||
-              char === "\n" ||
-              char === "\r" ||
-              char === "`" ||
-              char === "=" ||
-              char === "<" ||
-              char === ">"
-            ) {
-              needsQuoting = true;
-            }
-          }
-
-          if (needsQuoting) {
-            needsSpacing = false;
-            results.template += `="${escapeHTML(text, true)}"`;
-            // https://github.com/solidjs/solid/issues/2338
-            // results.templateWithClosingTags += `="${escapeHTML(text, true)}"`;
-          } else {
-            needsSpacing = true;
-            results.template += `=${escapeHTML(text, true)}`;
-            // https://github.com/solidjs/solid/issues/2338
-            // results.templateWithClosingTags += `=${escapeHTML(text, true)}`;
-          }
+          inlineAttributeOnTemplate(isSVG, key, results, value);
         }
       }
     });
@@ -1105,9 +1126,7 @@ function detectExpressions(children, index, config) {
             t.isJSXSpreadAttribute(attr) ||
             ["textContent", "innerHTML", "innerText"].includes(attr.name.name) ||
             (attr.name.namespace &&
-              (attr.name.namespace.name === "use" ||
-                attr.name.namespace.name === "attr" ||
-                attr.name.namespace.name === "prop")) ||
+              (attr.name.namespace.name === "use" || attr.name.namespace.name === "prop")) ||
             (t.isJSXExpressionContainer(attr.value) &&
               !(
                 t.isStringLiteral(attr.value.expression) ||

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -458,7 +458,7 @@ function transformAttributes(path, results) {
   let needsSpacing = true;
 
   // scoped because of `needsSpacing`
-  function inlineAttributeOnTemplate(isSVG, key, results, value, customAttribute) {
+  function inlineAttributeOnTemplate(isSVG, key, results, value) {
     !isSVG && (key = key.toLowerCase());
     results.template += `${needsSpacing ? " " : ""}${key}`;
 
@@ -471,13 +471,10 @@ function transformAttributes(path, results) {
     if (typeof text === "number") text = String(text);
     let needsQuoting = !config.omitQuotes;
 
-    // `attr:style=";;strange::code;"` shouldn't be changed, as it's custom
-    if (!customAttribute) {
-      if (key === "style" || key === "class") {
-        text = trimWhitespace(text);
-        if (key === "style") {
-          text = text.replace(/; /g, ";").replace(/: /g, ":");
-        }
+    if (key === "style" || key === "class") {
+      text = trimWhitespace(text);
+      if (key === "style") {
+        text = text.replace(/; /g, ";").replace(/: /g, ":");
       }
     }
 
@@ -816,7 +813,7 @@ function transformAttributes(path, results) {
 
           if (key !== "attr:onclick" && (t.isStringLiteral(value) || t.isNumericLiteral(value))) {
             // inlined  "attr:"
-            inlineAttributeOnTemplate(isSVG, key.slice(5), results, value, true);
+            inlineAttributeOnTemplate(isSVG, key.slice(5), results, value);
           } else {
             // dynamic "attr:"
             results.exprs.push(

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -112,7 +112,9 @@ export function transformElement(path, info) {
     results.template = "<svg>" + results.template;
     results.templateWithClosingTags = "<svg>" + results.templateWithClosingTags;
   }
-  if (!info.skipId) results.id = path.scope.generateUidIdentifier("el$");
+  if (!info.skipId) {
+    results.id = path.scope.generateUidIdentifier("el$");
+  }
   transformAttributes(path, results);
   if (config.contextToCustomElements && (tagName === "slot" || isCustomElement)) {
     contextToCustomElement(path, results);
@@ -1102,7 +1104,11 @@ function detectExpressions(children, index, config) {
           attr =>
             t.isJSXSpreadAttribute(attr) ||
             ["textContent", "innerHTML", "innerText"].includes(attr.name.name) ||
-            (attr.name.namespace && attr.name.namespace.name === "use") ||
+            (attr.name.namespace &&
+              (attr.name.namespace.name === "use" ||
+                attr.name.namespace.name === "bool" ||
+                attr.name.namespace.name === "attr" ||
+                attr.name.namespace.name === "prop")) ||
             (t.isJSXExpressionContainer(attr.value) &&
               !(
                 t.isStringLiteral(attr.value.expression) ||

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
@@ -263,4 +263,5 @@ const template80 = <div attr:true={true} attr:false={false}/>
 
 const template81 = <math display="block"><mrow></mrow></math>
 const template82 = <mrow><mi>x</mi><mo>=</mo></mrow>
-
+const template83 = <video attr:poster="1.jpg"/>
+const template84 = <div><video attr:poster="1.jpg"/></div>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
@@ -265,3 +265,8 @@ const template81 = <math display="block"><mrow></mrow></math>
 const template82 = <mrow><mi>x</mi><mo>=</mo></mrow>
 const template83 = <video attr:poster="1.jpg"/>
 const template84 = <div><video attr:poster="1.jpg"/></div>
+const template85 = <video prop:poster="1.jpg"/>
+const template86 = <div><video prop:poster="1.jpg"/></div>
+const template87 = <video bool:poster="1.jpg"/>
+const template88 = <div><video bool:poster="1.jpg"/></div>
+

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -82,7 +82,9 @@ var _tmpl$ = /*#__PURE__*/ _$template(
   ),
   _tmpl$53 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true),
   _tmpl$54 = /*#__PURE__*/ _$template(`<video></video>`),
-  _tmpl$55 = /*#__PURE__*/ _$template(`<div><video></video></div>`);
+  _tmpl$55 = /*#__PURE__*/ _$template(`<div><video></video></div>`),
+  _tmpl$56 = /*#__PURE__*/ _$template(`<video poster></video>`),
+  _tmpl$57 = /*#__PURE__*/ _$template(`<div><video poster></video></div>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -602,4 +604,17 @@ const template84 = (() => {
   _$setAttribute(_el$102, "poster", "1.jpg");
   return _el$101;
 })();
+const template85 = (() => {
+  var _el$103 = _tmpl$54();
+  _el$103.poster = "1.jpg";
+  return _el$103;
+})();
+const template86 = (() => {
+  var _el$104 = _tmpl$55(),
+    _el$105 = _el$104.firstChild;
+  _el$105.poster = "1.jpg";
+  return _el$104;
+})();
+const template87 = _tmpl$56();
+const template88 = _tmpl$57();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -81,10 +81,12 @@ var _tmpl$ = /*#__PURE__*/ _$template(
     true
   ),
   _tmpl$53 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true),
-  _tmpl$54 = /*#__PURE__*/ _$template(`<video></video>`),
-  _tmpl$55 = /*#__PURE__*/ _$template(`<div><video></video></div>`),
-  _tmpl$56 = /*#__PURE__*/ _$template(`<video poster></video>`),
-  _tmpl$57 = /*#__PURE__*/ _$template(`<div><video poster></video></div>`);
+  _tmpl$54 = /*#__PURE__*/ _$template(`<video poster="1.jpg"></video>`),
+  _tmpl$55 = /*#__PURE__*/ _$template(`<div><video poster="1.jpg"></video></div>`),
+  _tmpl$56 = /*#__PURE__*/ _$template(`<video></video>`),
+  _tmpl$57 = /*#__PURE__*/ _$template(`<div><video></video></div>`),
+  _tmpl$58 = /*#__PURE__*/ _$template(`<video poster></video>`),
+  _tmpl$59 = /*#__PURE__*/ _$template(`<div><video poster></video></div>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -593,28 +595,19 @@ const template80 = (() => {
 })();
 const template81 = _tmpl$52();
 const template82 = _tmpl$53();
-const template83 = (() => {
-  var _el$100 = _tmpl$54();
-  _$setAttribute(_el$100, "poster", "1.jpg");
-  return _el$100;
-})();
-const template84 = (() => {
-  var _el$101 = _tmpl$55(),
-    _el$102 = _el$101.firstChild;
-  _$setAttribute(_el$102, "poster", "1.jpg");
-  return _el$101;
-})();
+const template83 = _tmpl$54();
+const template84 = _tmpl$55();
 const template85 = (() => {
-  var _el$103 = _tmpl$54();
-  _el$103.poster = "1.jpg";
-  return _el$103;
+  var _el$102 = _tmpl$56();
+  _el$102.poster = "1.jpg";
+  return _el$102;
 })();
 const template86 = (() => {
-  var _el$104 = _tmpl$55(),
-    _el$105 = _el$104.firstChild;
-  _el$105.poster = "1.jpg";
-  return _el$104;
+  var _el$103 = _tmpl$57(),
+    _el$104 = _el$103.firstChild;
+  _el$104.poster = "1.jpg";
+  return _el$103;
 })();
-const template87 = _tmpl$56();
-const template88 = _tmpl$57();
+const template87 = _tmpl$58();
+const template88 = _tmpl$59();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -80,7 +80,9 @@ var _tmpl$ = /*#__PURE__*/ _$template(
     false,
     true
   ),
-  _tmpl$53 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true);
+  _tmpl$53 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true),
+  _tmpl$54 = /*#__PURE__*/ _$template(`<video></video>`),
+  _tmpl$55 = /*#__PURE__*/ _$template(`<div><video></video></div>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -589,4 +591,15 @@ const template80 = (() => {
 })();
 const template81 = _tmpl$52();
 const template82 = _tmpl$53();
+const template83 = (() => {
+  var _el$100 = _tmpl$54();
+  _$setAttribute(_el$100, "poster", "1.jpg");
+  return _el$100;
+})();
+const template84 = (() => {
+  var _el$101 = _tmpl$55(),
+    _el$102 = _el$101.firstChild;
+  _$setAttribute(_el$102, "poster", "1.jpg");
+  return _el$101;
+})();
 _$delegateEvents(["click", "input"]);


### PR DESCRIPTION
The following worked: 

```js
const div = <div prop:poster="test"></div>;
```
https://playground.solidjs.com/anonymous/4ecb5e58-9d49-48cd-b088-cd01116b24d1

but the following gives an error

```js
const div = <div><div prop:poster="test"></div></div>;
```
https://playground.solidjs.com/anonymous/d717fcfe-1aca-48fa-ba89-5f38fa6f8d91

--- 

Was hard to trace it down but figured the problem was `results.id` being undefined because of `info.skipId`  which calls `detectExpressions`.  

`detectExpressions` seems to try to skip when is a string/number.  

https://github.com/ryansolid/dom-expressions/blob/main/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js#L1105-L1110
 
I saw there's a case for the "use" namespace, so added the others too `attr/prop/bool` and that seems to have worked.

edit: removed `bool` from it as its inlined so not needed. 