### PR TITLE
WIP: tagged template literals runtime based on pota.quack.uy

### DIFF
--- a/packages/quack-dom-expressions/package.json
+++ b/packages/quack-dom-expressions/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "quack-dom-expressions",
+  "description": "A Fine-Grained Rendering Runtime API using Tagged Template Literals",
+  "version": "0.39.10",
+  "author": "Ryan Carniato, Tito Bouzout",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryansolid/dom-expressions/blob/main/packages/quack-dom-expressions"
+  },
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "types": "types/index.d.ts",
+  "sideEffects": false,
+  "devDependencies": {
+    "dom-expressions": "^0.39.10"
+  }
+}

--- a/packages/quack-dom-expressions/src/index.ts
+++ b/packages/quack-dom-expressions/src/index.ts
@@ -1,0 +1,205 @@
+// @ts-nocheck
+/* eslint-disable */
+
+import h from "solid-js/h";
+import { For, Match, Show, Switch } from "solid-js";
+import { Dynamic, Portal } from "solid-js/web";
+
+// https://playground.solidjs.com/anonymous/f9d79277-f659-4108-8e53-c4bf56f695eb
+
+/**
+ * WIP tagged template solid-js proposal
+ *
+ * @url https://pota.quack.uy/
+ * @url https://github.com/ryansolid/dom-expressions
+ * @url https://www.solidjs.com/
+ */
+
+// default components registry
+
+/** @type {Record<string, Component>} */
+const defaultRegistry = {
+  Dynamic,
+  For,
+  Match,
+  Portal,
+  Show,
+  Switch
+};
+
+// utils
+
+function getValue(value) {
+  while (typeof value === "function") value = value();
+  return value;
+}
+
+function makeCallback(children) {
+  return () => (q, u, a, c, k) =>
+    [children].flat(Infinity).map(x => (typeof x === "function" ? x(q, u, a, c, k) : x));
+}
+
+// parseXML
+
+const xmlns = ["class", "on", "style", "use", "prop", "attr", "bool", "ref"]
+  .map(x => `xmlns:${x}="/"`)
+  .join(" ");
+const id = "quack-20170301-dom-expressions-solidjs";
+const splitId = /(quack-20170301-dom-expressions-solidjs)/;
+
+/**
+ * Makes Nodes from TemplateStringsArray
+ *
+ * @param {TemplateStringsArray} content
+ * @returns {Element[]}
+ */
+const parseXML = (function () {
+  const cache = new WeakMap();
+
+  return content => {
+    if (cache.has(content)) {
+      return cache.get(content);
+    }
+
+    const html = new DOMParser().parseFromString(
+      `<xml ${xmlns}>${content.join(id)}</xml>`,
+      "text/xml"
+    ).firstChild.childNodes;
+
+    // error message display
+
+    if (html[0].tagName === "parsererror") {
+      const err = html[0];
+      err.style.padding = "1em";
+
+      const errorMessage = err.firstChild.nextSibling;
+      errorMessage.textContent = errorMessage.textContent.replace(/: /g, ":\n");
+
+      const title = err.firstChild;
+      title.textContent = "XML Syntax Error:";
+
+      const code = document.createTextNode(
+        "\n" +
+          content
+            .join("")
+            .split("\n")
+            .map((x, i) => i + 1 + ". " + x)
+            .join("\n")
+      );
+      err.firstChild.nextSibling.style.cssText = "";
+      err.lastChild.replaceWith(code);
+    }
+
+    cache.set(content, html);
+
+    return html;
+  };
+})();
+
+/**
+ * Recursively walks a template and transforms it to `h` calls
+ *
+ * @param {typeof xml} xml
+ * @param {Element[]} cached
+ * @param {...unknown} values
+ * @returns {Children}
+ */
+function toH(xml, cached, values) {
+  let index = 0;
+
+  /**
+   * Recursively transforms DOM nodes into Component calls
+   *
+   * @param {ChildNode} node - The DOM node to transform
+   * @returns {Children} Transformed node(s) as Components
+   */
+  function nodes(node) {
+    const { nodeType } = node;
+    if (nodeType === 1) {
+      // element
+      const { tagName, attributes, childNodes } = /** @type {Element} */ node;
+
+      // gather props
+      /** @type {Record<string, Accessor<unknown>>} */
+      const props = Object.create(null);
+      for (let { name, value } of attributes) {
+        if (value === id) {
+          value = values[index++];
+        } else if (value.includes(id)) {
+          const val = value.split(splitId).map(x => (x === id ? values[index++] : x));
+
+          value = () => val.map(getValue).join("");
+        }
+        props[name] = value;
+      }
+
+      // component
+      const component = xml.components[tagName];
+      /^[A-Z]/.test(tagName) &&
+        !component &&
+        console.warn(`xml: Forgot to ´xml.define({ ${tagName} })´?`);
+
+      // children - childNodes overwrites any props.children
+      if (childNodes.length) {
+        props.children = Array.from(childNodes).map(nodes);
+      }
+
+      // fix callbacks
+      if (component) {
+        props.children = makeCallback(props.children);
+      }
+
+      // calll
+      return h(xml.components[tagName] || tagName, props, props.children);
+    } else if (nodeType === 3) {
+      // text
+      const value = node.nodeValue;
+      return value.includes(id)
+        ? value.split(splitId).map(x => (x === id ? values[index++] : x))
+        : value;
+    } else if (nodeType === 8) {
+      // comment
+      const value = node.nodeValue;
+      if (value.includes(id)) {
+        const val = value.split(splitId).map(x => (x === id ? values[index++] : x));
+        return () => document.createComment(val.map(getValue).join(""));
+      } else {
+        return document.createComment(value);
+      }
+    } else {
+      throw new Error(`xml: ´nodeType´ not supported ´${nodeType}´`);
+    }
+  }
+
+  return Array.from(cached).map(nodes);
+}
+
+/**
+ * Function to create cached tagged template components
+ *
+ * @url https://pota.quack.uy/XML
+ */
+export function XML() {
+  /**
+   * Creates tagged template components
+   *
+   * @param {TemplateStringsArray} template
+   * @param {...unknown} values
+   * @url https://pota.quack.uy/XML
+   */
+  function xml(template, ...values) {
+    return toH(xml, parseXML(template), values);
+  }
+
+  xml.components = { ...defaultRegistry };
+  /** @param {Record<string, Component>} userComponents */
+  xml.define = userComponents => {
+    for (const name in userComponents) {
+      xml.components[name] = userComponents[name];
+    }
+  };
+
+  return xml;
+}
+
+export const xml = XML();

