### PR TITLE
inline style when is an object of string/numeric values

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -19,74 +19,75 @@ var _tmpl$ = /*#__PURE__*/ _$template(
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo></div>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div></div>`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b"></div>`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type="checkbox">`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\`</div>`),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi"type="button">Write</button>`),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi</button>`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col"></div>`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly><input></div>`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;"></div>`),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<a></a>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div><a></a></div>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div start="Hi">Hi</div>`),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div></div></label>`),
-  _tmpl$17 = /*#__PURE__*/ _$template(
-    `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4"></div>`
+  _tmpl$6 = /*#__PURE__*/ _$template(`<div style="margin-right:40px"></div>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<input type="checkbox">`),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\`</div>`),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type="button">Write</button>`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi</button>`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col"></div>`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly><input></div>`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;"></div>`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<a></a>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div><a></a></div>`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<div start="Hi">Hi</div>`),
+  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div></div></label>`),
+  _tmpl$18 = /*#__PURE__*/ _$template(
+    `<div class="class1 class2 class3 class4 class5 class6"random="random1 random2\n    random3 random4"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px"></div>`
   ),
-  _tmpl$18 = /*#__PURE__*/ _$template(`<button></button>`),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<input value="10">`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue</option></select>`),
-  _tmpl$21 = /*#__PURE__*/ _$template(`<div>empty string</div>`),
-  _tmpl$22 = /*#__PURE__*/ _$template(`<div>js empty</div>`),
-  _tmpl$23 = /*#__PURE__*/ _$template(`<div quack>hola</div>`),
-  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>"hola js"</div>`),
-  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>true</div>`),
-  _tmpl$26 = /*#__PURE__*/ _$template(`<div>false</div>`),
-  _tmpl$27 = /*#__PURE__*/ _$template(`<div quack>1</div>`),
-  _tmpl$28 = /*#__PURE__*/ _$template(`<div>0</div>`),
-  _tmpl$29 = /*#__PURE__*/ _$template(`<div quack>"1"</div>`),
-  _tmpl$30 = /*#__PURE__*/ _$template(`<div>"0"</div>`),
-  _tmpl$31 = /*#__PURE__*/ _$template(`<div>undefined</div>`),
-  _tmpl$32 = /*#__PURE__*/ _$template(`<div>null</div>`),
-  _tmpl$33 = /*#__PURE__*/ _$template(`<div>boolTest()</div>`),
-  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest</div>`),
-  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTestBinding</div>`),
-  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value</div>`),
-  _tmpl$37 = /*#__PURE__*/ _$template(`<div>fn</div>`),
-  _tmpl$38 = /*#__PURE__*/ _$template(`<div before quack>should have space before</div>`),
-  _tmpl$39 = /*#__PURE__*/ _$template(
+  _tmpl$19 = /*#__PURE__*/ _$template(`<button></button>`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<input value="10">`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue</option></select>`),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<div>empty string</div>`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<div>js empty</div>`),
+  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>hola</div>`),
+  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>"hola js"</div>`),
+  _tmpl$26 = /*#__PURE__*/ _$template(`<div quack>true</div>`),
+  _tmpl$27 = /*#__PURE__*/ _$template(`<div>false</div>`),
+  _tmpl$28 = /*#__PURE__*/ _$template(`<div quack>1</div>`),
+  _tmpl$29 = /*#__PURE__*/ _$template(`<div>0</div>`),
+  _tmpl$30 = /*#__PURE__*/ _$template(`<div quack>"1"</div>`),
+  _tmpl$31 = /*#__PURE__*/ _$template(`<div>"0"</div>`),
+  _tmpl$32 = /*#__PURE__*/ _$template(`<div>undefined</div>`),
+  _tmpl$33 = /*#__PURE__*/ _$template(`<div>null</div>`),
+  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest()</div>`),
+  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTest</div>`),
+  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestBinding</div>`),
+  _tmpl$37 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value</div>`),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<div>fn</div>`),
+  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack>should have space before</div>`),
+  _tmpl$40 = /*#__PURE__*/ _$template(
     `<div before quack after>should have space before/after</div>`
   ),
-  _tmpl$40 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after</div>`),
-  _tmpl$41 = /*#__PURE__*/ _$template(`<img src>`),
-  _tmpl$42 = /*#__PURE__*/ _$template(`<div><img src></div>`),
-  _tmpl$43 = /*#__PURE__*/ _$template(`<img src loading="lazy">`, true, false, false),
-  _tmpl$44 = /*#__PURE__*/ _$template(`<div><img src loading="lazy"></div>`, true, false, false),
-  _tmpl$45 = /*#__PURE__*/ _$template(`<iframe src></iframe>`),
-  _tmpl$46 = /*#__PURE__*/ _$template(`<div><iframe src></iframe></div>`),
-  _tmpl$47 = /*#__PURE__*/ _$template(`<iframe src loading="lazy"></iframe>`, true, false, false),
-  _tmpl$48 = /*#__PURE__*/ _$template(
+  _tmpl$41 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after</div>`),
+  _tmpl$42 = /*#__PURE__*/ _$template(`<img src>`),
+  _tmpl$43 = /*#__PURE__*/ _$template(`<div><img src></div>`),
+  _tmpl$44 = /*#__PURE__*/ _$template(`<img src loading="lazy">`, true, false, false),
+  _tmpl$45 = /*#__PURE__*/ _$template(`<div><img src loading="lazy"></div>`, true, false, false),
+  _tmpl$46 = /*#__PURE__*/ _$template(`<iframe src></iframe>`),
+  _tmpl$47 = /*#__PURE__*/ _$template(`<div><iframe src></iframe></div>`),
+  _tmpl$48 = /*#__PURE__*/ _$template(`<iframe src loading="lazy"></iframe>`, true, false, false),
+  _tmpl$49 = /*#__PURE__*/ _$template(
     `<div><iframe src loading="lazy"></iframe></div>`,
     true,
     false,
     false
   ),
-  _tmpl$49 = /*#__PURE__*/ _$template(`<div title="<u>data</u>"></div>`),
-  _tmpl$50 = /*#__PURE__*/ _$template(`<div truestr="true"truestrjs="true"></div>`),
-  _tmpl$51 = /*#__PURE__*/ _$template(`<div falsestr="false"falsestrjs="false"></div>`),
-  _tmpl$52 = /*#__PURE__*/ _$template(
+  _tmpl$50 = /*#__PURE__*/ _$template(`<div title="<u>data</u>"></div>`),
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div truestr="true"truestrjs="true"></div>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<div falsestr="false"falsestrjs="false"></div>`),
+  _tmpl$53 = /*#__PURE__*/ _$template(
     `<math display="block"><mrow></mrow></math>`,
     false,
     false,
     true
   ),
