### PR TITLE
ignore case when validating tag nesting

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/validate.js
@@ -87,7 +87,7 @@ export function isInvalidMarkup(html) {
   /** Parse HTML. `browser` is a string with the supposed resulting html of a real `innerHTML` call */
   const browser = innerHTML(html);
 
-  if (html !== browser) {
+  if (html.toLowerCase() !== browser.toLowerCase()) {
     return {
       html,
       browser


### PR DESCRIPTION
I have found that the tag `foreignObject` vs `foreignobject` causes problems. 

For whatever reason, I cannot seem to be able to reproduce anymore. I dont know if chrome or parse5 changed anything. 

In any case the casing of tags is not something we are interested to test, its the nesting, so the comparator lowercases both strings.