### PR TITLE
remove leftover package.json `validate-html-nesting`

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/package.json
+++ b/packages/babel-plugin-jsx-dom-expressions/package.json
@@ -23,8 +23,7 @@
     "@babel/plugin-syntax-jsx": "^7.18.6",
     "@babel/types": "^7.20.7",
     "html-entities": "2.3.3",
-    "parse5": "^7.1.2",
-    "validate-html-nesting": "^1.2.1"
+    "parse5": "^7.1.2"
   },
   "peerDependencies": {
     "@babel/core": "^7.20.12"


### PR DESCRIPTION
The new version is needed to be able to use `<hr/>` inside of `select` elements.