### PR TITLE
[main] avoid getters when possible, and apply getters recursively

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -260,7 +260,7 @@ function transformObjectToGettersRecursively(object) {
         t.isStringLiteral(value) ||
         t.isNumericLiteral(value) ||
         t.isBooleanLiteral(value) ||
-        t.isNullLiteral(value) ||
+        t.isNullLiteral(value) || // do not remove null/undefined from the object, people may use it for something
         t.isIdentifier(value)
       ) {
         return prop;

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -188,7 +188,8 @@ export default function transformComponent(path) {
                   runningObject.push(
                     t.objectProperty(
                       t.identifier(id.name),
-                      transformObjectToGettersRecursively(value.expression)
+                      transformObjectToGettersRecursively(value.expression),
+                      !t.isValidIdentifier(key)
                     )
                   );
                 }
@@ -196,10 +197,10 @@ export default function transformComponent(path) {
                 runningObject.push(
                   t.objectMethod(
                     "get",
-                  id,
-                  [],
-                  t.blockStatement([t.returnStatement(value.expression)]),
-                  !t.isValidIdentifier(key)
+                    id,
+                    [],
+                    t.blockStatement([t.returnStatement(value.expression)]),
+                    !t.isValidIdentifier(key)
                   )
                 );
               }
@@ -270,14 +271,14 @@ function transformObjectToGettersRecursively(object) {
             key,
             [],
             t.blockStatement([t.returnStatement(transformObjectToGettersRecursively(value))]),
-            !t.isValidIdentifier(key.name || key.value)
+            !t.isValidIdentifier(key.name)
           );
         }
 
         return t.objectProperty(
           key,
           transformObjectToGettersRecursively(value),
-          !t.isValidIdentifier(key.name || key.value)
+          !t.isValidIdentifier(key.name)
         );
       }
 
