### PR TITLE
main: update JSX types

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1420,7 +1420,7 @@ export namespace JSX {
     tabindex?: never;
 
     /** @experimental */
-    closedby: FunctionMaybe<"any" | "closerequest" | "none" | undefined>;
+    closedby?: FunctionMaybe<"any" | "closerequest" | "none" | undefined>;
   }
   interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
     height?: FunctionMaybe<number | string | undefined>;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1436,7 +1436,7 @@ export namespace JSX {
     tabindex?: never;
 
     /** @experimental */
-    closedby: "any" | "closerequest" | "none" | undefined;
+    closedby?: "any" | "closerequest" | "none" | undefined;
   }
   interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
     height?: number | string | undefined;


### PR DESCRIPTION
fix `closedby` type missing optional in `<dialog/>` element

see https://github.com/solidjs/solid/issues/2524