### PR TITLE
remove `validate-html-nesting` package

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/rollup.config.js
+++ b/packages/babel-plugin-jsx-dom-expressions/rollup.config.js
@@ -21,7 +21,7 @@ const plugins = [
 
 export default {
   input: "src/index.ts",
-  external: ["@babel/plugin-syntax-jsx", "@babel/helper-module-imports", "@babel/types", "html-entities", "validate-html-nesting"],
+  external: ["@babel/plugin-syntax-jsx", "@babel/helper-module-imports", "@babel/types", "html-entities"],
   output: {
     file: "index.js",
     format: "cjs",

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/preprocess.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/preprocess.js
@@ -1,29 +1,4 @@
-import * as t from "@babel/types";
 import config from "../config";
-import { isComponent } from "./utils";
-const { isValidHTMLNesting } = require("validate-html-nesting");
-
-// From https://github.com/MananTank/babel-plugin-validate-jsx-nesting/blob/main/src/index.js
-const JSXValidator = {
-  JSXElement(path) {
-    const elName = path.node.openingElement.name;
-    const parent = path.parent;
-
-    if (!t.isJSXElement(parent) || !t.isJSXIdentifier(elName)) return;
-    const elTagName = elName.name;
-    if (isComponent(elTagName)) return;
-    const parentElName = parent.openingElement.name;
-    if (!t.isJSXIdentifier(parentElName)) return;
-    const parentElTagName = parentElName.name;
-    if (!isComponent(parentElTagName)) {
-      if (!isValidHTMLNesting(parentElTagName, elTagName)) {
-        throw path.buildCodeFrameError(
-          `Invalid JSX: <${elTagName}> cannot be child of <${parentElTagName}>`
-        );
-      }
-    }
-  }
-};
 
 export default (path, { opts }) => {
   const merged = (path.hub.file.metadata.config = Object.assign({}, config, opts));
@@ -44,5 +19,4 @@ export default (path, { opts }) => {
       return;
     }
   }
-  if (merged.validate) path.traverse(JSXValidator);
 };


### PR DESCRIPTION
We have been using parse5 for a while for validating tag nesting, it _simulates_ a browser and seems to be enough.

`validate-html-nesting` doesnt seem to support math and is causing errors.  https://github.com/ryansolid/dom-expressions/issues/424 

Somehow whitespace changed, may use this link for the diff https://github.com/ryansolid/dom-expressions/pull/427/files?diff=unified&w=1