@@ -286,7 +287,7 @@ function transformObjectToGettersRecursively(object) {
         key,
         [],
         t.blockStatement([t.returnStatement(value)]),
-        !t.isValidIdentifier(key.name || key.value)
+        !t.isValidIdentifier(key.name)
       );
     }
 

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -177,7 +177,8 @@ export default function transformComponent(path) {
                   !hasStaticMarker(value, path) &&
                   value.expression.properties.some(
                     prop =>
-                      (t.isSpreadElement(prop) || prop.computed) &&
+                      (t.isSpreadElement(prop) ||
+                        (prop.computed && t.isMemberExpression(prop.key))) &&
                       !hasStaticMarker(prop, path) &&
                       !hasStaticMarker(prop.key, path) &&
                       !hasStaticMarker(prop.value, path)
@@ -281,7 +282,7 @@ function transformObjectToGettersRecursively(object, path) {
           !hasStaticMarker(value, path) &&
           value.properties.some(
             prop =>
-              (t.isSpreadElement(prop) || prop.computed) &&
+              (t.isSpreadElement(prop) || (prop.computed && t.isMemberExpression(prop.key))) &&
               !hasStaticMarker(prop, path) &&
               !hasStaticMarker(prop.key, path) &&
               !hasStaticMarker(prop.value, path)

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/component.js
@@ -172,7 +172,9 @@ export default function transformComponent(path) {
               runningObject.push(t.objectMethod("get", id, [], body, !t.isValidIdentifier(key)));
             } else {
               if (t.isObjectExpression(value.expression)) {
-                if (value.expression.properties.some(prop => t.isSpreadElement(prop))) {
+                if (
+                  value.expression.properties.some(prop => t.isSpreadElement(prop) || prop.computed)
+                ) {
                   runningObject.push(
                     t.objectMethod(
                       "get",
@@ -265,7 +267,7 @@ function transformObjectToGettersRecursively(object) {
       }
 
       if (t.isObjectExpression(value)) {
-        if (value.properties.some(prop => t.isSpreadElement(prop))) {
+        if (value.properties.some(prop => t.isSpreadElement(prop) || prop.computed)) {
           return t.objectMethod(
             "get",
             key,

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -77,6 +77,17 @@ export function isComponent(tagName) {
   );
 }
 
+export function hasStaticMarker(object, path) {
+  if (!object) return false;
+  if (
+    object.leadingComments &&
+    object.leadingComments[0] &&
+    object.leadingComments[0].value.trim() === getConfig(path).staticMarker
+  )
+    return true;
+  if (object.expression) return hasStaticMarker(object.expression, path);
+}
+
 export function isDynamic(path, { checkMember, checkTags, checkCallExpressions = true, native }) {
   const config = getConfig(path);
   if (config.generate === "ssr" && native) {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -325,6 +325,18 @@ const template87 = <Comp inputProps={
         [store.key]: 'ha'
     }
 } />
+const template87a1 = <Comp inputProps={
+    {
+        [quack]:'meaw',
+        [store]: 'ha'
+    }
+} />
+const template87a2 = <Comp inputProps={
+    {
+        [quack.key]:'meaw',
+        [store.key]: 'ha'
+    }
+} />
 
 const template88 = <Comp inputProps={
    {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -319,4 +319,11 @@ const template86 = <Comp inputProps={
     }
 } />
 
+const template87 = <Comp inputProps={
+    {
+        [quack]:'meaw',
+        [store.key]: 'ha'
+    }
+} />
+
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -264,3 +264,40 @@ const template80 = <div attr:true={true} attr:false={false}/>
 const template81 = <math display="block"><mrow></mrow></math>
 const template82 = <mrow><mi>x</mi><mo>=</mo></mrow>
 
+const template84 = <Comp inputProps={
+    {
+        quack,
+        title: title(),
+        name: name(),
+        quack:"best cat",
+        store:store.access,
+        static_: {
+          store:store.access,
+          quack: "best cat",
+          team:uy(),
+          store
+        },
+        spread: {
+          ...store
+        }
+    }
+} />
+
+const template85 = <Comp inputProps={
+    {
+        quack,
+        title: title(),
+        name: name(),
+        quack:"best cat",
+        store:store.access,
+        static_: {
+          store:store.access,
+          quack: "best cat",
+          team:uy(),
+          store
+        },
+        ...store
+    }
+} />
+
+

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -326,4 +326,56 @@ const template87 = <Comp inputProps={
     }
 } />
 
+const template88 = <Comp inputProps={
+   {
+       [quack]: /* @once */'meaw',
+        title: title(),
+        name:  /* @once */name(),
+        quack:"best cat",
+        store:store.access,
+        static_:  /* @once */ {
+            store:/* @once */store.access,
+            quack: "best cat",
+            team: /* @once */uy(),
+            /* @once */ store
+        },
+        /* @once */ ...store
+    }
+} />
 
+const template89 = <Comp inputProps={
+   {
+       [quack]: /* @once */'meaw',
+        title: title(),
+        name:  /* @once */name(),
+        quack:"best cat",
+        store:store.access,
+        static_:  /* @once */ {
+            store:/* @once */store.access,
+            quack: "best cat",
+            team: /* @once */uy(),
+            /* @once */ store
+        },
+        /* @once */ ...store,
+       ...store
+    }
+} />
+
+const template90 = <Comp inputProps={
+   {
+       [quack]: /* @once */'meaw',
+        title: title(),
+        name:  /* @once */name(),
+        quack:"best cat",
+        store:store.access,
+        static_:  /* @once */ {
+            store:/* @once */store.access,
+            quack: "best cat",
+            team: /* @once */uy(),
+            /* @once */ store,
+            ...store,
+        },
+        /* @once */ ...store,
+       ...store
+    }
+} />

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -301,3 +301,22 @@ const template85 = <Comp inputProps={
 } />
 
 
+
+const template86 = <Comp inputProps={
+    {
+        [quack]:'meaw',
+        title: title(),
+        name: name(),
+        quack:"best cat",
+        store:store.access,
+        static_: {
+          store:store.access,
+          quack: "best cat",
+          team:uy(),
+          store
+        },
+        ...store
+    }
+} />
+
+

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -670,4 +670,71 @@ const template87 = _$createComponent(Comp, {
     };
   }
 });
+const template88 = _$createComponent(Comp, {
+  inputProps: {
+    [quack]: /* @once */ "meaw",
+    get title() {
+      return title();
+    },
+    name: /* @once */ name(),
+    quack: "best cat",
+    get store() {
+      return store.access;
+    },
+    static_: {
+      store: /* @once */ store.access,
+      quack: "best cat",
+      team: /* @once */ uy(),
+      /* @once */ store
+    },
+    /* @once */ ...store
+  }
+});
+const template89 = _$createComponent(Comp, {
+  get inputProps() {
+    return {
+      [quack]: /* @once */ "meaw",
+      get title() {
+        return title();
+      },
+      name: /* @once */ name(),
+      quack: "best cat",
+      get store() {
+        return store.access;
+      },
+      static_: {
+        store: /* @once */ store.access,
+        quack: "best cat",
+        team: /* @once */ uy(),
+        /* @once */ store
+      },
+      /* @once */ ...store,
+      ...store
+    };
+  }
+});
+const template90 = _$createComponent(Comp, {
+  get inputProps() {
+    return {
+      [quack]: /* @once */ "meaw",
+      get title() {
+        return title();
+      },
+      name: /* @once */ name(),
+      quack: "best cat",
+      get store() {
+        return store.access;
+      },
+      static_: {
+        store: /* @once */ store.access,
+        quack: "best cat",
+        team: /* @once */ uy(),
+        /* @once */ store,
+        ...store
+      },
+      /* @once */ ...store,
+      ...store
+    };
+  }
+});
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -662,4 +662,12 @@ const template86 = _$createComponent(Comp, {
     };
   }
 });
+const template87 = _$createComponent(Comp, {
+  get inputProps() {
+    return {
+      [quack]: "meaw",
+      [store.key]: "ha"
+    };
+  }
+});
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -1,5 +1,6 @@
 import { template as _$template } from "r-dom";
 import { delegateEvents as _$delegateEvents } from "r-dom";
+import { createComponent as _$createComponent } from "r-dom";
 import { setBoolAttribute as _$setBoolAttribute } from "r-dom";
 import { insert as _$insert } from "r-dom";
 import { memo as _$memo } from "r-dom";
@@ -575,4 +576,62 @@ const template80 = (() => {
 })();
 const template81 = _tmpl$52();
 const template82 = _tmpl$53();
+const template84 = _$createComponent(Comp, {
+  inputProps: {
+    quack,
+    get title() {
+      return title();
+    },
+    get name() {
+      return name();
+    },
+    quack: "best cat",
+    get store() {
+      return store.access;
+    },
+    static_: {
+      get store() {
+        return store.access;
+      },
+      quack: "best cat",
+      get team() {
+        return uy();
+      },
+      store
+    },
+    get spread() {
+      return {
+        ...store
+      };
+    }
+  }
+});
+const template85 = _$createComponent(Comp, {
+  get inputProps() {
+    return {
+      quack,
+      get title() {
+        return title();
+      },
+      get name() {
+        return name();
+      },
+      quack: "best cat",
+      get store() {
+        return store.access;
+      },
+      static_: {
+        get store() {
+          return store.access;
+        },
+        quack: "best cat",
+        get team() {
+          return uy();
+        },
+        store
+      },
+      ...store
+    };
+  }
+});
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -634,4 +634,32 @@ const template85 = _$createComponent(Comp, {
     };
   }
 });
+const template86 = _$createComponent(Comp, {
+  get inputProps() {
+    return {
+      [quack]: "meaw",
+      get title() {
+        return title();
+      },
+      get name() {
+        return name();
+      },
+      quack: "best cat",
+      get store() {
+        return store.access;
+      },
+      static_: {
+        get store() {
+          return store.access;
+        },
+        quack: "best cat",
+        get team() {
+          return uy();
+        },
+        store
+      },
+      ...store
+    };
+  }
+});
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -670,6 +670,20 @@ const template87 = _$createComponent(Comp, {
     };
   }
 });
+const template87a1 = _$createComponent(Comp, {
+  inputProps: {
+    [quack]: "meaw",
+    [store]: "ha"
+  }
+});
+const template87a2 = _$createComponent(Comp, {
+  get inputProps() {
+    return {
+      [quack.key]: "meaw",
+      [store.key]: "ha"
+    };
+  }
+});
 const template88 = _$createComponent(Comp, {
   inputProps: {
     [quack]: /* @once */ "meaw",


### PR DESCRIPTION
It adds the optimization you suggested on discord, recorded here https://github.com/ryansolid/dom-expressions/issues/390

It considers spreads and computed keys, such `{[store.key]: "ja"}`, on which case it will keep using a getter.  It also considers `@once`.

It may be possible that we want this optimization in other places 🤔 , as when I search for `"get"` similar code popups around. Can you please have a look? Thanks!

I'm like 95% confident this won't break stuff, but honestly I'm not sure.  

Initially the recursion was a bit messy, I have just simplified it.