--- a/packages/quack-dom-expressions/test/playgound.tsx
+++ b/packages/quack-dom-expressions/test/playgound.tsx
@@ -1,0 +1,123 @@
+// @ts-nocheck
+/* eslint-disable */
+
+import { render } from "solid-js/web";
+import { createSignal, createMemo } from "solid-js";
+
+import { xml as sld, XML } from "./xml";
+
+function App() {
+  debugEnsureNoRerenders("App");
+
+  return sld`
+    <header><h1>Hello ! sld</h1></header>
+    <main>
+      <Counter/>
+      <List/>
+      <Toggle/>
+      <CustomComponent name="quack" description="${() => "meow meow milch"}"/>
+      <ParserErrorExample/>
+    </main>
+    <footer>thats all folks!</footer>`;
+}
+
+function Counter() {
+  debugEnsureNoRerenders("Counter");
+
+  const [count, setCount] = createSignal(1);
+  const increment = () => setCount(count => count + 1);
+
+  const nssld = new XML();
+
+  const double = () => createMemo(() => count() * 2);
+
+  nssld.define({ double });
+
+  return nssld`
+    <h2>Simple Counter</h2>
+    <label>
+      Inline a signal, define it as a tag, or just inline a function
+
+      <button type="button" on:click="${increment}">
+        ${count} <double/> ${() => count() * 3}
+      </button>
+    </label>
+    <hr/>
+  `;
+}
+
+function List(props) {
+  debugEnsureNoRerenders("List");
+
+  const [count, setCount] = createSignal(0);
+  setInterval(() => setCount(count => count + 1), 1000);
+
+  return sld`
+    <h2>Rendering a list</h2>
+    <For each="${[{ val: count }, { val: 1 }, { val: 2 }, { val: 3 }]}">
+    ${(value, index) => {
+      debugEnsureNoRerenders("List index " + index());
+      return sld`<div>value is ${value.val}, index is ${index}</div>`;
+    }}
+    </For>
+    <hr/>
+  `;
+}
+
+function Toggle(props) {
+  debugEnsureNoRerenders("Toggle");
+
+  const [showing, setShowing] = createSignal(false);
+  const toggle = () => setShowing(showing => !showing);
+
+  return sld`
+    <h2>Toggling something</h2>
+    <div>doesnt work, something wrong with \`h\` maybe</div>
+    <label>
+      <button type="button" on:click="${toggle}">
+        Toggle!
+      </button>
+      is it showing? ${showing}
+    </label>
+    <Show when="${showing}" >
+      ${showing => {
+        debugEnsureNoRerenders("Show callback " + showing());
+        return sld`<div>🦆 🐈‍⬛</div>`;
+      }}
+    </Show>
+    <hr/>
+  `;
+}
+
+function CustomComponent(props) {
+  return sld`
+    <h2>Custom component example</h2>
+    ${props.name} ${props.description.toUpperCase()}
+    <hr/>
+  `;
+}
+
+function ParserErrorExample() {
+  return [
+    sld`
+      <h2>Parser error example</h2>
+      when a tagged template has an syntax error it renders a helpful message
+      `,
+    sld`
+      <div>oops`
+  ];
+}
+
+sld.define({ Counter, List, Toggle, CustomComponent, ParserErrorExample });
+
+render(App, document.getElementById("app")!);
+
+// debug stuff
+
+// ensure no re-renders sanity check
+function debugEnsureNoRerenders(name) {
+  const [count, setCount] = createSignal(1);
+  setInterval(() => setCount(count => count + 1), 1000);
+  count();
+  console.log("rendered", name);
+}


