### PR TITLE
next: update JSX Types

### DIFF
--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1012,15 +1012,15 @@ export namespace JSX {
         ? K extends `on:${infer T}`
           ? T
           : K extends `on${infer T}`
-            ? Lowercase<T>
-            : never
+          ? Lowercase<T>
+          : never
         : never)
     | (keyof EventHandlersElement<any> extends infer K
         ? K extends `on:${infer T}`
           ? T
           : K extends `on${infer T}`
-            ? Lowercase<T>
-            : never
+          ? Lowercase<T>
+          : never
         : never)
     | (string & {});
 
@@ -1407,7 +1407,7 @@ export namespace JSX {
     tabindex?: never;
 
     /** @experimental */
-    closedby: FunctionMaybe<"any" | "closerequest" | "none" | RemoveAttribute>;
+    closedby?: FunctionMaybe<"any" | "closerequest" | "none" | RemoveAttribute>;
   }
   interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
     height?: FunctionMaybe<number | string | RemoveAttribute>;

--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -249,8 +249,6 @@ export namespace JSX {
     [x: string]: (el: DOMElement, accessor: Accessor<any>) => void;
   }
   interface ExplicitProperties {}
-  interface ExplicitAttributes {}
-  interface ExplicitBoolAttributes {}
   interface CustomEvents {}
   type DirectiveAttributes = {
     [Key in keyof Directives as `use:${Key}`]?: Directives[Key];
@@ -1037,8 +1035,6 @@ export namespace JSX {
       DirectiveAttributes,
       DirectiveFunctionAttributes<T>,
       PropAttributes,
-      AttrAttributes,
-      BoolAttributes,
       OnAttributes<T>,
       EventHandlersElement<T>,
       AriaAttributes {

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1013,15 +1013,15 @@ export namespace JSX {
         ? K extends `on:${infer T}`
           ? T
           : K extends `on${infer T}`
-            ? Lowercase<T>
-            : never
+          ? Lowercase<T>
+          : never
         : never)
     | (keyof EventHandlersElement<any> extends infer K
         ? K extends `on:${infer T}`
           ? T
           : K extends `on${infer T}`
-            ? Lowercase<T>
-            : never
+          ? Lowercase<T>
+          : never
         : never)
     | (string & {});
 
@@ -1409,7 +1409,7 @@ export namespace JSX {
     tabindex?: never;
 
     /** @experimental */
-    closedby: "any" | "closerequest" | "none" | RemoveAttribute;
+    closedby?: "any" | "closerequest" | "none" | RemoveAttribute;
   }
   interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
     height?: number | string | RemoveAttribute;

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -246,8 +246,6 @@ export namespace JSX {
     [x: string]: (el: DOMElement, accessor: Accessor<any>) => void;
   }
   interface ExplicitProperties {}
-  interface ExplicitAttributes {}
-  interface ExplicitBoolAttributes {}
   interface CustomEvents {}
   type DirectiveAttributes = {
     [Key in keyof Directives as `use:${Key}`]?: Directives[Key];
@@ -1038,8 +1036,6 @@ export namespace JSX {
       DirectiveAttributes,
       DirectiveFunctionAttributes<T>,
       PropAttributes,
-      AttrAttributes,
-      BoolAttributes,
       OnAttributes<T>,
       EventHandlersElement<T>,
       AriaAttributes {


### PR DESCRIPTION
- mark `closedby` as optional
- remove some types related to `attr:` and `bool:`