### PR TITLE
Warn when `data-hk` attribute is present on a template

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -88,6 +88,28 @@ export function transformElement(path, info) {
       renderer: "dom",
       skipTemplate: false
     };
+
+  path
+    .get("openingElement")
+    .get("attributes")
+    .some(a => {
+      if (a.node.name?.name === "data-hk") {
+        a.remove();
+        let filename = "";
+        try {
+          filename = path.scope.getProgramParent().path.hub.file.opts.filename;
+        } catch (e) {}
+
+        console.log(
+          "\n" +
+            path
+              .buildCodeFrameError(
+                `"data-hk" attribute found in template, which could potentially cause hydration miss-matches. Usually happens when copying and pasting Solid SSRed code into JSX. Please remove the attribute from the JSX. \n\n${filename}\n`
+              )
+              .toString()
+        );
+      }
+    });
   if (config.hydratable && (tagName === "html" || tagName === "head" || tagName === "body")) {
     results.skipTemplate = true;
     if (tagName === "head" && info.topLevel) {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -271,3 +271,4 @@ const template86 = <div style={{"background":"red", "color":"green", "border":si
 const template87 = <div style={{"background":"red", "color":"green", "border":somevalue}}/>
 const template88 = <div style={{"background":"red", "color":"green", "border":some.access}}/>
 const template89 = <div style={{"background":"red", "color":"green", "border":null}}/>
+const template90 = <div data-hk="should warn data-hk is present on template"/>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -583,4 +583,5 @@ const template88 = (() => {
   return _el$105;
 })();
 const template89 = _tmpl$58();
+const template90 = _tmpl$4();
 _$delegateEvents(["click", "input"]);


### PR DESCRIPTION
It happened in the docs website that a snippet from SSRed code was copied and pasted into JSX. The snippet included a `data-hk` attribute which could cause a hydration mismatch. 

It warns instead of crashing, and removes the attribute from the template, but the "Syntax Error" is very visible in the terminal. Reads as follows:

`"data-hk" attribute found in template, which could potentially cause hydration miss-matches. Usually happens when copying and pasting Solid SSRed code into JSX. Please remove the attribute from the JSX. \n\n${filename}\n`

Screenshot:  
<img width="1077" height="529" alt="image" src="https://github.com/user-attachments/assets/b49decc8-36e5-4372-a814-37a332b3334e" />