### PR DESCRIPTION
WIP 

Implementation of tagged template literals based on work done in https://pota.quack.uy/XML

Features:
- xml based
- simple to use syntax
- descriptive and useful errors with syntax errors
- can inline components
- namespaced, has a global component registry, and a local component registry
- As reactive as JSX
- can possibly be translated to JSX and JSX can be translated to tagged templates
 -  `h` based, as long as `h` works it should be low maintenance
 
Anti-features:
- its hella slow

Note:
- currently a bit buggy, I suspect `h` is doing weird stuff 
- I have chosen `sld`  for the name of the function, anything you consider is good for me. Prettier and other tools mess up with `html`. Having an own name forces tools to treat us specially. 
- discord thread https://discord.gg/solidjs  https://discord.com/channels/722131463138705510/1394408373176369202  

Example counter https://playground.solidjs.com/anonymous/2a9b1434-ec15-460b-afeb-d559dc9254cf
More examples: https://playground.solidjs.com/anonymous/9f6fd6e1-525f-4304-92f2-66b98fc5db96

Syntax:

 ```js
import { render } from "solid-js/web";
import { createSignal, createMemo } from "solid-js";
import { sld } from "solid-js/sld";

function Counter() {

  const [count, setCount] = createSignal(1);
  const increment = () => setCount(count => count + 1);

  const double = () => createMemo(() => count() * 2);

  sld.define({ double, Quadruple });

  return sld`
    <h2>Simple Counter</h2>
    <label>
      Inline a signal, define it as a tag, or just inline a function

      <button type="button" on:click="${increment}">
        ${count} <double/> ${() => count() * 3} <Quadruple count="${count}"/>
      </button>
    </label>
    <hr/>
  `;
}

function Quadruple(props){
  return () => props.count * 4 
}

render(Counter, document.getElementById("app")!);
```

