### PR TITLE
fix regression with inlining of `style` and `classList` 

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -27,7 +27,8 @@ import {
   convertJSXIdentifier,
   canNativeSpread,
   transformCondition,
-  trimWhitespace
+  trimWhitespace,
+  hasStaticMarker
 } from "../shared/utils";
 import { transformNode } from "../shared/transform";
 import { InlineElements, BlockElements } from "./constants";
@@ -798,9 +799,12 @@ function transformAttributes(path, results) {
           }
         } else if (
           config.effectWrapper &&
-          isDynamic(attribute.get("value").get("expression"), {
+          (isDynamic(attribute.get("value").get("expression"), {
             checkMember: true
-          })
+          }) ||
+            ((key === "classList" || key === "style") &&
+              !attribute.get("value").get("expression").evaluate().confident &&
+              !hasStaticMarker(value, path)))
         ) {
           /*
             Following code doesn't repect static marker `@once`.

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -77,6 +77,17 @@ export function isComponent(tagName) {
   );
 }
 
+export function hasStaticMarker(object, path) {
+  if (!object) return false;
+  if (
+    object.leadingComments &&
+    object.leadingComments[0] &&
+    object.leadingComments[0].value.trim() === getConfig(path).staticMarker
+  )
+    return true;
+  if (object.expression) return hasStaticMarker(object.expression, path);
+}
+
 export function isDynamic(path, { checkMember, checkTags, checkCallExpressions = true, native }) {
   const config = getConfig(path);
   if (config.generate === "ssr" && native) {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/code.js
@@ -136,3 +136,20 @@ const template29 = (
 const styleProp = { style: { width: props.width, height: props.height } };
 const template30 = <div style={/* @once */ styleProp.style} />;
 const template31 = <div style={styleProp.style} />;
+
+const style = {
+  background: "red",
+  border: "solid black " + count() + "px"
+};
+
+const template32 = (
+  <button type="button" aria-label={count()} style={style} classList={style}>
+    {count()}
+  </button>
+);
+
+const template33 = (
+  <button type="button" aria-label={count()} style={/* @once*/ style} classList={/* @once*/ style}>
+    {count()}
+  </button>
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -1,4 +1,5 @@
 import { template as _$template } from "r-dom";
+import { insert as _$insert } from "r-dom";
 import { setProp as _$setProp } from "r-custom";
 import { createElement as _$createElement } from "r-custom";
 import { style as _$style } from "r-dom";
@@ -16,7 +17,8 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div id=main><h1 class=base id=my-h1><a h
   _tmpl$4 = /*#__PURE__*/ _$template(`<div class="a b">`),
   _tmpl$5 = /*#__PURE__*/ _$template(`<div style=margin-right:40px>`),
   _tmpl$6 = /*#__PURE__*/ _$template(`<input type=checkbox readonly>`),
-  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`);
+  _tmpl$7 = /*#__PURE__*/ _$template(`<input type=checkbox>`),
+  _tmpl$8 = /*#__PURE__*/ _$template(`<button type=button>`);
 const selected = true;
 let id = "my-h1";
 let link;
@@ -341,4 +343,37 @@ const template31 = (() => {
   var _el$37 = _tmpl$3();
   _$effect(_$p => _$style(_el$37, styleProp.style, _$p));
   return _el$37;
+})();
+const style = {
+  background: "red",
+  border: "solid black " + count() + "px"
+};
+const template32 = (() => {
+  var _el$38 = _tmpl$8();
+  _$insert(_el$38, count);
+  _$effect(
+    _p$ => {
+      var _v$4 = count(),
+        _v$5 = style,
+        _v$6 = style;
+      _v$4 !== _p$.e && _$setAttribute(_el$38, "aria-label", (_p$.e = _v$4));
+      _p$.t = _$style(_el$38, _v$5, _p$.t);
+      _p$.a = _$classList(_el$38, _v$6, _p$.a);
+      return _p$;
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined
+    }
+  );
+  return _el$38;
+})();
+const template33 = (() => {
+  var _el$39 = _tmpl$8();
+  _$style(_el$39, style);
+  _$classList(_el$39, style);
+  _$insert(_el$39, count);
+  _$effect(() => _$setAttribute(_el$39, "aria-label", count()));
+  return _el$39;
 })();


### PR DESCRIPTION
When object is just an identifier it was not adding the effect, such `<div style={style} classList={classes}/>`.
This considers `@once`, for in case It's desired to bail out from the effect.