### PR TITLE
Catch stream write errors silently

### DIFF
--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -279,13 +279,13 @@ export function renderToStream(code, options = {}) {
           writable = {
             end() {
               writer.releaseLock();
-              w.close();
+              w.close().catch(() => {});
               resolve();
             }
           };
           buffer = {
             write(payload) {
-              writer.write(encoder.encode(payload));
+              writer.write(encoder.encode(payload)).catch(() => {});
             }
           };
           buffer.write(tmp);


### PR DESCRIPTION
If the WritableStream passed to `pipeTo` gets closed at some point (like if the browser is closed mid-stream), `write()` and `close()` can throw unhandled errors, which can crash NodeJS. This PR just silences those errors, though a more thorough implementation that ends rendering early could also be done.
We'd like to have this merged for Solid Start 2.