### PR TITLE
quote `data-hk` as it causes issues with parsers that don't consider unquoted attributes

### DIFF
--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -418,7 +418,7 @@ export function ssrAttribute(key, value, isBoolean) {
 
 export function ssrHydrationKey() {
   const hk = getHydrationKey();
-  return hk ? ` data-hk=${hk}` : "";
+  return hk ? ` data-hk="${hk}"` : "";
 }
 
 export function escape(s, attr) {

--- a/packages/dom-expressions/test/ssr/hydrate.spec.js
+++ b/packages/dom-expressions/test/ssr/hydrate.spec.js
@@ -18,7 +18,7 @@ describe("r.hydrate", () => {
     rendered = r2.renderToString(() =>
       r2.ssr(["<span", "><!--#-->", "<!--/--> John</span>"], r2.ssrHydrationKey(), r2.escape("Hi"))
     );
-    expect(rendered).toBe(`<span data-hk=0><!--#-->Hi<!--/--> John</span>`);
+    expect(rendered).toBe(`<span data-hk="0"><!--#-->Hi<!--/--> John</span>`);
     // gather refs
     container.innerHTML = rendered;
     const el1 = container.firstChild,
@@ -51,7 +51,7 @@ describe("r.hydrate", () => {
       "middle",
       r2.ssr(["<div", ">Last</div>"], r2.ssrHydrationKey())
     ]);
-    expect(rendered).toBe(`<div data-hk=0>First</div>middle<div data-hk=1>Last</div>`);
+    expect(rendered).toBe(`<div data-hk="0">First</div>middle<div data-hk="1">Last</div>`);
     // gather refs
     container.innerHTML = rendered;
     const el1 = container.firstChild,

--- a/packages/dom-expressions/test/ssr/ssr.spec.js
+++ b/packages/dom-expressions/test/ssr/ssr.spec.js
@@ -8,8 +8,8 @@ globalThis.TextEncoder = function () {
   return { encode: v => v };
 };
 
-const fixture = `<div data-hk=0 id="main" data-id="12" aria-role="button" class="static selected" checked style="color:red" ><h1 custom-attr="1" disabled title="Hello John" style="background-color:red" class="selected"><a href="/">Welcome</a></h1></div>`;
-const fixture2 = `<span data-hk=0 class="Hello John" > Hello &lt;div/> </span>`;
+const fixture = `<div data-hk="0" id="main" data-id="12" aria-role="button" class="static selected" checked style="color:red" ><h1 custom-attr="1" disabled title="Hello John" style="background-color:red" class="selected"><a href="/">Welcome</a></h1></div>`;
+const fixture2 = `<span data-hk="0" class="Hello John" > Hello &lt;div/> </span>`;
 const fixture3 = `<span> Hello &lt;div/><script nonce=\"1a2s3d4f5g\">window._$HY||(e=>{let t=e=>e&&e.hasAttribute&&(e.hasAttribute(\"data-hk\")?e:t(e.host&&e.host.nodeType?e.host:e.parentNode));[\"click\", \"input\"].forEach((o=>document.addEventListener(o,(o=>{if(!e.events)return;let s=t(o.composedPath&&o.composedPath()[0]||o.target);s&&!e.completed.has(s)&&e.events.push([s,o])}))))})(_$HY={events:[],completed:new WeakSet,r:{},fe(){}});</script><!--xs--><link rel=\"modulepreload\" href=\"chunk.js\"></span>`;
 const fixture4 = `<span > Hello &lt;div/> </span>`;
 


### PR DESCRIPTION
We have been debugging an issue with the docs website that isnt prerendering. 

The issue seems to be that the nitro parser ( https://github.com/natemoo-re/ultrahtml )  doesnt undertand unquoted attrributes. 

For whatever reason, all attributes seems to be quoted by default on SSR, except `data-hk` (causing the issue). This PR quotes the attribute.

This PR would close this https://github.com/solidjs/solid-start/issues/1954

Related 
- https://github.com/natemoo-re/ultrahtml/issues/82 