### PR TITLE
Default to attributes 

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -1,6 +1,5 @@
 import * as t from "@babel/types";
 import {
-  getPropAlias,
   Properties,
   ChildProperties,
   SVGNamespace,
@@ -249,7 +248,6 @@ export function setAttr(path, elem, name, value, { isSVG, dynamic, prevId, tagNa
 
   const isChildProp = ChildProperties.has(name);
   const isProp = Properties.has(name);
-  const alias = getPropAlias(name, tagName.toUpperCase());
   if (namespace !== "attr" && (isChildProp || (!isSVG && isProp) || namespace === "prop")) {
     if (config.hydratable && namespace !== "prop") {
       return t.callExpression(registerImportMethod(path, "setProperty"), [
@@ -260,7 +258,7 @@ export function setAttr(path, elem, name, value, { isSVG, dynamic, prevId, tagNa
     }
     const assignment = t.assignmentExpression(
       "=",
-      t.memberExpression(elem, t.identifier(alias || name)),
+      t.memberExpression(elem, t.identifier(name)),
       value
     );
     // handle select/options... TODO: consider other ways in the future
@@ -1216,9 +1214,7 @@ function processSpreads(path, attributes, { elem, isSVG, hasChildren, wrapCondit
         runningObject.push(
           t.objectProperty(
             t.stringLiteral(key),
-            isContainer
-              ? node.value.expression
-              : node.value || (Properties.has(key) ? t.booleanLiteral(true) : t.stringLiteral(""))
+            isContainer ? node.value.expression : node.value || t.stringLiteral("")
           )
         );
       }

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -224,8 +224,8 @@ export function setAttr(path, elem, name, value, { isSVG, dynamic, prevId, tagNa
       prevId
         ? [elem, value, t.booleanLiteral(isSVG), prevId]
         : isSVG
-        ? [elem, value, t.booleanLiteral(true)]
-        : [elem, value]
+          ? [elem, value, t.booleanLiteral(true)]
+          : [elem, value]
     );
   }
 
@@ -876,6 +876,17 @@ function transformAttributes(path, results) {
           return;
         }
         if (t.isJSXExpressionContainer(value)) value = value.expression;
+
+        // boolean as `<el attr={true | false}/>`, not as `<el attr={"true" | "false"}/>`
+        // `<el attr={true}/>` becomes `<el attr/>`
+        // `<el attr={false}/>` becomes `<el/>`
+        if (t.isBooleanLiteral(value)) {
+          if (value.value === true) {
+            results.template += `${needsSpacing ? " " : ""}${key}`;
+            needsSpacing = true;
+          }
+          return;
+        }
 
         // properties
         if (value && ChildProperties.has(key)) {

--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr-old/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr-old/element.js
@@ -99,8 +99,7 @@ function setAttr(attribute, results, name, value, isDynamic) {
 
   let attr = t.callExpression(registerImportMethod(attribute, "ssrAttribute"), [
     t.stringLiteral(name),
-    value,
-    t.booleanLiteral(false)
+    value
   ]);
   if (results.template[results.template.length - 1].length) {
     if (isDynamic) attr = t.arrowFunctionExpression([], attr);
@@ -322,8 +321,7 @@ function transformAttributes(path, results, info) {
           results.template.push("");
           let fn = t.callExpression(registerImportMethod(attribute, "ssrAttribute"), [
             t.stringLiteral(key),
-            value.expression,
-            t.booleanLiteral(true)
+            value.expression
           ]);
           if (isDynamicValue) fn = t.arrowFunctionExpression([], fn);
           results.templateValues.push(fn);

--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
@@ -1,6 +1,6 @@
 import * as t from "@babel/types";
 import { decode } from "html-entities";
-import { BooleanAttributes, ChildProperties } from "dom-expressions/src/constants";
+import { ChildProperties } from "dom-expressions/src/constants";
 import VoidElements from "../VoidElements";
 import {
   getTagName,
@@ -115,8 +115,7 @@ function setAttr(attribute, results, name, value, isDynamic, isBoolean) {
 
   let attr = t.callExpression(registerImportMethod(attribute, "ssrAttribute"), [
     t.stringLiteral(name),
-    value,
-    t.booleanLiteral(isBoolean)
+    value
   ]);
   if (isDynamic) {
     attr = t.arrowFunctionExpression([], attr);
@@ -329,9 +328,9 @@ function transformAttributes(path, results, info) {
           checkTags: true
         });
         let doEscape = true;
-        let isBoolean = false;
+        let isBoolean = t.isBooleanLiteral(value) || (t.isJSXExpressionContainer(value) && t.isBooleanLiteral(value.expression));
         if (key.startsWith("attr:")) key = key.replace("attr:", "");
-        if ((isBoolean = BooleanAttributes.has(key))) doEscape = false;
+        if (isBoolean) doEscape = false;
         if (key.startsWith("bool:")) {
           key = key.replace("bool:", "");
           isBoolean = true;
@@ -406,7 +405,7 @@ function transformAttributes(path, results, info) {
     } else {
       if (key === "$ServerOnly") return;
       if (t.isJSXExpressionContainer(value)) value = value.expression;
-      const isBoolean = BooleanAttributes.has(key);
+      const isBoolean = t.isBooleanLiteral(value)
       if (isBoolean && value && value.value !== "" && !value.value) return;
       appendToTemplate(results.template, ` ${key}`);
       if (!value) return;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
@@ -269,4 +269,3 @@ const template85 = <video prop:poster="1.jpg"/>
 const template86 = <div><video prop:poster="1.jpg"/></div>
 const template87 = <video bool:poster="1.jpg"/>
 const template88 = <div><video bool:poster="1.jpg"/></div>
-

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -116,7 +116,7 @@ const template = (() => {
     _el$2,
     _$mergeProps(results, {
       foo: "",
-      disabled: true,
+      disabled: "",
       get title() {
         return welcoming();
       },
@@ -273,7 +273,7 @@ const template14 = (() => {
   _$effect(
     () => state.visible,
     _v$ => {
-      _el$20.checked = _v$;
+      _$setAttribute(_el$20, "checked", _v$);
     }
   );
   return _el$20;
@@ -323,7 +323,7 @@ const template20 = (() => {
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
   _$addEventListener(_el$28, "input", doSomethingElse, true);
-  _el$28.readOnly = value;
+  _$setAttribute(_el$28, "readonly", value);
   _$effect(
     () => ({
       e: min(),
@@ -348,7 +348,7 @@ const template20 = (() => {
     _el$27.value = _v$;
   });
   _$effect(s2, _v$ => {
-    _el$28.checked = _v$;
+    _$setAttribute(_el$28, "checked", _v$);
   });
   return _el$26;
 })();
@@ -372,7 +372,7 @@ const template23 = (() => {
   _$effect(
     () => "t" in test,
     _v$ => {
-      _el$31.disabled = _v$;
+      _$setAttribute(_el$31, "disabled", _v$);
     }
   );
   return _el$31;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -74,7 +74,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(
   ),
   _tmpl$51 = /*#__PURE__*/ _$template(`<div title="<u>data</u>"></div>`),
   _tmpl$52 = /*#__PURE__*/ _$template(`<div true truestr="true"truestrjs="true"></div>`),
-  _tmpl$53 = /*#__PURE__*/ _$template(`<div false falsestr="false"falsestrjs="false"></div>`),
+  _tmpl$53 = /*#__PURE__*/ _$template(`<div falsestr="false"falsestrjs="false"></div>`),
   _tmpl$54 = /*#__PURE__*/ _$template(
     `<math display="block"><mrow></mrow></math>`,
     false,

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -95,7 +95,7 @@ const template = (() => {
     _el$2,
     _$mergeProps(results, {
       foo: "",
-      disabled: true,
+      disabled: "",
       get title() {
         return welcoming();
       },
@@ -253,7 +253,7 @@ const template14 = (() => {
   _$effect(
     () => state.visible,
     _v$ => {
-      _el$20.checked = _v$;
+      _$setAttribute(_el$20, "checked", _v$);
     }
   );
   return _el$20;
@@ -304,7 +304,7 @@ const template20 = (() => {
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
   _$addEventListener(_el$28, "input", doSomethingElse, true);
-  _el$28.readOnly = value;
+  _$setAttribute(_el$28, "readonly", value);
   _$effect(
     () => ({
       e: min(),
@@ -329,7 +329,7 @@ const template20 = (() => {
     _el$27.value = _v$;
   });
   _$effect(s2, _v$ => {
-    _el$28.checked = _v$;
+    _$setAttribute(_el$28, "checked", _v$);
   });
   return _el$26;
 })();
@@ -353,7 +353,7 @@ const template23 = (() => {
   _$effect(
     () => "t" in test,
     _v$ => {
-      _el$31.disabled = _v$;
+      _$setAttribute(_el$31, "disabled", _v$);
     }
   );
   return _el$31;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -63,8 +63,8 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 id=my-h1><a href=/>Welco
   _tmpl$48 = /*#__PURE__*/ _$template(`<div><iframe src loading=lazy>`, true, false, false),
   _tmpl$49 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`),
   _tmpl$50 = /*#__PURE__*/ _$template(`<div true truestr=true truestrjs=true>`),
-  _tmpl$51 = /*#__PURE__*/ _$template(`<div false falsestr=false falsestrjs=false>`),
-  _tmpl$52 = /*#__PURE__*/ _$template(`<div a b c d e f=0 g h l>`),
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div falsestr=false falsestrjs=false>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<div a b c d f=0 g h l>`),
   _tmpl$53 = /*#__PURE__*/ _$template(`<math display=block><mrow>`, false, false, true),
   _tmpl$54 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=`, false, false, true);
 import * as styles from "./styles.module.css";

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -97,7 +97,7 @@ const template = (() => {
     _el$2,
     _$mergeProps(results, {
       foo: "",
-      disabled: true,
+      disabled: "",
       get title() {
         return welcoming();
       },
@@ -257,7 +257,7 @@ const template14 = (() => {
   _$effect(
     () => state.visible,
     _v$ => {
-      _$setProperty(_el$20, "checked", _v$);
+      _$setAttribute(_el$20, "checked", _v$);
     }
   );
   return _el$20;
@@ -310,7 +310,7 @@ const template20 = (() => {
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
   _$addEventListener(_el$28, "input", doSomethingElse, true);
-  _$setProperty(_el$28, "readonly", value);
+  _$setAttribute(_el$28, "readonly", value);
   _$effect(
     () => ({
       e: min(),
@@ -335,7 +335,7 @@ const template20 = (() => {
     _$setProperty(_el$27, "value", _v$);
   });
   _$effect(s2, _v$ => {
-    _$setProperty(_el$28, "checked", _v$);
+    _$setAttribute(_el$28, "checked", _v$);
   });
   _$runHydrationEvents();
   return _el$26;
@@ -360,7 +360,7 @@ const template23 = (() => {
   _$effect(
     () => "t" in test,
     _v$ => {
-      _$setProperty(_el$31, "disabled", _v$);
+      _$setAttribute(_el$31, "disabled", _v$);
     }
   );
   return _el$31;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -67,8 +67,8 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 id=my-h1><a href=/>Welco
   _tmpl$48 = /*#__PURE__*/ _$template(`<div><iframe src loading=lazy>`, true, false, false),
   _tmpl$49 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`),
   _tmpl$50 = /*#__PURE__*/ _$template(`<div true truestr=true truestrjs=true>`),
-  _tmpl$51 = /*#__PURE__*/ _$template(`<div false falsestr=false falsestrjs=false>`),
-  _tmpl$52 = /*#__PURE__*/ _$template(`<div a b c d e f=0 g h l>`);
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div falsestr=false falsestrjs=false>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<div a b c d f=0 g h l>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -63,8 +63,8 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 id=my-h1><a href=/>Welco
   _tmpl$48 = /*#__PURE__*/ _$template(`<div><iframe src loading=lazy>`, true, false, false),
   _tmpl$49 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`),
   _tmpl$50 = /*#__PURE__*/ _$template(`<div true truestr=true truestrjs=true>`),
-  _tmpl$51 = /*#__PURE__*/ _$template(`<div false falsestr=false falsestrjs=false>`),
-  _tmpl$52 = /*#__PURE__*/ _$template(`<div a b c d e f=0 g h l>`);
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div falsestr=false falsestrjs=false>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<div a b c d f=0 g h l>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -93,7 +93,7 @@ const template = (() => {
     _el$2,
     _$mergeProps(results, {
       foo: "",
-      disabled: true,
+      disabled: "",
       get title() {
         return welcoming();
       },
@@ -251,7 +251,7 @@ const template14 = (() => {
   _$effect(
     () => state.visible,
     _v$ => {
-      _el$20.checked = _v$;
+      _$setAttribute(_el$20, "checked", _v$);
     }
   );
   return _el$20;
@@ -302,7 +302,7 @@ const template20 = (() => {
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
   _$addEventListener(_el$28, "input", doSomethingElse, true);
-  _el$28.readOnly = value;
+  _$setAttribute(_el$28, "readonly", value);
   _$effect(
     () => ({
       e: min(),
@@ -327,7 +327,7 @@ const template20 = (() => {
     _el$27.value = _v$;
   });
   _$effect(s2, _v$ => {
-    _el$28.checked = _v$;
+    _$setAttribute(_el$28, "checked", _v$);
   });
   return _el$26;
 })();
@@ -351,7 +351,7 @@ const template23 = (() => {
   _$effect(
     () => "t" in test,
     _v$ => {
-      _el$31.disabled = _v$;
+      _$setAttribute(_el$31, "disabled", _v$);
     }
   );
   return _el$31;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
@@ -64,10 +64,10 @@ var _tmpl$ = ['<a href="/" class="', '">Welcome</a>'],
   _tmpl$52 = ["<iframe", ' src loading="lazy"></iframe>'],
   _tmpl$53 = ["<div", '><iframe src loading="lazy"></iframe></div>'],
   _tmpl$54 = ["<div", ' title="<u>data</u>"></div>'],
-  _tmpl$55 = ["<div", ' true="true" truestr="true" truestrjs="true"></div>'],
-  _tmpl$56 = ["<div", ' false="false" falsestr="false" falsestrjs="false"></div>'],
-  _tmpl$57 = ["<div", "", "", "></div>"],
-  _tmpl$58 = ["<div", ' a b c d="true" e="false" f="0" g h', "", "", " l></div>"];
+  _tmpl$55 = ["<div", ' true truestr="true" truestrjs="true"></div>'],
+  _tmpl$56 = ["<div", ' falsestr="false" falsestrjs="false"></div>'],
+  _tmpl$57 = ["<div", " true></div>"],
+  _tmpl$58 = ["<div", ' a b c d f="0" g h', "", "", " l></div>"];
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -146,11 +146,11 @@ const template2 = _$ssrElement(
 const template3 = (() => {
   var _v$3 = _$ssrHydrationKey(),
     _v$5 = _$escape(state.content) || " ",
-    _v$4 = _$ssrRunInScope([() => _$ssrAttribute("name", _$escape(state.name, true), false)]);
+    _v$4 = _$ssrRunInScope([() => _$ssrAttribute("name", _$escape(state.name, true))]);
   return _$ssr(
     _tmpl$4,
     _v$3,
-    _$ssrAttribute("id", _$escape(state.id, true), false),
+    _$ssrAttribute("id", _$escape(state.id, true)),
     "background-color:" + _$escape(state.color, true),
     _v$4[0],
     _v$5
@@ -158,7 +158,7 @@ const template3 = (() => {
 })();
 const template4 = (() => {
   var _v$6 = _$ssrHydrationKey(),
-    _v$7 = _$ssrRunInScope([() => _$ssrAttribute("className", _$escape(state.class, true), false)]);
+    _v$7 = _$ssrRunInScope([() => _$ssrAttribute("className", _$escape(state.class, true))]);
   return _$ssr(_tmpl$5, _v$6, _v$7[0], "ccc:ddd");
 })();
 const template5 = (() => {
@@ -182,12 +182,7 @@ const template7 = (() => {
           "padding-top": props.top
         })
     ]);
-  return _$ssr(
-    _tmpl$8,
-    _v$11,
-    _v$12[0],
-    _$ssrAttribute("other-class", _$escape(undefVar, true), false)
-  );
+  return _$ssr(_tmpl$8, _v$11, _v$12[0], _$ssrAttribute("other-class", _$escape(undefVar, true)));
 })();
 let refTarget;
 const template8 = (() => {
@@ -216,7 +211,7 @@ const template13 = (() => {
 })();
 const template14 = (() => {
   var _v$19 = _$ssrHydrationKey(),
-    _v$20 = _$ssrRunInScope(() => _$ssrAttribute("checked", state.visible, true));
+    _v$20 = _$ssrRunInScope(() => _$ssrAttribute("checked", _$escape(state.visible, true)));
   return _$ssr(_tmpl$12, _v$19, _v$20);
 })();
 const template15 = (() => {
@@ -266,13 +261,13 @@ const template19 = (() => {
 const template20 = (() => {
   var _v$25 = _$ssrHydrationKey(),
     _v$27 = _$ssrRunInScope([
-      () => _$ssrAttribute("min", _$escape(min(), true), false),
-      () => _$ssrAttribute("max", _$escape(max(), true), false),
-      () => _$ssrAttribute("min", _$escape(min(), true), false),
-      () => _$ssrAttribute("max", _$escape(max(), true), false)
+      () => _$ssrAttribute("min", _$escape(min(), true)),
+      () => _$ssrAttribute("max", _$escape(max(), true)),
+      () => _$ssrAttribute("min", _$escape(min(), true)),
+      () => _$ssrAttribute("max", _$escape(max(), true))
     ]),
-    _v$26 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(s(), true), false)),
-    _v$28 = _$ssrRunInScope(() => _$ssrAttribute("checked", s2(), true));
+    _v$26 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(s(), true))),
+    _v$28 = _$ssrRunInScope(() => _$ssrAttribute("checked", _$escape(s2(), true)));
   return _$ssr(
     _tmpl$16,
     _v$25,
@@ -282,7 +277,7 @@ const template20 = (() => {
     _v$28,
     _v$27[2],
     _v$27[3],
-    _$ssrAttribute("readonly", value, true)
+    _$ssrAttribute("readonly", _$escape(value, true))
   );
 })();
 const template21 = (() => {
@@ -303,7 +298,7 @@ const template22 = (() => {
 const template23 = (() => {
   var _v$32 = _$ssrHydrationKey(),
     _v$34 = _$ssrRunInScope(() => "t" in test && "true"),
-    _v$33 = _$ssrRunInScope([() => _$ssrAttribute("disabled", "t" in test, true)]);
+    _v$33 = _$ssrRunInScope([() => _$ssrAttribute("disabled", "t" in _$escape(test, true))]);
   return _$ssr(_tmpl$19, _v$32, _v$33[0], _v$34);
 })();
 const template24 = _$ssrElement(
@@ -372,7 +367,7 @@ const template28 = _$ssrElement(
 const template29 = (() => {
   var _v$38 = _$ssrHydrationKey(),
     _v$39 = !!someValue;
-  return _$ssr(_tmpl$21, _v$38, _$ssrAttribute("attribute", !!someValue, false), _v$39);
+  return _$ssr(_tmpl$21, _v$38, _$ssrAttribute("attribute", !!someValue), _v$39);
 })();
 const template30 = (() => {
   var _v$40 = _$ssrHydrationKey();
@@ -437,9 +432,9 @@ const template40 = (() => {
 })();
 const template41 = (() => {
   var _v$57 = _$ssrHydrationKey(),
-    _v$58 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(state.color, true), false)),
-    _v$59 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(Color.Red, true), false)),
-    _v$60 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(Color.Blue, true), false));
+    _v$58 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(state.color, true))),
+    _v$59 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(Color.Red, true))),
+    _v$60 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(Color.Blue, true)));
   return _$ssr(_tmpl$25, _v$57, _v$58, _v$59, _v$60);
 })();
 
@@ -493,7 +488,7 @@ const template51 = (() => {
 })();
 const template52 = (() => {
   var _v$71 = _$ssrHydrationKey();
-  return _$ssr(_tmpl$36, _v$71, _$ssrAttribute("quack", undefined, true));
+  return _$ssr(_tmpl$36, _v$71, _$ssrAttribute("quack", undefined));
 })();
 const template53 = (() => {
   var _v$72 = _$ssrHydrationKey();
@@ -501,20 +496,20 @@ const template53 = (() => {
 })();
 const template54 = (() => {
   var _v$73 = _$ssrHydrationKey(),
-    _v$74 = _$ssrRunInScope([() => _$ssrAttribute("quack", boolTest(), true)]);
+    _v$74 = _$ssrRunInScope([() => _$ssrAttribute("quack", boolTest())]);
   return _$ssr(_tmpl$38, _v$73, _v$74[0]);
 })();
 const template55 = (() => {
   var _v$75 = _$ssrHydrationKey();
-  return _$ssr(_tmpl$39, _v$75, _$ssrAttribute("quack", boolTest, true));
+  return _$ssr(_tmpl$39, _v$75, _$ssrAttribute("quack", boolTest));
 })();
 const template56 = (() => {
   var _v$76 = _$ssrHydrationKey();
-  return _$ssr(_tmpl$40, _v$76, _$ssrAttribute("quack", boolTestBinding, true));
+  return _$ssr(_tmpl$40, _v$76, _$ssrAttribute("quack", boolTestBinding));
 })();
 const template57 = (() => {
   var _v$77 = _$ssrHydrationKey(),
-    _v$78 = _$ssrRunInScope([() => _$ssrAttribute("quack", boolTestObjBinding.value, true)]);
+    _v$78 = _$ssrRunInScope([() => _$ssrAttribute("quack", boolTestObjBinding.value)]);
   return _$ssr(_tmpl$41, _v$77, _v$78[0]);
 })();
 const template58 = (() => {
@@ -522,7 +517,7 @@ const template58 = (() => {
   return _$ssr(
     _tmpl$42,
     _v$79,
-    _$ssrAttribute("quack", () => false, true)
+    _$ssrAttribute("quack", () => false)
   );
 })();
 const template59 = (() => {
@@ -609,20 +604,15 @@ const template79 = (() => {
 })();
 const template80 = (() => {
   var _v$100 = _$ssrHydrationKey();
-  return _$ssr(
-    _tmpl$57,
-    _v$100,
-    _$ssrAttribute("true", _$escape(true, true), false),
-    _$ssrAttribute("false", _$escape(false, true), false)
-  );
+  return _$ssr(_tmpl$57, _v$100);
 })();
 const template81 = (() => {
   var _v$101 = _$ssrHydrationKey();
   return _$ssr(
     _tmpl$58,
     _v$101,
-    _$ssrAttribute("i", _$escape(undefined, true), false),
-    _$ssrAttribute("j", _$escape(null, true), false),
-    _$ssrAttribute("k", void 0, false)
+    _$ssrAttribute("i", _$escape(undefined, true)),
+    _$ssrAttribute("j", _$escape(null, true)),
+    _$ssrAttribute("k", void 0)
   );
 })();

--- a/packages/dom-expressions/src/client.d.ts
+++ b/packages/dom-expressions/src/client.d.ts
@@ -5,7 +5,6 @@ export const DelegatedEvents: Set<string>;
 export const DOMElements: Set<string>;
 export const SVGElements: Set<string>;
 export const SVGNamespace: Record<string, string>;
-export function getPropAlias(prop: string, tagName: string): string | undefined;
 
 type MountableElement = Element | Document | ShadowRoot | DocumentFragment | Node;
 export function render(code: () => JSX.Element, element: MountableElement): () => void;

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -1,10 +1,4 @@
-import {
-  Properties,
-  ChildProperties,
-  getPropAlias,
-  SVGNamespace,
-  DelegatedEvents
-} from "./constants";
+import { Properties, ChildProperties, SVGNamespace, DelegatedEvents } from "./constants";
 import {
   root,
   effect,
@@ -20,7 +14,6 @@ import reconcileArrays from "./reconcile";
 export {
   Properties,
   ChildProperties,
-  getPropAlias,
   DOMElements,
   SVGElements,
   SVGNamespace,
@@ -51,12 +44,15 @@ export function render(code, element, init, options = {}) {
     );
   }
   let disposer;
-  root(dispose => {
-    disposer = dispose;
-    element === document
-      ? flatten(code)
-      : insert(element, code(), element.firstChild ? null : undefined, init);
-  }, { id: options.renderId });
+  root(
+    dispose => {
+      disposer = dispose;
+      element === document
+        ? flatten(code)
+        : insert(element, code(), element.firstChild ? null : undefined, init);
+    },
+    { id: options.renderId }
+  );
   return () => {
     disposer();
     element.textContent = "";
@@ -108,8 +104,8 @@ export function setProperty(node, name, value) {
 
 export function setAttribute(node, name, value) {
   if (isHydrating(node)) return;
-  if (value == null) node.removeAttribute(name);
-  else node.setAttribute(name, value);
+  if (value == null || value === false) node.removeAttribute(name);
+  else node.setAttribute(name, value === true ? "" : value);
 }
 
 export function setAttributeNS(node, namespace, name, value) {
@@ -378,7 +374,7 @@ function flattenClassList(list, result) {
 }
 
 function assignProp(node, prop, value, prev, isSVG, skipRef) {
-  let propAlias, forceProp;
+  let forceProp;
   if (prop === "style") return style(node, value, prev), value;
   if (prop === "class") return className(node, value, isSVG, prev), value;
   if (value === prev) return prev;
@@ -406,14 +402,13 @@ function assignProp(node, prop, value, prev, isSVG, skipRef) {
   } else if (
     (forceProp = prop.slice(0, 5) === "prop:") ||
     ChildProperties.has(prop) ||
-    (!isSVG && (propAlias = getPropAlias(prop, node.tagName))) ||
-    Properties.has(prop)
+    (!isSVG && Properties.has(prop))
   ) {
     if (forceProp) prop = prop.slice(5);
     else if (isHydrating(node)) return value;
     if (prop === "value" && node.nodeName === "SELECT")
       queueMicrotask(() => (node.value = value)) || (node.value = value);
-    else node[propAlias || prop] = value;
+    else node[prop] = value;
   } else {
     const ns = isSVG && prop.indexOf(":") > -1 && SVGNamespace[prop.split(":")[0]];
     if (ns) setAttributeNS(node, ns, prop, value);

--- a/packages/dom-expressions/src/constants.d.ts
+++ b/packages/dom-expressions/src/constants.d.ts
@@ -1,5 +1,3 @@
-export function getPropAlias(prop: string, tagName: string): string | undefined;
-
 export const BooleanAttributes: Set<string>;
 
 export const Properties: Set<string>;

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -1,42 +1,5 @@
-const booleans = [
-  "allowfullscreen",
-  "async",
-  "autofocus",
-  "autoplay",
-  "checked",
-  "controls",
-  "default",
-  "disabled",
-  "formnovalidate",
-  "hidden",
-  "indeterminate",
-  "inert",
-  "ismap",
-  "loop",
-  "multiple",
-  "muted",
-  "nomodule",
-  "novalidate",
-  "open",
-  "playsinline",
-  "readonly",
-  "required",
-  "reversed",
-  "seamless",
-  "selected"
-];
-
-const BooleanAttributes = /*#__PURE__*/ new Set(booleans);
-
 const Properties = /*#__PURE__*/ new Set([
   "value",
-  "readOnly",
-  "noValidate",
-  "formNoValidate",
-  "isMap",
-  "noModule",
-  "playsInline",
-  ...booleans
 ]);
 
 const ChildProperties = /*#__PURE__*/ new Set([
@@ -45,41 +8,6 @@ const ChildProperties = /*#__PURE__*/ new Set([
   "innerText",
   "children"
 ]);
-
-const PropAliases = /*#__PURE__*/ Object.assign(Object.create(null), {
-  class: "className",
-  novalidate: {
-    $: "noValidate",
-    FORM: 1
-  },
-  formnovalidate: {
-    $: "formNoValidate",
-    BUTTON: 1,
-    INPUT: 1
-  },
-  ismap: {
-    $: "isMap",
-    IMG: 1
-  },
-  nomodule: {
-    $: "noModule",
-    SCRIPT: 1
-  },
-  playsinline: {
-    $: "playsInline",
-    VIDEO: 1
-  },
-  readonly: {
-    $: "readOnly",
-    INPUT: 1,
-    TEXTAREA: 1
-  }
-});
-
-function getPropAlias(prop, tagName) {
-  const a = PropAliases[prop];
-  return typeof a === "object" ? (a[tagName] ? a["$"] : undefined) : a;
-}
 
 // list of Element events that will be delegated
 const DelegatedEvents = /*#__PURE__*/ new Set([
@@ -479,10 +407,8 @@ const DOMElements = /*#__PURE__*/ new Set([
 ]);
 
 export {
-  BooleanAttributes,
   Properties,
   ChildProperties,
-  getPropAlias,
   DelegatedEvents,
   SVGElements,
   SVGNamespace,

--- a/packages/dom-expressions/src/server.d.ts
+++ b/packages/dom-expressions/src/server.d.ts
@@ -5,7 +5,6 @@ export const DelegatedEvents: Set<string>;
 export const DOMElements: Set<string>;
 export const SVGElements: Set<string>;
 export const SVGNamespace: Record<string, string>;
-export function getPropAlias(prop: string, tagName: string): string | undefined;
 
 type MountableElement = Element | Document | ShadowRoot | DocumentFragment | Node;
 

--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -7,7 +7,6 @@ export { getOwner, createComponent, effect, memo, untrack, ssrRunInScope } from 
 export {
   Properties,
   ChildProperties,
-  getPropAlias,
   DOMElements,
   SVGElements,
   SVGNamespace,
@@ -360,9 +359,6 @@ export function ssrElement(tag, props, children, needsId) {
       result += `style="${ssrStyle(value)}"`;
     } else if (prop === "class") {
       result += `class="${ssrClassName(value)}"`;
-    } else if (BooleanAttributes.has(prop)) {
-      if (value) result += prop;
-      else continue;
     } else if (
       value == undefined ||
       prop === "ref" ||
@@ -375,8 +371,11 @@ export function ssrElement(tag, props, children, needsId) {
       result += escape(prop.slice(5));
     } else if (prop.slice(0, 5) === "attr:") {
       result += `${escape(prop.slice(5))}="${escape(value, true)}"`;
+    } else if(typeof value === 'boolean'){
+      if (!value) continue;
+      result += escape(prop);
     } else {
-      result += `${escape(prop)}="${escape(value, true)}"`;
+      result += value === '' ? escape(prop) : `${escape(prop)}="${escape(value, true)}"`;
     }
     if (i !== keys.length - 1) result += " ";
   }
@@ -386,9 +385,14 @@ export function ssrElement(tag, props, children, needsId) {
   return ssr([result + ">", `</${tag}>`], resolveSSRNode(children, undefined, true));
 }
 
-export function ssrAttribute(key, value, isBoolean) {
-  return isBoolean ? (value ? " " + key : "") : value != null ? ` ${key}="${value}"` : "";
+export function ssrAttribute(key, value) {
+  return value == null || value === false
+    ? ""
+    : value === true
+      ? ` ${key}`
+      : ` ${key}="${value}"`;
 }
+
 
 export function ssrHydrationKey() {
   const hk = getHydrationKey();
@@ -403,7 +407,7 @@ export function escape(s, attr) {
       for (let i = 0; i < s.length; i++) s[i] = escape(s[i]);
       return s;
     }
-    if (attr && t === "boolean") return String(s);
+    if (attr && t === "boolean") return s;
     return s;
   }
   const delim = attr ? '"' : "<";

--- a/packages/lit-dom-expressions/src/index.ts
+++ b/packages/lit-dom-expressions/src/index.ts
@@ -23,7 +23,6 @@ interface Runtime {
   dynamicProperty(props: any, key: string): any;
   setAttribute(node: Element, name: string, value: any): void;
   setAttributeNS(node: Element, namespace: string, name: string, value: any): void;
-  getPropAlias(prop: string, tagName: string): string | undefined;
   Properties: Set<string>;
   ChildProperties: Set<string>;
   DelegatedEvents: Set<string>;
@@ -204,9 +203,9 @@ export function createHTML(
       options.exprs.push(`r.className(${tag},${expr},${isSVG},_$p)`);
     } else if (
       namespace !== "attr" &&
-      (isChildProp || (!isSVG && (r.getPropAlias(name, node.name.toUpperCase()) || isProp)) ||  namespace === "prop")
+      (isChildProp || (!isSVG && isProp) || namespace === "prop")
     ) {
-      options.exprs.push(`${tag}.${r.getPropAlias(name, node.name.toUpperCase()) || name} = ${expr}`);
+      options.exprs.push(`${tag}.${name} = ${expr}`);
     } else {
       const ns = isSVG && name.indexOf(":") > -1 && r.SVGNamespace[name.split(":")[0]];
       if (ns) options.exprs.push(`r.setAttributeNS(${tag},"${ns}","${name}",${expr})`);


### PR DESCRIPTION
It uses attributes by default instead of properties for booleans.

- gets rid of `PropAliases` and `Booleans` constants.
- keeps `Properties` Set just for `value`. It may be possible that some other property needs to be locked to be a property. So I figured to not remove the Set at this stage. In the future we may be just special case `value` if the set isn't needed.

In a nutshell, 
- `true(bool)` adds an empty attribute
- `false(bool)` removes the attribute
- everything else is just a string attribute
- Additionally, `undefined` still removes the attribute

Slightly unrelated note, escaping the attribute value outside `ssrAttribute` feels weird.  I will see to move the escaping inside `ssrAttribute` in a different PR.