-  _tmpl$53 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true),
-  _tmpl$54 = /*#__PURE__*/ _$template(`<video poster="1.jpg"></video>`),
-  _tmpl$55 = /*#__PURE__*/ _$template(`<div><video poster="1.jpg"></video></div>`),
-  _tmpl$56 = /*#__PURE__*/ _$template(`<video></video>`),
-  _tmpl$57 = /*#__PURE__*/ _$template(`<div><video></video></div>`),
-  _tmpl$58 = /*#__PURE__*/ _$template(`<video poster></video>`),
-  _tmpl$59 = /*#__PURE__*/ _$template(`<div><video poster></video></div>`);
+  _tmpl$54 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=</mo></mrow>`, false, false, true),
+  _tmpl$55 = /*#__PURE__*/ _$template(`<video poster="1.jpg"></video>`),
+  _tmpl$56 = /*#__PURE__*/ _$template(`<div><video poster="1.jpg"></video></div>`),
+  _tmpl$57 = /*#__PURE__*/ _$template(`<video></video>`),
+  _tmpl$58 = /*#__PURE__*/ _$template(`<div><video></video></div>`),
+  _tmpl$59 = /*#__PURE__*/ _$template(`<video poster></video>`),
+  _tmpl$60 = /*#__PURE__*/ _$template(`<div><video poster></video></div>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -186,14 +187,13 @@ const template6 = (() => {
 })();
 let undefVar;
 const template7 = (() => {
-  var _el$13 = _tmpl$4();
+  var _el$13 = _tmpl$6();
   _el$13.classList.toggle("other-class", !!undefVar);
   _el$13.classList.toggle("other-class2", !!undefVar);
   _$effect(
     _p$ => {
       var _v$ = {
           "background-color": color(),
-          "margin-right": "40px",
           ...props.style
         },
         _v$2 = props.top,
@@ -247,19 +247,19 @@ const template12 = (() => {
   return _el$18;
 })();
 const template13 = (() => {
-  var _el$19 = _tmpl$6();
+  var _el$19 = _tmpl$7();
   _el$19.checked = true;
   return _el$19;
 })();
 const template14 = (() => {
-  var _el$20 = _tmpl$6();
+  var _el$20 = _tmpl$7();
   _$effect(() => (_el$20.checked = state.visible));
   return _el$20;
 })();
-const template15 = _tmpl$7();
-const template16 = _tmpl$8();
+const template15 = _tmpl$8();
+const template16 = _tmpl$9();
 const template17 = (() => {
-  var _el$23 = _tmpl$9();
+  var _el$23 = _tmpl$10();
   _$addEventListener(_el$23, "click", increment, true);
   return _el$23;
 })();
@@ -277,9 +277,9 @@ const template18 = (() => {
   );
   return _el$24;
 })();
-const template19 = _tmpl$10();
+const template19 = _tmpl$11();
 const template20 = (() => {
-  var _el$26 = _tmpl$11(),
+  var _el$26 = _tmpl$12(),
     _el$27 = _el$26.firstChild,
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
@@ -322,7 +322,7 @@ const template21 = (() => {
   );
   return _el$29;
 })();
-const template22 = _tmpl$12();
+const template22 = _tmpl$13();
 const template23 = (() => {
   var _el$31 = _tmpl$4();
   _$insert(_el$31, () => "t" in test && "true");
@@ -330,7 +330,7 @@ const template23 = (() => {
   return _el$31;
 })();
 const template24 = (() => {
-  var _el$32 = _tmpl$13();
+  var _el$32 = _tmpl$14();
   _$spread(
     _el$32,
     _$mergeProps(props, {
@@ -342,7 +342,7 @@ const template24 = (() => {
   return _el$32;
 })();
 const template25 = (() => {
-  var _el$33 = _tmpl$14(),
+  var _el$33 = _tmpl$15(),
     _el$34 = _el$33.firstChild;
   _$insert(_el$33, () => props.children, _el$34);
   _$spread(
@@ -356,13 +356,13 @@ const template25 = (() => {
   return _el$33;
 })();
 const template26 = (() => {
-  var _el$35 = _tmpl$15();
+  var _el$35 = _tmpl$16();
   _$setAttribute(_el$35, "middle", middle);
   _$spread(_el$35, spread, false, true);
   return _el$35;
 })();
 const template27 = (() => {
-  var _el$36 = _tmpl$15();
+  var _el$36 = _tmpl$16();
   _$spread(
     _el$36,
     _$mergeProps(
@@ -378,7 +378,7 @@ const template27 = (() => {
   return _el$36;
 })();
 const template28 = (() => {
-  var _el$37 = _tmpl$16(),
+  var _el$37 = _tmpl$17(),
     _el$38 = _el$37.firstChild,
     _el$39 = _el$38.firstChild,
     _el$40 = _el$38.nextSibling,
@@ -396,7 +396,7 @@ const template29 = (() => {
   _$insert(_el$42, !!someValue);
   return _el$42;
 })();
-const template30 = _tmpl$17();
+const template30 = _tmpl$18();
 const template31 = (() => {
   var _el$44 = _tmpl$4();
   _$effect(_$p =>
@@ -406,29 +406,25 @@ const template31 = (() => {
   );
   return _el$44;
 })();
-const template32 = (() => {
-  var _el$45 = _tmpl$4();
-  _el$45.style.removeProperty("background-color");
-  return _el$45;
-})();
+const template32 = _tmpl$4();
 const template33 = [
   (() => {
-    var _el$46 = _tmpl$18();
+    var _el$46 = _tmpl$19();
     _$className(_el$46, styles.button);
     return _el$46;
   })(),
   (() => {
-    var _el$47 = _tmpl$18();
+    var _el$47 = _tmpl$19();
     _$className(_el$47, styles["foo--bar"]);
     return _el$47;
   })(),
   (() => {
-    var _el$48 = _tmpl$18();
+    var _el$48 = _tmpl$19();
     _$effect(() => _$className(_el$48, styles.foo.bar));
     return _el$48;
   })(),
   (() => {
-    var _el$49 = _tmpl$18();
+    var _el$49 = _tmpl$19();
     _$effect(() => _$className(_el$49, styles[foo()]));
     return _el$49;
   })()
@@ -464,7 +460,7 @@ const template38 = (() => {
   typeof _ref$7 === "function" && _$use(_ref$7, _el$54);
   return _el$54;
 })();
-const template39 = _tmpl$19();
+const template39 = _tmpl$20();
 const template40 = (() => {
   var _el$56 = _tmpl$4();
   _$effect(_$p =>
@@ -475,7 +471,7 @@ const template40 = (() => {
   return _el$56;
 })();
 const template41 = (() => {
-  var _el$57 = _tmpl$20(),
+  var _el$57 = _tmpl$21(),
     _el$58 = _el$57.firstChild,
     _el$59 = _el$58.nextSibling;
   _$effect(() => (_el$58.value = Color.Red));
@@ -492,57 +488,57 @@ const boolTestBinding = false;
 const boolTestObjBinding = {
   value: false
 };
-const template42 = _tmpl$21();
-const template43 = _tmpl$22();
-const template44 = _tmpl$23();
-const template45 = _tmpl$24();
-const template46 = _tmpl$25();
-const template47 = _tmpl$26();
-const template48 = _tmpl$27();
-const template49 = _tmpl$28();
-const template50 = _tmpl$29();
-const template51 = _tmpl$30();
-const template52 = _tmpl$31();
-const template53 = _tmpl$32();
+const template42 = _tmpl$22();
+const template43 = _tmpl$23();
+const template44 = _tmpl$24();
+const template45 = _tmpl$25();
+const template46 = _tmpl$26();
+const template47 = _tmpl$27();
+const template48 = _tmpl$28();
+const template49 = _tmpl$29();
+const template50 = _tmpl$30();
+const template51 = _tmpl$31();
+const template52 = _tmpl$32();
+const template53 = _tmpl$33();
 const template54 = (() => {
-  var _el$72 = _tmpl$33();
+  var _el$72 = _tmpl$34();
   _$effect(() => _$setBoolAttribute(_el$72, "quack", boolTest()));
   return _el$72;
 })();
 const template55 = (() => {
-  var _el$73 = _tmpl$34();
+  var _el$73 = _tmpl$35();
   _$setBoolAttribute(_el$73, "quack", boolTest);
   return _el$73;
 })();
 const template56 = (() => {
-  var _el$74 = _tmpl$35();
+  var _el$74 = _tmpl$36();
   _$setBoolAttribute(_el$74, "quack", boolTestBinding);
   return _el$74;
 })();
 const template57 = (() => {
-  var _el$75 = _tmpl$36();
+  var _el$75 = _tmpl$37();
   _$effect(() => _$setBoolAttribute(_el$75, "quack", boolTestObjBinding.value));
   return _el$75;
 })();
 const template58 = (() => {
-  var _el$76 = _tmpl$37();
+  var _el$76 = _tmpl$38();
   _$setBoolAttribute(_el$76, "quack", () => false);
   return _el$76;
 })();
-const template59 = _tmpl$38();
-const template60 = _tmpl$39();
-const template61 = _tmpl$40();
+const template59 = _tmpl$39();
+const template60 = _tmpl$40();
+const template61 = _tmpl$41();
 // this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;
 
-const template63 = _tmpl$41();
-const template64 = _tmpl$42();
-const template65 = _tmpl$43();
-const template66 = _tmpl$44();
-const template67 = _tmpl$45();
-const template68 = _tmpl$46();
-const template69 = _tmpl$47();
-const template70 = _tmpl$48();
-const template71 = _tmpl$49();
+const template63 = _tmpl$42();
+const template64 = _tmpl$43();
+const template65 = _tmpl$44();
+const template66 = _tmpl$45();
+const template67 = _tmpl$46();
+const template68 = _tmpl$47();
+const template69 = _tmpl$48();
+const template70 = _tmpl$49();
+const template71 = _tmpl$50();
 const template72 = (() => {
   var _el$89 = _tmpl$4();
   _$use(binding, _el$89);
@@ -572,12 +568,12 @@ const template76 = (() => {
   return _el$93;
 })();
 const template77 = (() => {
-  var _el$94 = _tmpl$50();
+  var _el$94 = _tmpl$51();
   _$setAttribute(_el$94, "true", true);
   return _el$94;
 })();
 const template78 = (() => {
-  var _el$95 = _tmpl$51();
+  var _el$95 = _tmpl$52();
   _$setAttribute(_el$95, "false", false);
   return _el$95;
 })();
@@ -593,50 +589,50 @@ const template80 = (() => {
   _$setAttribute(_el$97, "false", false);
   return _el$97;
 })();
-const template81 = _tmpl$52();
-const template82 = _tmpl$53();
-const template83 = _tmpl$54();
-const template84 = _tmpl$55();
+const template81 = _tmpl$53();
+const template82 = _tmpl$54();
+const template83 = _tmpl$55();
+const template84 = _tmpl$56();
 const template85 = (() => {
-  var _el$102 = _tmpl$56();
+  var _el$102 = _tmpl$57();
   _el$102.poster = "1.jpg";
   return _el$102;
 })();
 const template86 = (() => {
-  var _el$103 = _tmpl$57(),
+  var _el$103 = _tmpl$58(),
     _el$104 = _el$103.firstChild;
   _el$104.poster = "1.jpg";
   return _el$103;
 })();
-const template87 = _tmpl$58();
-const template88 = _tmpl$59();
+const template87 = _tmpl$59();
+const template88 = _tmpl$60();
 const template89 = (() => {
-  var _el$107 = _tmpl$56();
+  var _el$107 = _tmpl$57();
   _el$107.playsInline = value;
   return _el$107;
 })();
 const template90 = (() => {
-  var _el$108 = _tmpl$56();
+  var _el$108 = _tmpl$57();
   _el$108.playsInline = true;
   return _el$108;
 })();
 const template91 = (() => {
-  var _el$109 = _tmpl$56();
+  var _el$109 = _tmpl$57();
   _el$109.playsInline = false;
   return _el$109;
 })();
 const template92 = (() => {
-  var _el$110 = _tmpl$56();
+  var _el$110 = _tmpl$57();
   _el$110.playsInline = value;
   return _el$110;
 })();
 const template93 = (() => {
-  var _el$111 = _tmpl$56();
+  var _el$111 = _tmpl$57();
   _el$111.playsInline = true;
   return _el$111;
 })();
 const template94 = (() => {
-  var _el$112 = _tmpl$56();
+  var _el$112 = _tmpl$57();
   _el$112.playsInline = false;
   return _el$112;
 })();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -264,3 +264,10 @@ const template80 = <div attr:true={true} attr:false={false}/>
 const template81 = <math display="block"><mrow></mrow></math>
 const template82 = <mrow><mi>x</mi><mo>=</mo></mrow>
 
+const template83 = <div style={{"background":"red"}}/>
+const template84 = <div style={{"background":"red", "color":"green", "margin":3, "padding":0.4}}/>
+const template85 = <div style={{"background":"red", "color":"green", "border":undefined}}/>
+const template86 = <div style={{"background":"red", "color":"green", "border":signal()}}/>
+const template87 = <div style={{"background":"red", "color":"green", "border":somevalue}}/>
+const template88 = <div style={{"background":"red", "color":"green", "border":some.access}}/>
+const template89 = <div style={{"background":"red", "color":"green", "border":null}}/>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -17,56 +17,62 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly><input>`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<a>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div><a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div>`),
-  _tmpl$17 = /*#__PURE__*/ _$template(
-    `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4">`
+  _tmpl$6 = /*#__PURE__*/ _$template(`<div style=margin-right:40px>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly><input>`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<a>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div><a>`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
+  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is </span><input><div>`),
+  _tmpl$18 = /*#__PURE__*/ _$template(
+    `<div class="class1 class2 class3 class4 class5 class6"random="random1 random2\n    random3 random4"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px">`
   ),
-  _tmpl$18 = /*#__PURE__*/ _$template(`<button>`),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<input value=10>`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
-  _tmpl$21 = /*#__PURE__*/ _$template(`<div>empty string`),
-  _tmpl$22 = /*#__PURE__*/ _$template(`<div>js empty`),
-  _tmpl$23 = /*#__PURE__*/ _$template(`<div quack>hola`),
-  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>"hola js"`),
-  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>true`),
-  _tmpl$26 = /*#__PURE__*/ _$template(`<div>false`),
-  _tmpl$27 = /*#__PURE__*/ _$template(`<div quack>1`),
-  _tmpl$28 = /*#__PURE__*/ _$template(`<div>0`),
-  _tmpl$29 = /*#__PURE__*/ _$template(`<div quack>"1"`),
-  _tmpl$30 = /*#__PURE__*/ _$template(`<div>"0"`),
-  _tmpl$31 = /*#__PURE__*/ _$template(`<div>undefined`),
-  _tmpl$32 = /*#__PURE__*/ _$template(`<div>null`),
-  _tmpl$33 = /*#__PURE__*/ _$template(`<div>boolTest()`),
-  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest`),
-  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
-  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
-  _tmpl$37 = /*#__PURE__*/ _$template(`<div>fn`),
-  _tmpl$38 = /*#__PURE__*/ _$template(`<div before quack>should have space before`),
-  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack after>should have space before/after`),
-  _tmpl$40 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after`),
-  _tmpl$41 = /*#__PURE__*/ _$template(`<img src>`),
-  _tmpl$42 = /*#__PURE__*/ _$template(`<div><img src>`),
-  _tmpl$43 = /*#__PURE__*/ _$template(`<img src loading=lazy>`, true, false, false),
-  _tmpl$44 = /*#__PURE__*/ _$template(`<div><img src loading=lazy>`, true, false, false),
-  _tmpl$45 = /*#__PURE__*/ _$template(`<iframe src>`),
-  _tmpl$46 = /*#__PURE__*/ _$template(`<div><iframe src>`),
-  _tmpl$47 = /*#__PURE__*/ _$template(`<iframe src loading=lazy>`, true, false, false),
-  _tmpl$48 = /*#__PURE__*/ _$template(`<div><iframe src loading=lazy>`, true, false, false),
-  _tmpl$49 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`),
-  _tmpl$50 = /*#__PURE__*/ _$template(`<div truestr=true truestrjs=true>`),
-  _tmpl$51 = /*#__PURE__*/ _$template(`<div falsestr=false falsestrjs=false>`),
-  _tmpl$52 = /*#__PURE__*/ _$template(`<math display=block><mrow>`, false, false, true),
-  _tmpl$53 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=`, false, false, true);
+  _tmpl$19 = /*#__PURE__*/ _$template(`<button>`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<input value=10>`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<div>empty string`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<div>js empty`),
+  _tmpl$24 = /*#__PURE__*/ _$template(`<div quack>hola`),
+  _tmpl$25 = /*#__PURE__*/ _$template(`<div quack>"hola js"`),
+  _tmpl$26 = /*#__PURE__*/ _$template(`<div quack>true`),
+  _tmpl$27 = /*#__PURE__*/ _$template(`<div>false`),
+  _tmpl$28 = /*#__PURE__*/ _$template(`<div quack>1`),
+  _tmpl$29 = /*#__PURE__*/ _$template(`<div>0`),
+  _tmpl$30 = /*#__PURE__*/ _$template(`<div quack>"1"`),
+  _tmpl$31 = /*#__PURE__*/ _$template(`<div>"0"`),
+  _tmpl$32 = /*#__PURE__*/ _$template(`<div>undefined`),
+  _tmpl$33 = /*#__PURE__*/ _$template(`<div>null`),
+  _tmpl$34 = /*#__PURE__*/ _$template(`<div>boolTest()`),
+  _tmpl$35 = /*#__PURE__*/ _$template(`<div>boolTest`),
+  _tmpl$36 = /*#__PURE__*/ _$template(`<div>boolTestBinding`),
+  _tmpl$37 = /*#__PURE__*/ _$template(`<div>boolTestObjBinding.value`),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<div>fn`),
+  _tmpl$39 = /*#__PURE__*/ _$template(`<div before quack>should have space before`),
+  _tmpl$40 = /*#__PURE__*/ _$template(`<div before quack after>should have space before/after`),
+  _tmpl$41 = /*#__PURE__*/ _$template(`<div quack after>should have space before/after`),
+  _tmpl$42 = /*#__PURE__*/ _$template(`<img src>`),
+  _tmpl$43 = /*#__PURE__*/ _$template(`<div><img src>`),
+  _tmpl$44 = /*#__PURE__*/ _$template(`<img src loading=lazy>`, true, false, false),
+  _tmpl$45 = /*#__PURE__*/ _$template(`<div><img src loading=lazy>`, true, false, false),
+  _tmpl$46 = /*#__PURE__*/ _$template(`<iframe src>`),
+  _tmpl$47 = /*#__PURE__*/ _$template(`<div><iframe src>`),
+  _tmpl$48 = /*#__PURE__*/ _$template(`<iframe src loading=lazy>`, true, false, false),
+  _tmpl$49 = /*#__PURE__*/ _$template(`<div><iframe src loading=lazy>`, true, false, false),
+  _tmpl$50 = /*#__PURE__*/ _$template(`<div title="<u>data</u>">`),
+  _tmpl$51 = /*#__PURE__*/ _$template(`<div truestr=true truestrjs=true>`),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<div falsestr=false falsestrjs=false>`),
+  _tmpl$53 = /*#__PURE__*/ _$template(`<math display=block><mrow>`, false, false, true),
+  _tmpl$54 = /*#__PURE__*/ _$template(`<mrow><mi>x</mi><mo>=`, false, false, true),
+  _tmpl$55 = /*#__PURE__*/ _$template(`<div style=background:red>`),
+  _tmpl$56 = /*#__PURE__*/ _$template(
+    `<div style=background:red;color:green;margin:3;padding:0.4>`
+  ),
+  _tmpl$57 = /*#__PURE__*/ _$template(`<div style=background:red;color:green>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -166,14 +172,13 @@ const template6 = (() => {
 })();
 let undefVar;
 const template7 = (() => {
-  var _el$13 = _tmpl$4();
+  var _el$13 = _tmpl$6();
   _el$13.classList.toggle("other-class", !!undefVar);
   _el$13.classList.toggle("other-class2", !!undefVar);
   _$effect(
     _p$ => {
       var _v$ = {
           "background-color": color(),
-          "margin-right": "40px",
           ...props.style
         },
         _v$2 = props.top,
@@ -227,19 +232,19 @@ const template12 = (() => {
   return _el$18;
 })();
 const template13 = (() => {
-  var _el$19 = _tmpl$6();
+  var _el$19 = _tmpl$7();
   _el$19.checked = true;
   return _el$19;
 })();
 const template14 = (() => {
-  var _el$20 = _tmpl$6();
+  var _el$20 = _tmpl$7();
   _$effect(() => (_el$20.checked = state.visible));
   return _el$20;
 })();
-const template15 = _tmpl$7();
-const template16 = _tmpl$8();
+const template15 = _tmpl$8();
+const template16 = _tmpl$9();
 const template17 = (() => {
-  var _el$23 = _tmpl$9();
+  var _el$23 = _tmpl$10();
   _$addEventListener(_el$23, "click", increment, true);
   return _el$23;
 })();
@@ -257,9 +262,9 @@ const template18 = (() => {
   );
   return _el$24;
 })();
-const template19 = _tmpl$10();
+const template19 = _tmpl$11();
 const template20 = (() => {
-  var _el$26 = _tmpl$11(),
+  var _el$26 = _tmpl$12(),
     _el$27 = _el$26.firstChild,
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
@@ -302,7 +307,7 @@ const template21 = (() => {
   );
   return _el$29;
 })();
-const template22 = _tmpl$12();
+const template22 = _tmpl$13();
 const template23 = (() => {
   var _el$31 = _tmpl$4();
   _$insert(_el$31, () => "t" in test && "true");
@@ -310,7 +315,7 @@ const template23 = (() => {
   return _el$31;
 })();
 const template24 = (() => {
-  var _el$32 = _tmpl$13();
+  var _el$32 = _tmpl$14();
   _$spread(
     _el$32,
     _$mergeProps(props, {
@@ -322,7 +327,7 @@ const template24 = (() => {
   return _el$32;
 })();
 const template25 = (() => {
-  var _el$33 = _tmpl$14(),
+  var _el$33 = _tmpl$15(),
     _el$34 = _el$33.firstChild;
   _$insert(_el$33, () => props.children, _el$34);
   _$spread(
@@ -336,13 +341,13 @@ const template25 = (() => {
   return _el$33;
 })();
 const template26 = (() => {
-  var _el$35 = _tmpl$15();
+  var _el$35 = _tmpl$16();
   _$setAttribute(_el$35, "middle", middle);
   _$spread(_el$35, spread, false, true);
   return _el$35;
 })();
 const template27 = (() => {
-  var _el$36 = _tmpl$15();
+  var _el$36 = _tmpl$16();
   _$spread(
     _el$36,
     _$mergeProps(
@@ -358,7 +363,7 @@ const template27 = (() => {
   return _el$36;
 })();
 const template28 = (() => {
-  var _el$37 = _tmpl$16(),
+  var _el$37 = _tmpl$17(),
     _el$38 = _el$37.firstChild,
     _el$39 = _el$38.firstChild,
     _el$40 = _el$38.nextSibling,
@@ -376,7 +381,7 @@ const template29 = (() => {
   _$insert(_el$42, !!someValue);
   return _el$42;
 })();
-const template30 = _tmpl$17();
+const template30 = _tmpl$18();
 const template31 = (() => {
   var _el$44 = _tmpl$4();
   _$effect(_$p =>
@@ -386,29 +391,25 @@ const template31 = (() => {
   );
   return _el$44;
 })();
-const template32 = (() => {
-  var _el$45 = _tmpl$4();
-  _el$45.style.removeProperty("background-color");
-  return _el$45;
-})();
+const template32 = _tmpl$4();
 const template33 = [
   (() => {
-    var _el$46 = _tmpl$18();
+    var _el$46 = _tmpl$19();
     _$className(_el$46, styles.button);
     return _el$46;
   })(),
   (() => {
-    var _el$47 = _tmpl$18();
+    var _el$47 = _tmpl$19();
     _$className(_el$47, styles["foo--bar"]);
     return _el$47;
   })(),
   (() => {
-    var _el$48 = _tmpl$18();
+    var _el$48 = _tmpl$19();
     _$effect(() => _$className(_el$48, styles.foo.bar));
     return _el$48;
   })(),
   (() => {
-    var _el$49 = _tmpl$18();
+    var _el$49 = _tmpl$19();
     _$effect(() => _$className(_el$49, styles[foo()]));
     return _el$49;
   })()
@@ -444,7 +445,7 @@ const template38 = (() => {
   typeof _ref$7 === "function" && _$use(_ref$7, _el$54);
   return _el$54;
 })();
-const template39 = _tmpl$19();
+const template39 = _tmpl$20();
 const template40 = (() => {
   var _el$56 = _tmpl$4();
   _$effect(_$p =>
@@ -455,7 +456,7 @@ const template40 = (() => {
   return _el$56;
 })();
 const template41 = (() => {
-  var _el$57 = _tmpl$20(),
+  var _el$57 = _tmpl$21(),
     _el$58 = _el$57.firstChild,
     _el$59 = _el$58.nextSibling;
   _$effect(() => (_el$58.value = Color.Red));
@@ -472,57 +473,57 @@ const boolTestBinding = false;
 const boolTestObjBinding = {
   value: false
 };
-const template42 = _tmpl$21();
-const template43 = _tmpl$22();
-const template44 = _tmpl$23();
-const template45 = _tmpl$24();
-const template46 = _tmpl$25();
-const template47 = _tmpl$26();
-const template48 = _tmpl$27();
-const template49 = _tmpl$28();
-const template50 = _tmpl$29();
-const template51 = _tmpl$30();
-const template52 = _tmpl$31();
-const template53 = _tmpl$32();
+const template42 = _tmpl$22();
+const template43 = _tmpl$23();
+const template44 = _tmpl$24();
+const template45 = _tmpl$25();
+const template46 = _tmpl$26();
+const template47 = _tmpl$27();
+const template48 = _tmpl$28();
+const template49 = _tmpl$29();
+const template50 = _tmpl$30();
+const template51 = _tmpl$31();
+const template52 = _tmpl$32();
+const template53 = _tmpl$33();
 const template54 = (() => {
-  var _el$72 = _tmpl$33();
+  var _el$72 = _tmpl$34();
   _$effect(() => _$setBoolAttribute(_el$72, "quack", boolTest()));
   return _el$72;
 })();
 const template55 = (() => {
-  var _el$73 = _tmpl$34();
+  var _el$73 = _tmpl$35();
   _$setBoolAttribute(_el$73, "quack", boolTest);
   return _el$73;
 })();
 const template56 = (() => {
-  var _el$74 = _tmpl$35();
+  var _el$74 = _tmpl$36();
   _$setBoolAttribute(_el$74, "quack", boolTestBinding);
   return _el$74;
 })();
 const template57 = (() => {
-  var _el$75 = _tmpl$36();
+  var _el$75 = _tmpl$37();
   _$effect(() => _$setBoolAttribute(_el$75, "quack", boolTestObjBinding.value));
   return _el$75;
 })();
 const template58 = (() => {
-  var _el$76 = _tmpl$37();
+  var _el$76 = _tmpl$38();
   _$setBoolAttribute(_el$76, "quack", () => false);
   return _el$76;
 })();
-const template59 = _tmpl$38();
-const template60 = _tmpl$39();
-const template61 = _tmpl$40();
+const template59 = _tmpl$39();
+const template60 = _tmpl$40();
+const template61 = _tmpl$41();
 // this crash it for some reason- */ const template62 = <div bool:quack>really empty</div>;
 
-const template63 = _tmpl$41();
-const template64 = _tmpl$42();
-const template65 = _tmpl$43();
-const template66 = _tmpl$44();
-const template67 = _tmpl$45();
-const template68 = _tmpl$46();
-const template69 = _tmpl$47();
-const template70 = _tmpl$48();
-const template71 = _tmpl$49();
+const template63 = _tmpl$42();
+const template64 = _tmpl$43();
+const template65 = _tmpl$44();
+const template66 = _tmpl$45();
+const template67 = _tmpl$46();
+const template68 = _tmpl$47();
+const template69 = _tmpl$48();
+const template70 = _tmpl$49();
+const template71 = _tmpl$50();
 const template72 = (() => {
   var _el$89 = _tmpl$4();
   _$use(binding, _el$89);
@@ -552,12 +553,12 @@ const template76 = (() => {
   return _el$93;
 })();
 const template77 = (() => {
-  var _el$94 = _tmpl$50();
+  var _el$94 = _tmpl$51();
   _$setAttribute(_el$94, "true", true);
   return _el$94;
 })();
 const template78 = (() => {
-  var _el$95 = _tmpl$51();
+  var _el$95 = _tmpl$52();
   _$setAttribute(_el$95, "false", false);
   return _el$95;
 })();
@@ -573,6 +574,35 @@ const template80 = (() => {
   _$setAttribute(_el$97, "false", false);
   return _el$97;
 })();
-const template81 = _tmpl$52();
-const template82 = _tmpl$53();
+const template81 = _tmpl$53();
+const template82 = _tmpl$54();
+const template83 = _tmpl$55();
+const template84 = _tmpl$56();
+const template85 = _tmpl$57();
+const template86 = (() => {
+  var _el$103 = _tmpl$57();
+  _$effect(_$p =>
+    (_$p = signal()) != null
+      ? _el$103.style.setProperty("border", _$p)
+      : _el$103.style.removeProperty("border")
+  );
+  return _el$103;
+})();
+const template87 = (() => {
+  var _el$104 = _tmpl$57();
+  somevalue != null
+    ? _el$104.style.setProperty("border", somevalue)
+    : _el$104.style.removeProperty("border");
+  return _el$104;
+})();
+const template88 = (() => {
+  var _el$105 = _tmpl$57();
+  _$effect(_$p =>
+    (_$p = some.access) != null
+      ? _el$105.style.setProperty("border", _$p)
+      : _el$105.style.removeProperty("border")
+  );
+  return _el$105;
+})();
+const template89 = _tmpl$57();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -20,25 +20,26 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$3 = /*#__PURE__*/ _$template(`<div foo>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
-  _tmpl$8 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
-  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
-  _tmpl$10 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
-  _tmpl$11 = /*#__PURE__*/ _$template(`<div><input readonly><input>`),
-  _tmpl$12 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
-  _tmpl$13 = /*#__PURE__*/ _$template(`<a>`),
-  _tmpl$14 = /*#__PURE__*/ _$template(`<div><!$><!/><a>`),
-  _tmpl$15 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
-  _tmpl$16 = /*#__PURE__*/ _$template(`<label><span>Input is <!$><!/></span><input><div>`),
-  _tmpl$17 = /*#__PURE__*/ _$template(
-    `<div class="class1 class2 class3 class4 class5 class6"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px;"random="random1 random2\n    random3 random4">`
+  _tmpl$6 = /*#__PURE__*/ _$template(`<div style=margin-right:40px>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<div class="\`a">\`$\``),
+  _tmpl$9 = /*#__PURE__*/ _$template(`<button class="static hi"type=button>Write`),
+  _tmpl$10 = /*#__PURE__*/ _$template(`<button class="a b c">Hi`),
+  _tmpl$11 = /*#__PURE__*/ _$template(`<div class="bg-red-500 flex flex-col">`),
+  _tmpl$12 = /*#__PURE__*/ _$template(`<div><input readonly><input>`),
+  _tmpl$13 = /*#__PURE__*/ _$template(`<div data="&quot;hi&quot;"data2="&quot;">`),
+  _tmpl$14 = /*#__PURE__*/ _$template(`<a>`),
+  _tmpl$15 = /*#__PURE__*/ _$template(`<div><!$><!/><a>`),
+  _tmpl$16 = /*#__PURE__*/ _$template(`<div start=Hi>Hi`),
+  _tmpl$17 = /*#__PURE__*/ _$template(`<label><span>Input is <!$><!/></span><input><div>`),
+  _tmpl$18 = /*#__PURE__*/ _$template(
+    `<div class="class1 class2 class3 class4 class5 class6"random="random1 random2\n    random3 random4"style="color:red;background-color:blue !important;border:1px solid black;font-size:12px">`
   ),
-  _tmpl$18 = /*#__PURE__*/ _$template(`<button>`),
-  _tmpl$19 = /*#__PURE__*/ _$template(`<input value=10>`),
-  _tmpl$20 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
-  _tmpl$21 = /*#__PURE__*/ _$template(`<div a a a a=0 a a a>`),
-  _tmpl$22 = /*#__PURE__*/ _$template(`<video>`);
+  _tmpl$19 = /*#__PURE__*/ _$template(`<button>`),
+  _tmpl$20 = /*#__PURE__*/ _$template(`<input value=10>`),
+  _tmpl$21 = /*#__PURE__*/ _$template(`<select><option>Red</option><option>Blue`),
+  _tmpl$22 = /*#__PURE__*/ _$template(`<div a a a a=0 a a a>`),
+  _tmpl$23 = /*#__PURE__*/ _$template(`<video>`);
 import * as styles from "./styles.module.css";
 const selected = true;
 let id = "my-h1";
@@ -137,14 +138,13 @@ const template6 = (() => {
 })();
 let undefVar;
 const template7 = (() => {
-  var _el$13 = _$getNextElement(_tmpl$4);
+  var _el$13 = _$getNextElement(_tmpl$6);
   _el$13.classList.toggle("other-class", !!undefVar);
   _el$13.classList.toggle("other-class2", !!undefVar);
   _$effect(
     _p$ => {
       var _v$ = {
           "background-color": color(),
-          "margin-right": "40px",
           ...props.style
         },
         _v$2 = props.top,
@@ -198,19 +198,19 @@ const template12 = (() => {
   return _el$18;
 })();
 const template13 = (() => {
-  var _el$19 = _$getNextElement(_tmpl$6);
+  var _el$19 = _$getNextElement(_tmpl$7);
   _$setProperty(_el$19, "checked", true);
   return _el$19;
 })();
 const template14 = (() => {
-  var _el$20 = _$getNextElement(_tmpl$6);
+  var _el$20 = _$getNextElement(_tmpl$7);
   _$effect(() => _$setProperty(_el$20, "checked", state.visible));
   return _el$20;
 })();
-const template15 = _$getNextElement(_tmpl$7);
-const template16 = _$getNextElement(_tmpl$8);
+const template15 = _$getNextElement(_tmpl$8);
+const template16 = _$getNextElement(_tmpl$9);
 const template17 = (() => {
-  var _el$23 = _$getNextElement(_tmpl$9);
+  var _el$23 = _$getNextElement(_tmpl$10);
   _$addEventListener(_el$23, "click", increment, true);
   _$runHydrationEvents();
   return _el$23;
@@ -230,9 +230,9 @@ const template18 = (() => {
   _$runHydrationEvents();
   return _el$24;
 })();
-const template19 = _$getNextElement(_tmpl$10);
+const template19 = _$getNextElement(_tmpl$11);
 const template20 = (() => {
-  var _el$26 = _$getNextElement(_tmpl$11),
+  var _el$26 = _$getNextElement(_tmpl$12),
     _el$27 = _el$26.firstChild,
     _el$28 = _el$27.nextSibling;
   _$addEventListener(_el$27, "input", doSomething, true);
@@ -276,7 +276,7 @@ const template21 = (() => {
   );
   return _el$29;
 })();
-const template22 = _$getNextElement(_tmpl$12);
+const template22 = _$getNextElement(_tmpl$13);
 const template23 = (() => {
   var _el$31 = _$getNextElement(_tmpl$4);
   _$insert(_el$31, () => "t" in test && "true");
@@ -284,7 +284,7 @@ const template23 = (() => {
   return _el$31;
 })();
 const template24 = (() => {
-  var _el$32 = _$getNextElement(_tmpl$13);
+  var _el$32 = _$getNextElement(_tmpl$14);
   _$spread(
     _el$32,
     _$mergeProps(props, {
@@ -297,7 +297,7 @@ const template24 = (() => {
   return _el$32;
 })();
 const template25 = (() => {
-  var _el$33 = _$getNextElement(_tmpl$14),
+  var _el$33 = _$getNextElement(_tmpl$15),
     _el$35 = _el$33.firstChild,
     [_el$36, _co$] = _$getNextMarker(_el$35.nextSibling),
     _el$34 = _el$36.nextSibling;
@@ -314,14 +314,14 @@ const template25 = (() => {
   return _el$33;
 })();
 const template26 = (() => {
-  var _el$37 = _$getNextElement(_tmpl$15);
+  var _el$37 = _$getNextElement(_tmpl$16);
   _$setAttribute(_el$37, "middle", middle);
   _$spread(_el$37, spread, false, true);
   _$runHydrationEvents();
   return _el$37;
 })();
 const template27 = (() => {
-  var _el$38 = _$getNextElement(_tmpl$15);
+  var _el$38 = _$getNextElement(_tmpl$16);
   _$spread(
     _el$38,
     _$mergeProps(
@@ -338,7 +338,7 @@ const template27 = (() => {
   return _el$38;
 })();
 const template28 = (() => {
-  var _el$39 = _$getNextElement(_tmpl$16),
+  var _el$39 = _$getNextElement(_tmpl$17),
     _el$40 = _el$39.firstChild,
     _el$41 = _el$40.firstChild,
     _el$42 = _el$41.nextSibling,
@@ -359,7 +359,7 @@ const template29 = (() => {
   _$insert(_el$46, !!someValue);
   return _el$46;
 })();
-const template30 = _$getNextElement(_tmpl$17);
+const template30 = _$getNextElement(_tmpl$18);
 const template31 = (() => {
   var _el$48 = _$getNextElement(_tmpl$4);
   _$effect(_$p =>
@@ -369,29 +369,25 @@ const template31 = (() => {
   );
   return _el$48;
 })();
-const template32 = (() => {
-  var _el$49 = _$getNextElement(_tmpl$4);
-  _el$49.style.removeProperty("background-color");
-  return _el$49;
-})();
+const template32 = _$getNextElement(_tmpl$4);
 const template33 = [
   (() => {
-    var _el$50 = _$getNextElement(_tmpl$18);
+    var _el$50 = _$getNextElement(_tmpl$19);
     _$className(_el$50, styles.button);
     return _el$50;
   })(),
   (() => {
-    var _el$51 = _$getNextElement(_tmpl$18);
+    var _el$51 = _$getNextElement(_tmpl$19);
     _$className(_el$51, styles["foo--bar"]);
     return _el$51;
   })(),
   (() => {
-    var _el$52 = _$getNextElement(_tmpl$18);
+    var _el$52 = _$getNextElement(_tmpl$19);
     _$effect(() => _$className(_el$52, styles.foo.bar));
     return _el$52;
   })(),
   (() => {
-    var _el$53 = _$getNextElement(_tmpl$18);
+    var _el$53 = _$getNextElement(_tmpl$19);
     _$effect(() => _$className(_el$53, styles[foo()]));
     return _el$53;
   })()
@@ -428,7 +424,7 @@ const template38 = (() => {
   typeof _ref$7 === "function" && _$use(_ref$7, _el$58);
   return _el$58;
 })();
-const template39 = _$getNextElement(_tmpl$19);
+const template39 = _$getNextElement(_tmpl$20);
 const template40 = (() => {
   var _el$60 = _$getNextElement(_tmpl$4);
   _$effect(_$p =>
@@ -439,7 +435,7 @@ const template40 = (() => {
   return _el$60;
 })();
 const template41 = (() => {
-  var _el$61 = _$getNextElement(_tmpl$20),
+  var _el$61 = _$getNextElement(_tmpl$21),
     _el$62 = _el$61.firstChild,
     _el$63 = _el$62.nextSibling;
   _$effect(() => _$setProperty(_el$62, "value", Color.Red));
@@ -448,7 +444,7 @@ const template41 = (() => {
   return _el$61;
 })();
 const template42 = (() => {
-  var _el$64 = _$getNextElement(_tmpl$21);
+  var _el$64 = _$getNextElement(_tmpl$22);
   _$setAttribute(_el$64, "a", true);
   _$setAttribute(_el$64, "a", false);
   _$setAttribute(_el$64, "a", undefined);
@@ -457,32 +453,32 @@ const template42 = (() => {
   return _el$64;
 })();
 const template43 = (() => {
-  var _el$65 = _$getNextElement(_tmpl$22);
+  var _el$65 = _$getNextElement(_tmpl$23);
   _$setProperty(_el$65, "playsInline", value);
   return _el$65;
 })();
 const template44 = (() => {
-  var _el$66 = _$getNextElement(_tmpl$22);
+  var _el$66 = _$getNextElement(_tmpl$23);
   _$setProperty(_el$66, "playsInline", true);
   return _el$66;
 })();
 const template45 = (() => {
-  var _el$67 = _$getNextElement(_tmpl$22);
+  var _el$67 = _$getNextElement(_tmpl$23);
   _$setProperty(_el$67, "playsInline", false);
   return _el$67;
 })();
 const template46 = (() => {
-  var _el$68 = _$getNextElement(_tmpl$22);
+  var _el$68 = _$getNextElement(_tmpl$23);
   _$setProperty(_el$68, "playsInline", value);
   return _el$68;
 })();
 const template47 = (() => {
-  var _el$69 = _$getNextElement(_tmpl$22);
+  var _el$69 = _$getNextElement(_tmpl$23);
   _$setProperty(_el$69, "playsInline", true);
   return _el$69;
 })();
 const template48 = (() => {
-  var _el$70 = _$getNextElement(_tmpl$22);
+  var _el$70 = _$getNextElement(_tmpl$23);
   _$setProperty(_el$70, "playsInline", false);
   return _el$70;
 })();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -13,8 +13,9 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$2 = /*#__PURE__*/ _$template(`<div><div></div><div> </div><div>`),
   _tmpl$3 = /*#__PURE__*/ _$template(`<div>`),
   _tmpl$4 = /*#__PURE__*/ _$template(`<div class="a b">`),
-  _tmpl$5 = /*#__PURE__*/ _$template(`<input type=checkbox readonly>`),
-  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox>`);
+  _tmpl$5 = /*#__PURE__*/ _$template(`<div style=margin-right:40px>`),
+  _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox readonly>`),
+  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`);
 const selected = true;
 let id = "my-h1";
 let link;
@@ -108,12 +109,11 @@ const template6 = (() => {
   return _el$12;
 })();
 const template7 = (() => {
-  var _el$13 = _tmpl$3();
+  var _el$13 = _tmpl$5();
   _$effect(
     _p$ => {
       var _v$ = {
           "background-color": color(),
-          "margin-right": "40px",
           ...props.style
         },
         _v$2 = props.top,
@@ -164,12 +164,12 @@ const template12 = (() => {
   return _el$18;
 })();
 const template13 = (() => {
-  var _el$19 = _tmpl$5();
+  var _el$19 = _tmpl$6();
   _el$19.checked = true;
   return _el$19;
 })();
 const template14 = (() => {
-  var _el$20 = _tmpl$6();
+  var _el$20 = _tmpl$7();
   _el$20.readOnly = value;
   _$effect(() => (_el$20.checked = state.visible));
   return _el$20;


### PR DESCRIPTION
This improves on the current optimization of inlining styles by inlining also:
   
 1. when is an object, the key is a string, and value is string/numeric
 2. remove properties from object when value is undefined/null

There is already implemented a preprocess styles, but I am not confident to change it and just wanted to add 1 more step.  I tried to add it after, but everything kept breaking, so I just added it before.

This optimization was motivated by the eslint plugin for solid, because for whatever reason autoformat makes of the style attribute an object. 

For example, you go to the playground and paste the following it will complain `style` is a string.
```js
const div = <div style="background:red;" />;
```
