### PR TITLE
avoid double escaping array in ssr, fixes #393

### DIFF
--- a/packages/dom-expressions/jest.config.js
+++ b/packages/dom-expressions/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
       displayName: "server",
       testMatch: ["<rootDir>/test/ssr/*.spec.js(x)?"],
       transform: {
-        "^.+\\.[t|j]sx?$": require.resolve("./test/transform-dom")
+        "^.+\\.[t|j]sx?$": require.resolve("./test/transform-server")
       }
     },
     {

--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -417,6 +417,7 @@ export function escape(s, attr) {
   if (t !== "string") {
     if (!attr && t === "function") return escape(s());
     if (!attr && Array.isArray(s)) {
+      s = s.slice(); // avoids double escaping - https://github.com/ryansolid/dom-expressions/issues/393
       for (let i = 0; i < s.length; i++) s[i] = escape(s[i]);
       return s;
     }

--- a/packages/dom-expressions/test/ssr/jsx.spec.jsx
+++ b/packages/dom-expressions/test/ssr/jsx.spec.jsx
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as r from "../../src/server";
+
+// avoid double escaping - https://github.com/ryansolid/dom-expressions/issues/393
+
+{
+  const a = ["<"];
+  const div = <div>{[a, a]}</div>;
+
+  it("avoids double escape 1", async () => {
+    expect(r.renderToString(() => div).replace(/<![^>]+>/g, "")).toBe("<div>&lt;&lt;</div>");
+  });
+}
+
+{
+  let x = "<";
+  let a = (
+    <>
+      {x}
+      {x}
+    </>
+  );
+  let v = (
+    <>
+      {a}
+      {a}
+    </>
+  );
+  it("avoids double escape 2", async () => {
+    const stringified = '[["<","<"],["<","<"]]';
+
+    expect(JSON.stringify(v)).toBe(stringified);
+    expect(r.renderToString(() => <>{v}</>)).toBe("&lt;<!--!$-->&lt;&lt;<!--!$-->&lt;");
+    expect(JSON.stringify(v)).toBe(stringified);
+  });
+}

--- a/packages/dom-expressions/test/transform-server.js
+++ b/packages/dom-expressions/test/transform-server.js
@@ -1,0 +1,15 @@
+const babelJest = require("babel-jest");
+
+module.exports = babelJest.createTransformer({
+  presets: [["@babel/preset-env", { targets: { node: "current" } }]],
+  plugins: [
+    [
+      "babel-plugin-transform-rename-import",
+      {
+        original: "rxcore",
+        replacement: __dirname + "/core"
+      }
+    ],
+    ["babel-plugin-jsx-dom-expressions", { moduleName: "../../src/server", generate: "ssr" }]
+  ]
+});


### PR DESCRIPTION
It fixes #393

Uses `slice` as suggested by @mdynnl and applies @katywings `transform-server` for adding tests