### PR TITLE
requireImportSource: Don't skip other Babel plugins 

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/README.md
+++ b/packages/babel-plugin-jsx-dom-expressions/README.md
@@ -175,6 +175,29 @@ Removes tags from the template output if they have no closing parents and are th
 
 Removes quotes for html attributes when possible from the template output. This may not work in all browser-like environments the same. The solution has been tested again Chrome/Edge/Firefox/Safari.
 
+### requireImportSource
+
+- Type: `string | false`
+- Default: `false`
+
+When set to a string value, this option restricts JSX transformation to only files that contain a specific JSX import source pragma comment. The plugin will only transform JSX in files that include a comment with `@jsxImportSource` followed by the specified value. If the comment is missing or specifies a different import source, the transformation is skipped for that file.
+
+Example usage:
+```js
+// In babel configuration:
+{
+  plugins: [
+    ["jsx-dom-expressions", {
+      requireImportSource: "r-dom"
+    }]
+  ]
+}
+
+// In your component file:
+/** @jsxImportSource r-dom */
+const template = <div>Hello</div>;
+```
+
 ## Special Binding
 
 ### ref

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/postprocess.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/postprocess.js
@@ -3,9 +3,12 @@ import { getRendererConfig, registerImportMethod } from "./utils";
 import { appendTemplates as appendTemplatesDOM } from "../dom/template";
 import { appendTemplates as appendTemplatesSSR } from "../ssr/template";
 import { isInvalidMarkup } from "./validate.js";
+import skipSymbol from "./skipSymbol.js";
 
 // add to the top/bottom of the module.
-export default path => {
+export default (path, state) => {
+  if (state[skipSymbol]) return;
+
   if (path.scope.data.events) {
     path.node.body.push(
       t.expressionStatement(

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/preprocess.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/preprocess.js
@@ -1,6 +1,8 @@
 import * as t from "@babel/types";
 import config from "../config";
 import { isComponent } from "./utils";
+import skipSymbol from "./skipSymbol.js";
+
 const { isValidHTMLNesting } = require("validate-html-nesting");
 
 // From https://github.com/MananTank/babel-plugin-validate-jsx-nesting/blob/main/src/index.js
@@ -25,7 +27,9 @@ const JSXValidator = {
   }
 };
 
-export default (path, { opts }) => {
+export default (path, state) => {
+  const { opts } = state;
+
   const merged = (path.hub.file.metadata.config = Object.assign({}, config, opts));
   const lib = merged.requireImportSource;
   if (lib) {
@@ -40,7 +44,7 @@ export default (path, { opts }) => {
       }
     }
     if (!process) {
-      path.skip();
+      state[skipSymbol] = true;
       return;
     }
   }

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/skipSymbol.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/skipSymbol.js
@@ -1,0 +1,3 @@
+const skipSymbol = Symbol("skip-babel-plugin-jsx-dom-expressions");
+
+export default skipSymbol;

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
@@ -17,8 +17,11 @@ import {
 } from "./utils";
 import transformComponent from "./component";
 import transformFragmentChildren from "./fragment";
+import skipSymbol from "./skipSymbol.js";
 
-export function transformJSX(path) {
+export function transformJSX(path, state) {
+  if (state[skipSymbol]) return;
+
   const config = getConfig(path);
   const replace = transformThis(path);
   const result = transformNode(

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/otherPragma/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/otherPragma/code.js
@@ -1,0 +1,3 @@
+/** @jsxImportSource jsx-dom */
+
+const template = <div>Hello</div>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/otherPragma/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/otherPragma/output.js
@@ -1,0 +1,4 @@
+/** @jsxImportSource jsx-dom */
+
+const template = <div>Hello</div>;
+("fin");

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/withPragma/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/withPragma/code.js
@@ -1,0 +1,3 @@
+/** @jsxImportSource r-dom */
+
+const template = <div>Hello</div>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/withPragma/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/withPragma/output.js
@@ -1,0 +1,6 @@
+import { template as _$template } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(`<div>Hello`);
+/** @jsxImportSource r-dom */
+
+const template = _tmpl$();
+("fin");

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/withoutPragma/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/withoutPragma/code.js
@@ -1,0 +1,1 @@
+const template = <div>Hello</div>;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/withoutPragma/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_require_import_source_fixtures__/withoutPragma/output.js
@@ -1,0 +1,2 @@
+const template = <div>Hello</div>;
+("fin");

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-require-import-source.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-require-import-source.spec.js
@@ -2,7 +2,6 @@ const path = require("path");
 const pluginTester = require("babel-plugin-tester").default;
 const t = require("@babel/types");
 const plugin = require("../index");
-const assert = require("assert");
 
 pluginTester({
   plugin,

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-require-import-source.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-require-import-source.spec.js
@@ -1,0 +1,35 @@
+const path = require("path");
+const pluginTester = require("babel-plugin-tester").default;
+const t = require("@babel/types");
+const plugin = require("../index");
+const assert = require("assert");
+
+pluginTester({
+  plugin,
+  pluginOptions: {
+    moduleName: "r-dom",
+    builtIns: ["For", "Show"],
+    generate: "dom",
+    wrapConditionals: true,
+    contextToCustomElements: true,
+    staticMarker: "@once",
+    requireImportSource: "r-dom"
+  },
+  title: "Convert JSX",
+  fixtures: path.join(__dirname, "__dom_require_import_source_fixtures__"),
+  snapshot: true,
+  babelOptions: {
+    // requireImportSource should not prevent this plugin from running
+    plugins: [
+      {
+        visitor: {
+          Program: {
+            exit: path => {
+              path.pushContainer("body", [t.expressionStatement(t.stringLiteral("fin"))]);
+            }
+          }
+        }
+      }
+    ]
+  }
+});


### PR DESCRIPTION
fixes #417. Also adds documentation for `requireImportSource` to the README.

I'm not super familiar with writing Babel plugins, or with the conventions of this project, so any suggestions are welcome.