### PR TITLE
sld-dom-expressions

### DIFF
--- a/packages/sld-dom-expressions/README.md
+++ b/packages/sld-dom-expressions/README.md
@@ -1,0 +1,98 @@
+# sld
+
+sld is a no-build, no-JSX tagged-template library for SolidJS
+
+## Quick overview
+
+- `sld` - default tagged template instance with the built-in component registry.
+  - `sld.define({CompA})` - creates a new instance from the existing instance and combines registered components
+  - `sld.sld` - self reference so all tags can start with `sld` for potential tooling
+- `SLD({CompA})` - factory function which includes built-in components
+- `createSLD({CompA})` - factory function which doesn't include built-in components
+
+## Basic usage
+
+Use the default `sld` tag for templates and the `SLD` or `sld.define` factory to create a local instance.
+
+```ts
+import { sld } from "@solidjs/sld";
+
+//Write a component with JSX like syntax
+function Counter() {
+  const [count, setCount] = createSignal(0);
+  return sld`<button onClick=${() => setCount((v) => v + 1)}>
+    ${() => count()}
+  </button>`;
+}
+
+//Use component in another template by defining or inlining
+function App() {
+  return sld.define({ Counter }).sld`
+  <Counter />
+  <${Counter} />
+`;
+}
+
+//Render like normal solid-js component
+render(() => App(), document.body);
+```
+
+## Syntax
+
+### Text & Whitespace
+
+- Text in the template gets set via innerHTML so it will decode html encoded characters. You really only need this for < `&lt;` and > `&gt;` and sometimes spaces (&nbsp;)
+- Pure whitepace between elements is ignored in the AST. Leading and Trailing Whitespace is omitted when there is at least one expression in it
+- When in doubt set text via expression to ensure exact match.
+
+### Elements && Component Tags
+
+- Tag names must start with `a-zA-Z$_` and then can have `a-zA-Z0-9$.:-_` characters.
+- Elements/Components can be self closing `<div />` or matched closing `<div></div>`
+- Capital tags are treated as components and will throw if now registered `<ComponentA></ComponentA>` or `<ComponentA />`
+- Content between tags is treated as children. Will return an array unless only a single child node (text,elem, or expression)
+- Inline components can be closed with `</${ComponentA}>` or `<//>`
+
+### Attributes & Properties
+
+- `<input value="Hello World" />` - static string property
+- `<input value='Hello World' />` - static string property
+- `<input disabled />` - static boolean property
+- `<input value=${val} />` - dynamic property
+- `<input onEvent=${} />` — Delgated event listener (Not Reactive)
+- `<input onevent=${} />` - Delegated event (depracated) (Not Reactive)
+- `<input on:event=${} />` - event listener on the element (Not Reactive)
+- `<input prop:value=${} />` — DOM property
+- `<input ...${} />` — spread properties
+- `<input ref=${} />` — ref (Not Reactive)
+- `<div children=${} />` attribute is used only if the element has no child nodes (JSX-like behavior).
+
+## Reactivity and props
+
+- Props that are functions with zero arguments and not `on` events or `ref` are treated as reactive accessors and are auto-wrapped to getters on props (so you can pass `() => value` and the runtime will call it for updates).
+- For properties that accept a function that are not `on` events. You may need to add `()=>` to ensure the function doesn't get wrapped as a getter.
+
+```ts
+import { sld} from "@solidjs/sld";
+
+const [count, setCount] = createSignal(0);
+
+sld`<button count=${() => count()}  />`;
+//or just the signal/memo
+sld`<button count=${count} />`;
+
+//Add ()=> to avoid Counter possibly getting auto-wrapped
+sld`<Route component=${() => Counter} />`;
+
+
+## JSX vs SLD
+
+| Feature              | Solid JSX                                         | `sld` Tagged Template                                      |
+| :------------------- | :------------------------------------------------ | :--------------------------------------------------------- |
+| **Fragments**        | Required: `<>...</>` for multiple root nodes      | **None needed**: Returns a flat array of nodes             |
+| **Dot Notation**     | Supported: `<Input.Label />`                      | `.` is valid in identifier tokens           |
+| **Spread Syntax**    | `<div {...props} />`                              | `<div ...${props} />`                                      |
+| **Comments**         | `{/* JSX Comment */}`                             | `<!-- -->` (Stripped by parser)                            |
+| **Raw Text Tags**    | Escaping or `innerHTML` required                  | `<style>`/`<script>` treat children as text |
+| **Whitespace**       | JSX-style stripping                               | Contextual: Trims between tags, preserves inside text      |
+| **Reactivity**       | Signals are auto-wrapped in JSX                   | Reactive Holes must be wrapped in `()=> `     |

--- a/packages/sld-dom-expressions/package-lock.json
+++ b/packages/sld-dom-expressions/package-lock.json
@@ -1,0 +1,2300 @@
+{
+  "name": "sld-dom-expressions",
+  "version": "0.41.0-next.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sld-dom-expressions",
+      "version": "0.41.0-next.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/browser-playwright": "^4.0.18",
+        "@vitest/browser-preview": "^4.0.18",
+        "dom-expressions": "../../packages/dom-expressions",
+        "tsdown": "^0.20.3",
+        "vitest": "^4.0.18"
+      }
+    },
+    "../dom-expressions": {
+      "version": "0.50.0-next.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-transform-rename-import": "^2.3.0"
+      },
+      "devDependencies": {
+        "babel-plugin-jsx-dom-expressions": "workspace:*",
+        "csstype": "^3.1",
+        "seroval": "~1.5.0",
+        "seroval-plugins": "~1.5.0"
+      },
+      "peerDependencies": {
+        "csstype": "^3.0",
+        "seroval": "~1.5.0",
+        "seroval-plugins": "~1.5.0"
+      }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.1.tgz",
+      "integrity": "sha512-3ypWOOiC4AYHKr8vYRVtWtWmyvcoItHtVqF8paFax+ydpmUdPsJpLBkBBs5ItmhdrwC3a0ZSqqFAdzls4ODP3w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^8.0.0-rc.1",
+        "@babel/types": "^8.0.0-rc.1",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.2.tgz",
+      "integrity": "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.1.tgz",
+      "integrity": "sha512-6HyyU5l1yK/7h9Ki52i5h6mDAx4qJdiLQO4FdCyJNoB/gy3T3GGJdhQzzbZgvgZCugYBvwtQiWRt94QKedHnkA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^8.0.0-rc.1"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.1.tgz",
+      "integrity": "sha512-ubmJ6TShyaD69VE9DQrlXcdkvJbmwWPB8qYj0H2kaJi29O7vJT9ajSdBd2W8CG34pwL9pYA74fi7RHC1qbLoVQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0-rc.1",
+        "@babel/helper-validator-identifier": "^8.0.0-rc.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@babel/types/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.2.tgz",
+      "integrity": "sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.3",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.10.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.112.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.112.0.tgz",
+      "integrity": "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@quansync/fs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
+      "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
+      "dev": true,
+      "dependencies": {
+        "quansync": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.3.tgz",
+      "integrity": "sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.3.tgz",
+      "integrity": "sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.3.tgz",
+      "integrity": "sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.3.tgz",
+      "integrity": "sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.3.tgz",
+      "integrity": "sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.3.tgz",
+      "integrity": "sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.3.tgz",
+      "integrity": "sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.3.tgz",
+      "integrity": "sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.3.tgz",
+      "integrity": "sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.3.tgz",
+      "integrity": "sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.3.tgz",
+      "integrity": "sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.3.tgz",
+      "integrity": "sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.40.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
+    },
+    "node_modules/@vitest/browser": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/mocker": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pixelmatch": "7.1.0",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.0.3",
+        "ws": "^8.18.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.18"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@vitest/browser-preview": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/browser": "4.0.18"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.18"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-kit": {
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0-beta.1.tgz",
+      "integrity": "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^8.0.0-beta.4",
+        "estree-walker": "^3.0.3",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
+      "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-expressions": {
+      "resolved": "../dom-expressions",
+      "link": true
+    },
+    "node_modules/dts-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-2.1.3.tgz",
+      "integrity": "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "oxc-resolver": ">=11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "oxc-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.3",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.3",
+        "@esbuild/android-arm": "0.25.3",
+        "@esbuild/android-arm64": "0.25.3",
+        "@esbuild/android-x64": "0.25.3",
+        "@esbuild/darwin-arm64": "0.25.3",
+        "@esbuild/darwin-x64": "0.25.3",
+        "@esbuild/freebsd-arm64": "0.25.3",
+        "@esbuild/freebsd-x64": "0.25.3",
+        "@esbuild/linux-arm": "0.25.3",
+        "@esbuild/linux-arm64": "0.25.3",
+        "@esbuild/linux-ia32": "0.25.3",
+        "@esbuild/linux-loong64": "0.25.3",
+        "@esbuild/linux-mips64el": "0.25.3",
+        "@esbuild/linux-ppc64": "0.25.3",
+        "@esbuild/linux-riscv64": "0.25.3",
+        "@esbuild/linux-s390x": "0.25.3",
+        "@esbuild/linux-x64": "0.25.3",
+        "@esbuild/netbsd-arm64": "0.25.3",
+        "@esbuild/netbsd-x64": "0.25.3",
+        "@esbuild/openbsd-arm64": "0.25.3",
+        "@esbuild/openbsd-x64": "0.25.3",
+        "@esbuild/sunos-x64": "0.25.3",
+        "@esbuild/win32-arm64": "0.25.3",
+        "@esbuild/win32-ia32": "0.25.3",
+        "@esbuild/win32-x64": "0.25.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.0.1.tgz",
+      "integrity": "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==",
+      "dev": true
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/import-without-cache": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.2.5.tgz",
+      "integrity": "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/jiti": {
+      "version": "2.5.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "dev": true,
+      "license": "CC0-1.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
+      "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ]
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.3.tgz",
+      "integrity": "sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==",
+      "dev": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.112.0",
+        "@rolldown/pluginutils": "1.0.0-rc.3"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.3",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.3",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.3",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.3"
+      }
+    },
+    "node_modules/rolldown-plugin-dts": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.22.1.tgz",
+      "integrity": "sha512-5E0AiM5RSQhU6cjtkDFWH6laW4IrMu0j1Mo8x04Xo1ALHmaRMs9/7zej7P3RrryVHW/DdZAp85MA7Be55p0iUw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "8.0.0-rc.1",
+        "@babel/helper-validator-identifier": "8.0.0-rc.1",
+        "@babel/parser": "8.0.0-rc.1",
+        "@babel/types": "8.0.0-rc.1",
+        "ast-kit": "^3.0.0-beta.1",
+        "birpc": "^4.0.0",
+        "dts-resolver": "^2.1.3",
+        "get-tsconfig": "^4.13.1",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "@ts-macro/tsc": "^0.3.6",
+        "@typescript/native-preview": ">=7.0.0-dev.20250601.1",
+        "rolldown": "^1.0.0-rc.3",
+        "typescript": "^5.0.0",
+        "vue-tsc": "~3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@ts-macro/tsc": {
+          "optional": true
+        },
+        "@typescript/native-preview": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rolldown-plugin-dts/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.1.tgz",
+      "integrity": "sha512-I4YnARytXC2RzkLNVnf5qFNFMzp679qZpmtw/V3Jt2uGnWiIxyJtaukjG7R8pSx8nG2NamICpGfljQsogj+FbQ==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.40.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.7"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.40.1",
+        "@rollup/rollup-android-arm64": "4.40.1",
+        "@rollup/rollup-darwin-arm64": "4.40.1",
+        "@rollup/rollup-darwin-x64": "4.40.1",
+        "@rollup/rollup-freebsd-arm64": "4.40.1",
+        "@rollup/rollup-freebsd-x64": "4.40.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.40.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.40.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.40.1",
+        "@rollup/rollup-linux-arm64-musl": "4.40.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.40.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.40.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.40.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.40.1",
+        "@rollup/rollup-linux-x64-gnu": "4.40.1",
+        "@rollup/rollup-linux-x64-musl": "4.40.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.40.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.40.1",
+        "@rollup/rollup-win32-x64-msvc": "4.40.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tsdown": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.20.3.tgz",
+      "integrity": "sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w==",
+      "dev": true,
+      "dependencies": {
+        "ansis": "^4.2.0",
+        "cac": "^6.7.14",
+        "defu": "^6.1.4",
+        "empathic": "^2.0.0",
+        "hookable": "^6.0.1",
+        "import-without-cache": "^0.2.5",
+        "obug": "^2.1.1",
+        "picomatch": "^4.0.3",
+        "rolldown": "1.0.0-rc.3",
+        "rolldown-plugin-dts": "^0.22.1",
+        "semver": "^7.7.3",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tree-kill": "^1.2.2",
+        "unconfig-core": "^7.4.2",
+        "unrun": "^0.2.27"
+      },
+      "bin": {
+        "tsdown": "dist/run.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "@arethetypeswrong/core": "^0.18.1",
+        "@vitejs/devtools": "*",
+        "publint": "^0.3.0",
+        "typescript": "^5.0.0",
+        "unplugin-lightningcss": "^0.4.0",
+        "unplugin-unused": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@arethetypeswrong/core": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "publint": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "unplugin-lightningcss": {
+          "optional": true
+        },
+        "unplugin-unused": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/unconfig-core": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
+      "integrity": "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==",
+      "dev": true,
+      "dependencies": {
+        "@quansync/fs": "^1.0.0",
+        "quansync": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/unrun": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.27.tgz",
+      "integrity": "sha512-Mmur1UJpIbfxasLOhPRvox/QS4xBiDii71hMP7smfRthGcwFL2OAmYRgduLANOAU4LUkvVamuP+02U+c90jlrw==",
+      "dev": true,
+      "dependencies": {
+        "rolldown": "1.0.0-rc.3"
+      },
+      "bin": {
+        "unrun": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Gugustinette"
+      },
+      "peerDependencies": {
+        "synckit": "^0.11.11"
+      },
+      "peerDependenciesMeta": {
+        "synckit": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    }
+  }
+}

--- a/packages/sld-dom-expressions/package.json
+++ b/packages/sld-dom-expressions/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "sld-dom-expressions",
+  "description": "A Fine-Grained Rendering Runtime API using Tagged Template Literals",
+  "version": "0.50.0-next.2",
+  "author": "Daniel Kling",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryansolid/dom-expressions/blob/main/packages/sld-dom-expressions"
+  },
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.mts",
+  "typings": "dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format esm --minify",
+    "test": "vitest",
+    "prepare": "npm run build"
+  },
+  "devDependencies": {
+    "@vitest/browser-playwright": "^4.0.18",
+    "@vitest/browser-preview": "^4.0.18",
+    "dom-expressions": "../../packages/dom-expressions",
+    "vitest": "^4.0.18",
+    "tsdown": "^0.20.3"
+  }
+}

--- a/packages/sld-dom-expressions/src/index.ts
+++ b/packages/sld-dom-expressions/src/index.ts
@@ -1,0 +1,5 @@
+import { createSLDRuntime } from "./sld";
+import { type SLDInstance } from "./types";
+
+export { createSLDRuntime, SLDInstance };
+

--- a/packages/sld-dom-expressions/src/parse.ts
+++ b/packages/sld-dom-expressions/src/parse.ts
@@ -1,0 +1,252 @@
+import {
+  STRING_TOKEN,
+  CLOSE_TAG_TOKEN,
+  EQUALS_TOKEN,
+  EXPRESSION_TOKEN,
+  IDENTIFIER_TOKEN,
+  OPEN_TAG_TOKEN,
+  SLASH_TOKEN,
+  SPREAD_TOKEN,
+  TEXT_TOKEN,
+  Token
+} from "./tokenize";
+
+const isComponentNode = (name: string): boolean => {
+  const char = name.charCodeAt(0);
+  return (
+    char >= 65 && char <= 90 // Uppercase A-Z
+  );
+};
+
+// Node type constants
+export const ROOT_NODE = 0;
+export const ELEMENT_NODE = 1;
+export const COMPONENT_NODE = 2;
+export const TEXT_NODE = 3;
+export const EXPRESSION_NODE = 4;
+
+// Prop type constants
+export const BOOLEAN_PROP = 0;
+export const STATIC_PROP = 1;
+export const EXPRESSION_PROP = 2;
+export const SPREAD_PROP = 3;
+
+export type NodeType =
+  | typeof ROOT_NODE
+  | typeof ELEMENT_NODE
+  | typeof COMPONENT_NODE
+  | typeof TEXT_NODE
+  | typeof EXPRESSION_NODE;
+export type PropType =
+  | typeof BOOLEAN_PROP
+  | typeof STATIC_PROP
+  | typeof EXPRESSION_PROP
+  | typeof SPREAD_PROP;
+
+export type ChildNode = ElementNode | TextNode | ExpressionNode | ComponentNode;
+
+export interface RootNode {
+  type: typeof ROOT_NODE;
+  children: ChildNode[];
+  template?: HTMLTemplateElement;
+}
+
+export interface ElementNode {
+  type: typeof ELEMENT_NODE;
+  name: string;
+  props: PropNode[];
+  children: ChildNode[];
+}
+
+export interface ComponentNode {
+  type: typeof COMPONENT_NODE;
+  name: string | number;
+  props: PropNode[];
+  children: ChildNode[];
+  template?: HTMLTemplateElement;
+}
+
+export interface TextNode {
+  type: typeof TEXT_NODE;
+  value: string;
+}
+
+export interface ExpressionNode {
+  type: typeof EXPRESSION_NODE;
+  value: number;
+}
+
+export interface BooleanProp {
+  name: string;
+  type: typeof BOOLEAN_PROP;
+  value: boolean;
+}
+
+export interface StringProp {
+  name: string;
+  type: typeof STATIC_PROP;
+  value: string;
+  quote?: "'" | '"';
+}
+
+export interface ExpressionProp {
+  name: string;
+  type: typeof EXPRESSION_PROP;
+  value: number;
+}
+
+export interface SpreadProp {
+  type: typeof SPREAD_PROP;
+  value: number;
+}
+
+export type PropNode = BooleanProp | StringProp | ExpressionProp | SpreadProp;
+
+export const parse = (tokens: Token[], voidElements: Set<string>): RootNode => {
+  const root: RootNode = { type: ROOT_NODE, children: [] };
+  const stack: (RootNode | ElementNode | ComponentNode)[] = [root];
+  let pos = 0;
+  const len = tokens.length;
+
+  while (pos < len) {
+    const token = tokens[pos];
+    const parent = stack[stack.length - 1];
+
+    switch (token.type) {
+      case TEXT_TOKEN: {
+        // --- TEXT ---
+        const value = token.value;
+        if (value.trim() === "") {
+          const prevType = tokens[pos - 1]?.type;
+          const nextType = tokens[pos + 1]?.type;
+          // Filter out empty text nodes between tags
+          if (prevType === CLOSE_TAG_TOKEN || nextType === OPEN_TAG_TOKEN) {
+            pos++;
+            continue;
+          }
+        }
+        parent.children.push({ type: TEXT_NODE, value });
+        pos++;
+        continue;
+      }
+
+      case EXPRESSION_TOKEN: {
+        // --- EXPRESSION ---
+        parent.children.push({ type: EXPRESSION_NODE, value: token.value });
+        pos++;
+        continue;
+      }
+
+      case OPEN_TAG_TOKEN: {
+        // --- TAG ---
+        const nextToken = tokens[++pos];
+
+        // Handle Closing Tag: </name>
+        if (nextToken.type === SLASH_TOKEN) {
+          const nameToken = tokens[++pos];
+          const closeToken = tokens[++pos];
+          const currentParent = stack[stack.length - 1] as ElementNode | ComponentNode;
+          if (
+            stack.length > 1 &&
+            closeToken.type === CLOSE_TAG_TOKEN &&
+            ((nameToken?.type === IDENTIFIER_TOKEN && currentParent.name === nameToken.value) ||
+              ((nameToken?.type === EXPRESSION_TOKEN || nameToken.type === SLASH_TOKEN) &&
+                typeof currentParent.name === "number"))
+          ) {
+            const node = stack.pop();
+            if (node?.type === ELEMENT_NODE && voidElements.has(node.name)) {
+              node.children = [];
+            }
+            pos++;
+            continue;
+          }
+          throw new Error("Mismatched closing tag.");
+        }
+
+        // Handle Opening Tag: <name ...>
+        if (nextToken.type === IDENTIFIER_TOKEN || nextToken.type === EXPRESSION_TOKEN) {
+          const tagName = nextToken.value;
+          const node: ElementNode | ComponentNode = {
+            type:
+              typeof tagName === "number" || isComponentNode(tagName)
+                ? COMPONENT_NODE
+                : ELEMENT_NODE,
+            name: tagName,
+            props: [],
+            children: []
+          } as ElementNode | ComponentNode;
+          parent.children.push(node);
+          pos++; // Consume tag name
+
+          // --- Attribute Parsing Loop ---
+          while (pos < len) {
+            const attrToken = tokens[pos];
+            if (attrToken.type === CLOSE_TAG_TOKEN || attrToken.type === SLASH_TOKEN) {
+              break; // End of attributes
+            }
+
+            if (attrToken.type === SPREAD_TOKEN) {
+              const expr = tokens[pos + 1];
+              if (expr?.type === EXPRESSION_TOKEN) {
+                node.props.push({ type: SPREAD_PROP, value: expr.value });
+                pos += 2; // Consume '...' and expression
+              } else {
+                throw new Error("Spread operator must be followed by an expression.");
+              }
+            } else if (attrToken.type === IDENTIFIER_TOKEN) {
+              const name = attrToken.value;
+              const next = tokens[pos + 1];
+
+              if (next?.type === EQUALS_TOKEN) {
+                pos += 2; // Consume name and '='
+                const valToken = tokens[pos];
+                if (valToken.type === EXPRESSION_TOKEN) {
+                  node.props.push({ name, type: EXPRESSION_PROP, value: valToken.value });
+                  pos++;
+                } else if (valToken.type === STRING_TOKEN) {
+                  const quote = valToken.quote;
+                  node.props.push({
+                    name,
+                    value: valToken.value,
+                    quote,
+                    type: STATIC_PROP
+                  } as StringProp);
+                  pos++;
+                } else {
+                  throw new Error("Attribute value must be an expression or a string.");
+                }
+              } else {
+                // Boolean prop
+                node.props.push({ type: BOOLEAN_PROP, name, value: true });
+                pos++;
+              }
+            } else {
+              throw new Error("Invalid attribute.");
+            }
+          }
+
+          // --- Tag Closing Logic ---
+          const endToken = tokens[pos];
+          if (endToken.type === SLASH_TOKEN) {
+            // Self-closing: <div/>
+            pos += 2; // Consume '/' and '>'
+          } else if (endToken.type === CLOSE_TAG_TOKEN) {
+            // Opening: <div>
+            pos++; // Consume '>'
+            stack.push(node);
+          }
+          continue;
+        }
+      }
+
+      default:
+        throw new Error(`Unexpected token: ${JSON.stringify(token)}`);
+    }
+  }
+
+  if (stack.length > 1) {
+    throw new Error("Unclosed tag found.");
+  }
+
+  return root;
+};

--- a/packages/sld-dom-expressions/src/sld.ts
+++ b/packages/sld-dom-expressions/src/sld.ts
@@ -1,0 +1,239 @@
+import {
+  BOOLEAN_PROP,
+  COMPONENT_NODE,
+  ChildNode,
+  ComponentNode,
+  ELEMENT_NODE,
+  EXPRESSION_NODE,
+  EXPRESSION_PROP,
+  ElementNode,
+  ROOT_NODE,
+  RootNode,
+  SPREAD_PROP,
+  STATIC_PROP,
+  TEXT_NODE,
+  parse
+} from "./parse";
+import { tokenize } from "./tokenize";
+import { ComponentRegistry, SLDInstance, Runtime } from "./types";
+import { type JSX } from "../../dom-expressions/src/jsx";
+
+const flat = (arr: any[]) => {
+  return arr.length === 1 ? arr[0] : arr;
+};
+
+
+export function createSLDRuntime(r: Runtime) {
+  const cache = new WeakMap<TemplateStringsArray, RootNode>();
+
+  //Walk over text, comment, and element nodes
+  const walker = document.createTreeWalker(document, 129);
+
+  const createElement = (name: string) => {
+    return r.SVGElements.has(name)
+      ? document.createElementNS("http://www.w3.org/2000/svg", name)
+      : r.MathMLElements.has(name)
+      ? document.createElementNS("http://www.w3.org/1998/Math/MathML", name)
+      : document.createElement(name);
+  };
+
+  //Factory function to create new SLD instances.
+  const createSLD = <T extends ComponentRegistry>(components: T): SLDInstance<T> => {
+    const sld = (strings: TemplateStringsArray, ...values: any[]) => {
+      const root = getCachedRoot(strings);
+
+      return renderChildren(root, values, components);
+    };
+    sld.components = components;
+    sld.sld = sld;
+    sld.define = <TNew extends ComponentRegistry>(newComponents: TNew) => {
+      return createSLD({ ...components, ...newComponents });
+    };
+
+    return sld as SLDInstance<T>;
+  };
+
+  const getCachedRoot = (strings: TemplateStringsArray): RootNode => {
+    let root = cache.get(strings);
+    if (!root) {
+      root = parse(tokenize(strings, r.RawTextElements), r.VoidElements);
+      buildTemplate(root);
+      cache.set(strings, root);
+    }
+    return root;
+  };
+
+  //build template element with same exact shape as tree so they can be walked through in sync
+  const buildTemplate = (node: RootNode | ChildNode): void => {
+    if (node.type === ROOT_NODE || node.type === COMPONENT_NODE) {
+      //Criteria for using template is component or root has at least 1 element. May be be a more optimal condition.
+      if (node.children.some(v => v.type === ELEMENT_NODE)) {
+        const template = document.createElement("template");
+        template.content.append(...node.children.map(buildNodes));
+        // buildNodes(node.children, template.content);
+        // template.innerHTML = node.children.map(buildHTML).join("");
+        node.template = template;
+      }
+      node.children.forEach(buildTemplate);
+    } else if (node.type === ELEMENT_NODE) {
+      node.children.forEach(buildTemplate);
+    }
+  };
+
+  const textTemplate = document.createElement("template");
+
+  const buildNodes = (node: ChildNode): Node => {
+    switch (node.type) {
+      case TEXT_NODE:
+        textTemplate.innerHTML = node.value;
+        return document.createTextNode(textTemplate.content.textContent ?? "");
+      case EXPRESSION_NODE:
+        return document.createComment("+");
+      case COMPONENT_NODE:
+        return document.createComment(node.name as string);
+      case ELEMENT_NODE:
+        let hasSpread = false;
+
+        const elem = createElement(node.name);
+        //props located after spread need to be applied after spread for possible overrides
+        node.props = node.props.filter(prop => {
+          if (prop.type === STATIC_PROP) {
+            if (prop.name.startsWith("prop:")) return true;
+            elem.setAttribute(prop.name, prop.value);
+            return hasSpread;
+          } else if (prop.type === BOOLEAN_PROP) {
+            // attributeHTML += ` ${prop.name}`;
+            elem.setAttribute(prop.name, "");
+            return hasSpread;
+          } else if (prop.type === SPREAD_PROP) {
+            hasSpread = true;
+            return hasSpread;
+          }
+          return true;
+        });
+        elem.append(...node.children.map(buildNodes));
+
+        return elem;
+    }
+  };
+
+  const renderNode = (node: ChildNode, values: any[], components: ComponentRegistry): any => {
+    switch (node.type) {
+      case TEXT_NODE:
+        return node.value;
+      case EXPRESSION_NODE:
+        return values[node.value];
+      case COMPONENT_NODE:
+        const component = typeof node.name === "string" ? components[node.name] : values[node.name];
+        if (component && typeof component === "function") {
+          return r.createComponent(component, gatherProps(node, values, components));
+        } else {
+          throw new Error(`Component "${node.name}" not found in registry`);
+        }
+      case ELEMENT_NODE:
+        let name = node.name;
+
+        // 3. Standard HTML Element (node.name is guaranteed string here)
+        const element = createElement(name);
+        const props = gatherProps(node, values, components);
+
+        r.spread(element, props, true);
+
+        return element;
+    }
+  };
+
+  const renderChildren = (
+    node: RootNode | ComponentNode,
+    values: any[],
+    components: ComponentRegistry
+  ): JSX.Element => {
+    if (!node.template) {
+      return flat(node.children.map(n => renderNode(n, values, components)));
+    }
+
+    const clone = node.template.content.cloneNode(true);
+    walker.currentNode = clone;
+
+    const walkNodes = (nodes: ChildNode[]) => {
+      for (const node of nodes) {
+        if (
+          node.type === ELEMENT_NODE ||
+          node.type === EXPRESSION_NODE ||
+          node.type === COMPONENT_NODE
+        ) {
+          const domNode = walker.nextNode()!;
+          if (node.type === EXPRESSION_NODE || node.type === COMPONENT_NODE) {
+            r.insert(domNode.parentNode!, renderNode(node, values, components), domNode);
+            walker.currentNode = domNode;
+          } else {
+            // Standard Element path...
+            if (node.props.length) {
+              const props = gatherProps(node, values, components);
+              r.spread(domNode as Element, props, true);
+            }
+            walkNodes(node.children);
+          }
+        }
+      }
+    };
+    walkNodes(node.children);
+    return Array.from(clone.childNodes);
+  };
+
+  const gatherProps = (
+    node: ElementNode | ComponentNode,
+    values: any[],
+    components: ComponentRegistry,
+    props: Record<string, any> = {}
+  ) => {
+    for (const prop of node.props) {
+      switch (prop.type) {
+        case BOOLEAN_PROP:
+          props[prop.name] = true;
+          break;
+        case STATIC_PROP:
+          props[prop.name] = prop.value;
+          break;
+        case EXPRESSION_PROP:
+          applyGetter(props, prop.name, values[prop.value]);
+          break;
+        case SPREAD_PROP:
+          const spread = values[prop.value];
+          if (!spread || typeof spread !== "object") throw new Error("Can only spread objects");
+          props = r.mergeProps(props, spread);
+          break;
+      }
+    }
+
+    // children - childNodes overwrites any props.children
+    if (node.type === COMPONENT_NODE && node.children.length) {
+      Object.defineProperty(props, "children", {
+        get() {
+          return renderChildren(node, values, components);
+        }
+      });
+    }
+    return props;
+  };
+
+  const applyGetter = (props: Record<string, any>, name: string, value: any) => {
+    if (
+      typeof value === "function" &&
+      value.length === 0 &&
+      name !== "ref" &&
+      !name.startsWith("on")
+    ) {
+      Object.defineProperty(props, name, {
+        get() {
+          return value();
+        },
+        enumerable: true
+      });
+    } else {
+      props[name] = value;
+    }
+  };
+
+  return createSLD;
+}

--- a/packages/sld-dom-expressions/src/tokenize.ts
+++ b/packages/sld-dom-expressions/src/tokenize.ts
@@ -1,0 +1,243 @@
+export const OPEN_TAG_TOKEN = 0;
+export const CLOSE_TAG_TOKEN = 1;
+export const SLASH_TOKEN = 2;
+export const IDENTIFIER_TOKEN = 3;
+export const EQUALS_TOKEN = 4;
+export const STRING_TOKEN = 5;
+export const TEXT_TOKEN = 6;
+export const EXPRESSION_TOKEN = 7;
+export const SPREAD_TOKEN = 8;
+
+const isIdentifierChar = (code: number): boolean => {
+  return (
+    isIdentifierStart(code) ||
+    (code >= 48 && code <= 58) || // 0-9, :
+    code === 46 || // .
+    code === 45 // -
+  );
+};
+
+const isIdentifierStart = (code: number): boolean => {
+  return (
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 97 && code <= 122) || // a-z
+    code === 95 || // _
+    code === 36 // $
+  );
+};
+
+const isWhitespace = (code: number): boolean => {
+  return (code >= 9 && code <= 13) || code === 32; // \t \n \v \f \r space
+};
+
+export interface OpenTagToken {
+  type: typeof OPEN_TAG_TOKEN;
+  // value: "<";
+}
+
+export interface CloseTagToken {
+  type: typeof CLOSE_TAG_TOKEN;
+  // value: ">";
+}
+
+export interface SlashToken {
+  type: typeof SLASH_TOKEN;
+  // value: "/";
+}
+
+export interface IdentifierToken {
+  type: typeof IDENTIFIER_TOKEN;
+  value: string;
+}
+
+export interface EqualsToken {
+  type: typeof EQUALS_TOKEN;
+  // value: "=";
+}
+
+export interface StringToken {
+  type: typeof STRING_TOKEN;
+  value: string;
+  quote: "'" | '"';
+}
+
+export interface TextToken {
+  type: typeof TEXT_TOKEN;
+  value: string;
+}
+
+export interface SpreadToken {
+  type: typeof SPREAD_TOKEN;
+  // value: "..."
+}
+
+export interface ExpressionToken {
+  type: typeof EXPRESSION_TOKEN;
+  value: number;
+}
+
+export type Token =
+  | OpenTagToken
+  | CloseTagToken
+  | SlashToken
+  | IdentifierToken
+  | EqualsToken
+  | StringToken
+  | TextToken
+  | ExpressionToken
+  // | QuoteToken
+  | SpreadToken;
+
+// Add a new state for elements that contain raw text only
+const STATE_TEXT = 0;
+const STATE_TAG = 1;
+const STATE_RAW_TEXT = 2;
+const STATE_COMMENT = 3;
+
+export const tokenize = (
+  strings: TemplateStringsArray | string[],
+  rawTextElements: Set<string>
+): Token[] => {
+  const tokens: Token[] = [];
+  let state = STATE_TEXT;
+  let lastTagName = "";
+  let cursor = 0;
+
+  for (let i = 0; i < strings.length; i++) {
+    const str = strings[i];
+    const len = str.length;
+    cursor = 0;
+
+    while (cursor < len) {
+      switch (state) {
+        case STATE_TEXT: {
+          lastTagName = "";
+          const nextTag = str.indexOf("<", cursor);
+          if (nextTag === -1) {
+            if (cursor < len) tokens.push({ type: TEXT_TOKEN, value: str.slice(cursor) });
+            cursor = len;
+          } else {
+            if (nextTag > cursor)
+              tokens.push({
+                type: TEXT_TOKEN,
+                value: str.slice(cursor, nextTag)
+              });
+
+            if (str[nextTag + 1] === "!" && str[nextTag + 2] === "-" && str[nextTag + 3] === "-") {
+              state = STATE_COMMENT;
+              cursor = nextTag + 4;
+            } else {
+              tokens.push({ type: OPEN_TAG_TOKEN });
+              state = STATE_TAG;
+              cursor = nextTag + 1;
+            }
+          }
+          break;
+        }
+        case STATE_TAG: {
+          const code = str.charCodeAt(cursor);
+
+          if (isWhitespace(code)) {
+            cursor++;
+          } else if (code === 62) {
+            // ">"
+            if (
+              rawTextElements.has(lastTagName) &&
+              tokens[tokens.length - 1]?.type !== SLASH_TOKEN
+            ) {
+              state = STATE_RAW_TEXT;
+            } else {
+              state = STATE_TEXT;
+              lastTagName = "";
+            }
+            tokens.push({ type: CLOSE_TAG_TOKEN });
+
+            cursor++;
+          } else if (code === 61) {
+            // "="
+            tokens.push({ type: EQUALS_TOKEN });
+            cursor++;
+          } else if (code === 47) {
+            // "/"
+            tokens.push({ type: SLASH_TOKEN });
+            cursor++;
+          } else if (code === 34 || code === 39) {
+            const char = str[cursor] as "'" | '"';
+            const endQuoteIndex = str.indexOf(char, cursor + 1);
+
+            if (endQuoteIndex === -1) {
+              throw new Error(`Unterminated string`);
+            }
+            tokens.push({
+              type: STRING_TOKEN,
+              value: str.slice(cursor + 1, endQuoteIndex),
+              quote: char
+            });
+            cursor = endQuoteIndex + 1;
+          } else if (isIdentifierStart(code)) {
+            const start = cursor;
+            while (cursor < len && isIdentifierChar(str.charCodeAt(cursor))) cursor++;
+            const value = str.slice(start, cursor);
+            if (lastTagName === "") {
+              lastTagName = value;
+            }
+            tokens.push({ type: IDENTIFIER_TOKEN, value });
+          } else if (code === 46 && str[cursor + 1] === "." && str[cursor + 2] === ".") {
+            // "."
+            tokens.push({ type: SPREAD_TOKEN });
+            cursor += 3;
+          } else {
+            throw new Error(`Unexpected Character: ${str[cursor]}`);
+          }
+          break;
+        }
+        case STATE_RAW_TEXT: {
+          // Case-sensitive search for the specific closing tag with optional whitespace in between, e.g. < / textarea >
+          const closeTagRegex = new RegExp(`<\\s*/\\s*${lastTagName}\\s*>`, "g");
+          closeTagRegex.lastIndex = cursor;
+          const match = closeTagRegex.exec(str);
+
+          if (match) {
+            const endOfRawIdx = match.index;
+            if (endOfRawIdx > cursor) {
+              tokens.push({
+                type: TEXT_TOKEN,
+                value: str.slice(cursor, endOfRawIdx)
+              });
+            }
+            state = STATE_TEXT;
+            cursor = endOfRawIdx;
+            lastTagName = "";
+          } else {
+            tokens.push({ type: TEXT_TOKEN, value: str.slice(cursor) });
+            cursor = len;
+          }
+          break;
+        }
+        case STATE_COMMENT: {
+          // LOOK FOR END OF COMMENT: - - >
+          const endComment = str.indexOf("-->", cursor);
+
+          if (endComment === -1) {
+            // If we don't find the closer in this string chunk,
+            // we consume the rest of the string and stay in STATE_COMMENT
+            cursor = len;
+          } else {
+            // Found it! Return to normal text parsing
+            state = STATE_TEXT;
+            cursor = endComment + 3;
+          }
+          break;
+        }
+      }
+    }
+
+    if (i < strings.length - 1) {
+      if (state !== STATE_COMMENT) {
+        tokens.push({ type: EXPRESSION_TOKEN, value: i });
+      }
+    }
+  }
+
+  return tokens;
+};

--- a/packages/sld-dom-expressions/src/types.ts
+++ b/packages/sld-dom-expressions/src/types.ts
@@ -1,0 +1,84 @@
+// import {type JSX} from "../../dom-expressions/src/jsx"
+
+export type MaybeFunction<T> = T | (() => T);
+export type MaybeFunctionProps<T> = {
+  [K in keyof T]: K extends `on${string}` | "ref" ? T[K] : MaybeFunction<T[K]>;
+};
+// export type IntrinsicElementsMaybeFunction = {
+//   [K in keyof JSX.IntrinsicElements]: MaybeFunctionProps<JSX.IntrinsicElements[K]>;
+// };
+
+export type FunctionComponent = (...args: any[]) => any;
+/**
+ * Component registry type
+ * @example
+ * ```tsx
+ * const components: ComponentRegistry = {
+ *   MyComponent: (props) => <div>Hello {props.name}</div>
+ * }
+ * ```
+ */
+export type ComponentRegistry = Record<string, FunctionComponent>;
+
+/**
+ * SLD Instance type
+ * @template T Component registry
+ */
+export type SLDInstance<T extends ComponentRegistry> = {
+  /**
+   * SLD template function
+   * @example
+   * ```tsx
+   * const myTemplate = sld`<div>Hello World</div>`
+   * ```
+   */
+  (strings: TemplateStringsArray, ...values: any[]): Array<Node | string | number | boolean | null | undefined>;
+
+  /**
+   * Self reference to SLD instance for tooling
+   * @example
+   * ```tsx
+   * const MyComponent: FunctionComponent = (props) => {
+   *   // Use sld to create a template inside a component
+   *   return mySLD.sld`<div>Hello ${props.name}</div>`
+   * ```
+   */
+  sld: SLDInstance<T>;
+
+  /**
+   * Create a new SLD instance with additional components added to the registry
+   * @param components New components to add to the registry
+   * @example
+   * ```tsx
+   * const MyComponent: FunctionComponent = (props) => <div>Hello {props.name}</div>
+   * const mySLD = sld.define({MyComponent})
+   * const myTemplate = mySLD`<MyComponent name="World" />`
+   * ```
+   */
+  define<TNew extends ComponentRegistry>(components: TNew): SLDInstance<T & TNew>;
+
+  /**
+   * Component registry
+   */
+  components: T;
+
+  /**
+   * For types for tools only. Not used at runtime.
+   */
+  // elements: JSX.IntrinsicElements;
+};
+
+type MountableElement = Element | Document | ShadowRoot | DocumentFragment | Node;
+type ClassList =
+| Record<string, boolean>
+| Array<string | number | boolean | null | undefined | Record<string, boolean>>;
+export interface Runtime {
+  insert(parent: MountableElement, accessor: any, marker?: Node | null, init?: any): any;
+  spread<T>(node: Element, accessor: (() => T) | T, skipChildren?: Boolean): void;
+  createComponent(Comp: (props: any) => any, props: any): any;
+  mergeProps(...sources: unknown[]): any;
+  SVGElements: Set<string>;
+  VoidElements: Set<string>;
+  RawTextElements: Set<string>;
+  MathMLElements:Set<string>
+}

--- a/packages/sld-dom-expressions/tests/core.ts
+++ b/packages/sld-dom-expressions/tests/core.ts
@@ -1,0 +1,50 @@
+import { untrack } from "@solidjs/signals";
+
+export const sharedConfig = {};
+
+export function createComponent(Comp: any, props: any) {
+  if (Comp.prototype && Comp.prototype.isClassComponent) {
+    return untrack(() => {
+      const comp = new Comp(props);
+      return comp.render(props);
+    });
+  }
+  return untrack(() => Comp(props));
+}
+
+export {
+  createRoot as root,
+  createRenderEffect as effect,
+  createMemo as memo,
+  getOwner,
+  untrack,
+  merge as mergeProps,
+  flatten,
+  flush
+} from "@solidjs/signals";
+
+export const RawTextElements = new Set([
+  "style",
+  "script",
+  "noscript",
+  "template",
+  "textarea",
+  "title",
+]);
+
+export const VoidElements = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);

--- a/packages/sld-dom-expressions/tests/parse.test.ts
+++ b/packages/sld-dom-expressions/tests/parse.test.ts
@@ -1,0 +1,996 @@
+import { describe, it, expect } from "vitest";
+import {
+  BOOLEAN_PROP,
+  COMPONENT_NODE,
+  ELEMENT_NODE,
+  EXPRESSION_NODE,
+  ROOT_NODE,
+  STATIC_PROP,
+  TEXT_NODE,
+  EXPRESSION_PROP,
+  SPREAD_PROP,
+  parse,
+} from "../src/parse";
+import { MathMLElements} from "../../dom-expressions/src/constants";
+import { tokenize } from "../src/tokenize";
+import { RawTextElements, VoidElements } from "./core";
+
+function jsx(strings: TemplateStringsArray, ...values: any[]) {
+  return parse(tokenize(strings, RawTextElements), VoidElements);
+}
+
+describe("Simple AST", () => {
+  it("simple text", () => {
+    const ast = jsx`Hello World!`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [{ type: TEXT_NODE, value: "Hello World!" }],
+    });
+  });
+
+  it("simple element", () => {
+    const ast = jsx`<div></div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [{ type: ELEMENT_NODE, name: "div", props: [], children: [] }],
+    });
+  });
+
+  it("text content", () => {
+    const ast = jsx`<div>Hello</div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [{ type: TEXT_NODE, value: "Hello" }],
+        },
+      ],
+    });
+  });
+
+  it("expression inside text", () => {
+    const name = "World";
+    const ast = jsx`<div>Hello ${name}</div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [
+            { type: TEXT_NODE, value: "Hello " },
+            { type: EXPRESSION_NODE, value: 0 },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("self-closing", () => {
+    const ast = jsx`<input />`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [{ type: ELEMENT_NODE, name: "input", props: [], children: [] }],
+    });
+  });
+
+  it("nested elements", () => {
+    const ast = jsx`
+      <div>
+        <span>text</span>
+      </div>
+    `;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [
+            {
+              type: ELEMENT_NODE,
+              name: "span",
+              props: [],
+              children: [{ type: TEXT_NODE, value: "text" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("Attributes", () => {
+  it("string attribute", () => {
+    const ast = jsx`<div id="app"></div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [{ name: "id", type: STATIC_PROP, value: "app", quote: '"' }],
+          children: [],
+        },
+      ],
+    });
+  });
+
+  it("string attribute single quoted", () => {
+    const ast = jsx`<div id='app'></div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [{ name: "id", type: STATIC_PROP, value: "app", quote: "'" }],
+          children: [],
+        },
+      ],
+    });
+  });
+
+  it("boolean attribute", () => {
+    const ast = jsx`<input checked />`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+
+          name: "input",
+          props: [{ name: "checked", type: BOOLEAN_PROP, value: true }],
+          children: [],
+        },
+      ],
+    });
+  });
+
+  it("boolean attribute", () => {
+    const ast = jsx`<button checked></button>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+
+          name: "button",
+          props: [{ name: "checked", type: BOOLEAN_PROP, value: true }],
+          children: [],
+        },
+      ],
+    });
+  });
+
+  it("expression attribute", () => {
+    const id = "my-id";
+    const ast = jsx`<div id=${id}></div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+
+          name: "div",
+          props: [{ name: "id", type: EXPRESSION_PROP, value: 0 }],
+          children: [],
+        },
+      ],
+    });
+  });
+
+
+
+  it("multiple attributes", () => {
+    const value = "test";
+    const ast = jsx`<input type="text" value=${value} disabled />`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "input",
+          props: [
+            { name: "type", type: STATIC_PROP, value: "text", quote: '"' },
+            { name: "value", type: EXPRESSION_PROP, value: 0 },
+            { name: "disabled", type: BOOLEAN_PROP, value: true },
+          ],
+          children: [],
+        },
+      ],
+    });
+  });
+
+  it("spread attribute with ...", () => {
+    const id = "my-id";
+    const ast = jsx`<div ...${id}></div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [{ type: SPREAD_PROP, value: 0 }],
+          children: [],
+        },
+      ],
+    });
+  });
+});
+
+describe("whitespace handling", () => {
+  it("preserves whitespace in text nodes in root", () => {
+    const ast = jsx`  Hello <div>   Hello   World   </div> !   `;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        { type: TEXT_NODE, value: "  Hello " },
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [{ type: TEXT_NODE, value: "   Hello   World   " }],
+        },
+        { type: TEXT_NODE, value: " !   " },
+      ],
+    });
+  });
+
+  it("trims leading and trailing whitespace-only text nodes at root", () => {
+    const ast = jsx`
+    <div>Hello World</div>
+    `;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [{ type: TEXT_NODE, value: "Hello World" }],
+        },
+      ],
+    });
+  });
+
+  it("preserves whitespace in text nodes", () => {
+    const ast = jsx`<div>   Hello   World   </div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [{ type: TEXT_NODE, value: "   Hello   World   " }],
+        },
+      ],
+    });
+  });
+  it("preserves whitespace in text nodes with elements", () => {
+    const ast = jsx`<div>
+       Hello World
+       <span>!</span> 
+       </div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [
+            {
+              type: TEXT_NODE,
+              value: `
+       Hello World
+       `,
+            },
+            {
+              type: ELEMENT_NODE,
+              name: "span",
+              props: [],
+              children: [{ type: TEXT_NODE, value: "!" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("preserves whitespace in mixed text nodes", () => {
+    const name = "User";
+    const ast = jsx`<div>  Hello ${name}  !  </div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [
+            { type: TEXT_NODE, value: "  Hello " },
+            { type: EXPRESSION_NODE, value: 0 },
+            { type: TEXT_NODE, value: "  !  " },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("trims whitespace-only text nodes around expressions", () => {
+    const name = "User";
+    const ast = jsx`<div>
+      ${name}
+    </div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [{ type: EXPRESSION_NODE, value: 0 }],
+        },
+      ],
+    });
+  });
+
+  it("trims whitespace-only text nodes around expressions", () => {
+    const name = "User";
+    const ast = jsx`   ${name}   `;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: TEXT_NODE,
+          value: "   ",
+        },
+        {
+          type: EXPRESSION_NODE,
+          value: 0,
+        },
+        {
+          type: TEXT_NODE,
+          value: "   ",
+        },
+      ],
+    });
+  });
+
+  it("filters only beginning and trailing whitespace in mixed text nodes", () => {
+    const name = "User";
+    const ast = jsx`<div>  ${"Hello"}  ${name}  !  </div>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [
+            { type: EXPRESSION_NODE, value: 0 },
+            { type: TEXT_NODE, value: "  " },
+            { type: EXPRESSION_NODE, value: 1 },
+            { type: TEXT_NODE, value: "  !  " },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("Complex Examples", () => {
+  it("JSX with multiple expressions", () => {
+    const title = "App";
+    const content = "Hello";
+    const count = 42;
+    const ast = jsx`
+      <div id="root">
+        <h1>${title}</h1>
+        <p>${content} - ${count}</p>
+      </div>
+    `;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [{ name: "id", type: STATIC_PROP, value: "root", quote: '"' }],
+          children: [
+            {
+              type: ELEMENT_NODE,
+              name: "h1",
+              props: [],
+              children: [{ type: EXPRESSION_NODE, value: 0 }],
+            },
+            {
+              type: ELEMENT_NODE,
+              name: "p",
+              props: [],
+              children: [
+                { type: EXPRESSION_NODE, value: 1 },
+                { type: TEXT_NODE, value: " - " },
+                { type: EXPRESSION_NODE, value: 2 },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("list-like structure", () => {
+    const items = ["a", "b", "c"];
+    const ast = jsx`
+      <ul>
+        <li>${items[0]}</li>
+        <li>${items[1]}</li>
+        <li>${items[2]}</li>
+      </ul>
+    `;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "ul",
+          props: [],
+          children: [
+            {
+              type: ELEMENT_NODE,
+              name: "li",
+              props: [],
+              children: [{ type: EXPRESSION_NODE, value: 0 }],
+            },
+            {
+              type: ELEMENT_NODE,
+              name: "li",
+              props: [],
+              children: [{ type: EXPRESSION_NODE, value: 1 }],
+            },
+            {
+              type: ELEMENT_NODE,
+              name: "li",
+              props: [],
+              children: [{ type: EXPRESSION_NODE, value: 2 }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("Specialized Element AST", () => {
+  it("void elements: children", () => {
+    // Note: br is void, img is void. They should be siblings, not nested.
+    const ast = jsx`<div><img src="test.png" >Children should get <span>wiped</span></img></div>`;
+
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "div",
+          props: [],
+          children: [
+            {
+              type: ELEMENT_NODE,
+              name: "img",
+              props: [
+                {
+                  name: "src",
+                  type: STATIC_PROP,
+                  value: "test.png",
+                  quote: '"',
+                },
+              ],
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("raw text elements: textarea ignoring content", () => {
+    // The content inside <textarea> is treated as a single TEXT_NODE
+    const ast = jsx`<textarea><div class="fake">${0}</div></textarea>`;
+
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: ELEMENT_NODE,
+          name: "textarea",
+          props: [],
+          children: [
+            {
+              type: TEXT_NODE,
+              value: '<div class="fake">',
+            },
+            { type: EXPRESSION_NODE, value: 0 },
+            {
+              type: TEXT_NODE,
+              value: "</div>",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+});
+
+describe("Dynamic Component Tags", () => {
+  it("parses dynamic opening tag with expression as tag name", () => {
+    const Comp = "Comp";
+    const ast = jsx`<${Comp}></${Comp}>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: COMPONENT_NODE,
+          name: 0,
+          props: [],
+          children: [],
+        },
+      ],
+    });
+  });
+
+  it("parses dynamic component with children", () => {
+    const Comp = "Comp";
+    const ast = jsx`<${Comp}><span>content</span></${Comp}>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: COMPONENT_NODE,
+          name: 0,
+          props: [],
+          children: [
+            {
+              type: ELEMENT_NODE,
+              name: "span",
+              props: [],
+              children: [{ type: TEXT_NODE, value: "content" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parses self-closing dynamic component", () => {
+    const Comp = "Comp";
+    const ast = jsx`<${Comp} />`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: COMPONENT_NODE,
+          name: 0,
+          props: [],
+          children: [],
+        },
+      ],
+    });
+  });
+
+
+  it("parses dynamic component with attributes", () => {
+    const Comp = "Comp";
+    const value = "test";
+    const ast = jsx`<${Comp} id=${value}></${Comp}>`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        {
+          type: COMPONENT_NODE,
+          name: 0,
+          props: [{ name: "id", type: EXPRESSION_PROP, value: 1 }],
+          children: [],
+        },
+      ],
+    });
+  });
+});
+
+describe("Edge Cases", () => {
+  it("empty template", () => {
+    const ast = jsx``;
+    expect(ast).toEqual({ type: ROOT_NODE, children: [] });
+  });
+  it("only expressions", () => {
+    const a = 1;
+    const b = 2;
+    const ast = jsx`${a}${b}`;
+    expect(ast).toEqual({
+      type: ROOT_NODE,
+      children: [
+        { type: EXPRESSION_NODE, value: 0 },
+        { type: EXPRESSION_NODE, value: 1 },
+      ],
+    });
+  });
+});
+
+describe("Errors", () => {
+  it("error on open tag", () => {
+    expect(() => jsx`<div`).toThrow();
+  });
+
+  it("error on mismatched tag", () => {
+    expect(() => jsx`<div></span>`).toThrow();
+  });
+
+  it("error on extra <", () => {
+    expect(() => jsx`<div><</span>`).toThrow();
+  });
+
+  it("error on bad tag name", () => {
+    expect(() => jsx`<1div><</1div>`).toThrow();
+  });
+
+  it("error on unclosed tags", () => {
+    expect(() => jsx`<div>`).toThrow();
+  });
+
+  it("error on spread without expression", () => {
+    expect(() => jsx`<div ... bool></div>`).toThrow();
+  });
+
+  it("error on unmatched close", () => {
+    expect(() => jsx`</div>`).toThrow();
+  });
+});
+
+describe("Advanced Parser Edge Cases", () => {
+  describe("Spread Attributes", () => {
+    it("handles multiple spread attributes", () => {
+      const props1 = { class: "first" };
+      const props2 = { id: "second" };
+      const ast = jsx`<div ...${props1} ...${props2}></div>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "div",
+            props: [
+              { type: SPREAD_PROP, value: 0 },
+              { type: SPREAD_PROP, value: 1 },
+            ],
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("handles spread with mixed other attributes", () => {
+      const props = { class: "dynamic", "data-test": "value" };
+      const ast = jsx`<div id="static" ...${props} required></div>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "div",
+            props: [
+              { name: "id", type: STATIC_PROP, value: "static", quote: '"' },
+              { type: SPREAD_PROP, value: 0 },
+              { name: "required", type: BOOLEAN_PROP, value: true },
+            ],
+            children: [],
+          },
+        ],
+      });
+    });
+
+  });
+
+
+  describe("Special Tag Names and Namespaces", () => {
+    it("handles custom elements with hyphens", () => {
+      const ast = jsx`<my-custom-element attr="value"></my-custom-element>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "my-custom-element",
+            props: [{ name: "attr", type: STATIC_PROP, value: "value", quote: '"' }],
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("handles namespaced tags", () => {
+      const ast = jsx`<svg:rect x="10" y="20"></svg:rect>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "svg:rect",
+            props: [
+              { name: "x", type: STATIC_PROP, value: "10", quote: '"' },
+              { name: "y", type: STATIC_PROP, value: "20", quote: '"' },
+            ],
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("handles foreignObject in SVG", () => {
+      const ast = jsx`<svg><foreignObject><div>HTML content</div></foreignObject></svg>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "svg",
+            props: [],
+            children: [
+              {
+                type: ELEMENT_NODE,
+                name: "foreignObject",
+                props: [],
+                children: [
+                  {
+                    type: ELEMENT_NODE,
+                    name: "div",
+                    props: [],
+                    children: [{ type: TEXT_NODE, value: "HTML content" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe("Advanced Text and Expression Handling", () => {
+    it("handles complex text with multiple adjacent expressions", () => {
+      const items = ["a", "b", "c"];
+      const separator = ", ";
+      const ast = jsx`${items[0]}${separator}${items[1]}${separator}${items[2]}`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          { type: EXPRESSION_NODE, value: 0 },
+          { type: EXPRESSION_NODE, value: 1 },
+          { type: EXPRESSION_NODE, value: 2 },
+          { type: EXPRESSION_NODE, value: 3 },
+          { type: EXPRESSION_NODE, value: 4 },
+        ],
+      });
+    });
+
+    it("handles text with HTML entities", () => {
+      const ast = jsx`<div>Use &lt; and &gt; for brackets</div>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "div",
+            props: [],
+            children: [{ type: TEXT_NODE, value: "Use &lt; and &gt; for brackets" }],
+          },
+        ],
+      });
+    });
+
+    it("handles text with numeric character references", () => {
+      const ast = jsx`<div>Copyright &#169; 2023</div>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "div",
+            props: [],
+            children: [{ type: TEXT_NODE, value: "Copyright &#169; 2023" }],
+          },
+        ],
+      });
+    });
+  });
+
+  describe("Complex Nesting and Structure", () => {
+    it("handles deeply nested structures", () => {
+      const ast = jsx`
+        <div>
+          <section>
+            <article>
+              <header>
+                <h1>Title</h1>
+              </header>
+              <main>
+                <p>Content</p>
+              </main>
+              <footer>
+                <small>Footer</small>
+              </footer>
+            </article>
+          </section>
+        </div>
+      `;
+
+      const divChild = ast.children[0] as any;
+      const sectionChild = divChild.children[0] as any;
+      const articleChild = sectionChild.children[0] as any;
+
+      expect(articleChild.name).toBe("article");
+      expect(articleChild.children.length).toBe(3);
+    });
+
+    it("handles sibling elements at root", () => {
+      const ast = jsx`<div>First</div><span>Second</span><p>Third</p>`;
+
+      expect(ast.children).toHaveLength(3);
+      expect((ast.children[0] as any).name).toBe("div");
+      expect((ast.children[1] as any).name).toBe("span");
+      expect((ast.children[2] as any).name).toBe("p");
+    });
+
+    it("handles mixed text and elements at root", () => {
+      const ast = jsx`Before<div>Element</div>After`;
+
+      expect(ast.children).toHaveLength(3);
+      expect((ast.children[0] as any).type).toBe(TEXT_NODE);
+      expect((ast.children[1] as any).type).toBe(ELEMENT_NODE);
+      expect((ast.children[2] as any).type).toBe(TEXT_NODE);
+    });
+  });
+
+  describe("Void and Raw Text Elements", () => {
+    it("handles void elements with attributes and self-closing syntax", () => {
+      const ast = jsx`<img src="test.jpg" alt="Test Image" />`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "img",
+            props: [
+              { name: "src", type: STATIC_PROP, value: "test.jpg", quote: '"' },
+              { name: "alt", type: STATIC_PROP, value: "Test Image", quote: '"' },
+            ],
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("handles void elements without explicit slash", () => {
+      const ast = jsx`<br></br>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "br",
+            props: [],
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("handles script element with complex content", () => {
+      const ast = jsx`<script>
+        function test() {
+          return x < y && z > w;
+        }
+      </script>`;
+
+      expect(((ast.children[0] as any).children[0] as any).value).toContain(
+        "return x < y && z > w;",
+      );
+    });
+
+    it("handles style element with CSS content", () => {
+      const ast = jsx`<style>
+        .class > .child { color: red; }
+        @media (max-width: 768px) {
+          .responsive { display: block; }
+        }
+      </style>`;
+
+      const styleContent = ((ast.children[0] as any).children[0] as any).value;
+      expect(styleContent).toContain(".class > .child");
+      expect(styleContent).toContain("@media");
+    });
+  });
+
+  describe("Attribute Namespaces and Special Props", () => {
+    it("handles on: namespace for events", () => {
+      const handler = () => {};
+      const ast = jsx`<div on:click=${handler}></div>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "div",
+            props: [{ name: "on:click", type: EXPRESSION_PROP, value: 0 }],
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("handles prop: and attr: namespaces", () => {
+      const value = "test";
+      const ast = jsx`<input prop:value=${value} attr:title="Title"></input>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "input",
+            props: [
+              { name: "prop:value", type: EXPRESSION_PROP, value: 0 },
+              { name: "attr:title", type: STATIC_PROP, value: "Title", quote: '"' },
+            ],
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("handles ref attribute", () => {
+      const ref = (el: HTMLElement) => {};
+      const ast = jsx`<div ref=${ref}></div>`;
+
+      expect(ast).toEqual({
+        type: ROOT_NODE,
+        children: [
+          {
+            type: ELEMENT_NODE,
+            name: "div",
+            props: [{ name: "ref", type: EXPRESSION_PROP, value: 0 }],
+            children: [],
+          },
+        ],
+      });
+    });
+  });
+
+  describe("Error Recovery and Edge Cases", () => {
+    it("handles attributes with special characters", () => {
+      const ast = jsx`<div data-attr_with.special:chars="value"></div>`;
+
+      expect(((ast.children[0] as any).props[0] as any).name).toBe("data-attr_with.special:chars");
+    });
+
+
+  });
+});

--- a/packages/sld-dom-expressions/tests/sld.test.ts
+++ b/packages/sld-dom-expressions/tests/sld.test.ts
@@ -1,0 +1,945 @@
+import { createRoot, createSignal, flush, createMemo } from "@solidjs/signals";
+import { createSLDRuntime } from "../src";
+import { expect, it, describe, beforeEach } from "vitest";
+import * as r from "../../dom-expressions/src/client";
+import {  MathMLElements} from "../../dom-expressions/src/constants";
+import { RawTextElements, VoidElements } from "./core";
+
+
+
+const createSLD = createSLDRuntime({...r,VoidElements,RawTextElements,MathMLElements})
+
+const For = (props:any)=>{
+  return createMemo(()=>props.each.map((v:any)=>props.children(v) ))as any
+}
+
+const Show = (props:any)=>{
+  return createMemo(()=>props.when ? props.children : null) as any
+}
+
+
+const sld = createSLD({ For, Show });
+
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SLD Integration Tests", () => {
+  describe("Basic Element Rendering", () => {
+    it("renders simple text content", () => {
+      const result = sld`Hello World!`;
+      expect(result).toBe("Hello World!");
+    });
+
+    it("renders simple elements", () => {
+      const result = sld`<div>Test</div>` as Node[];
+      const el = result[0] as HTMLElement;
+      expect(el.tagName).toBe("DIV");
+      expect(el.textContent).toBe("Test");
+    });
+
+    it("renders self-closing elements", () => {
+      const result = sld`<input type="text" />` as Node[];
+      const input = result[0] as HTMLInputElement;
+      expect(input.tagName).toBe("INPUT");
+      expect(input.type).toBe("text");
+    });
+
+    it("renders nested elements", () => {
+      const result = sld`<div><span>Nested</span></div>` as Node[];
+      const div = result[0] as HTMLElement;
+      const span = div.querySelector("span");
+      expect(span?.textContent).toBe("Nested");
+    });
+  });
+
+  describe("Attributes and Props", () => {
+    it("handles complex attribute names and mixed values", () => {
+      const [cls, setCls] = createSignal("active");
+      const result =
+        sld`<div class=${()=>`base ${cls()}`} data-test-id="main-div" aria-hidden="false"></div>` as Node[];
+      const el = result[0] as HTMLElement;
+
+      expect(el.className).toBe("base active");
+      expect(el.getAttribute("data-test-id")).toBe("main-div");
+
+      setCls("inactive");
+              flush()
+
+      expect(el.className).toBe("base inactive");
+    });
+
+    it("handles boolean attributes correctly", () => {
+      const [disabled, setDisabled] = createSignal(true);
+      const result = sld`<button disabled=${disabled} autofocus>Click</button>` as Node[];
+      const btn = result[0] as HTMLButtonElement;
+
+      expect(btn.disabled).toBe(true);
+      expect(btn.hasAttribute("autofocus")).toBe(true);
+
+      setDisabled(false);
+              flush()
+
+      expect(btn.disabled).toBe(false);
+    });
+
+    it("handles spread props with static before spread", () => {
+      const props = { id: "spread", class: "blue", "data-attr": "val" };
+      const result = sld`<div id="static" class="red" ...${props}></div>` as Node[];
+      const el = result[0] as HTMLElement;
+
+      expect(el.id).toBe("spread");
+      expect(el.className).toBe("blue");
+      expect(el.getAttribute("data-attr")).toBe("val");
+    });
+
+    it("handles spread props with static after spread", () => {
+      const props = { id: "spread", class: "blue", "data-attr": "val" };
+      const result = sld`<div ...${props} id="static" class="red"></div>` as Node[];
+      const el = result[0] as HTMLElement;
+
+      expect(el.id).toBe("static");
+      expect(el.className).toBe("red");
+      expect(el.getAttribute("data-attr")).toBe("val");
+    });
+
+    it("respects override order with spreads and static attributes", () => {
+      const props = { id: "from-spread", "data-info": "hidden" };
+      const result = sld`<div ...${props} id="final-id"></div>` as Node[];
+      const el = result[0] as HTMLElement;
+
+      expect(el.id).toBe("final-id");
+      expect(el.getAttribute("data-info")).toBe("hidden");
+    });
+
+    it("handles explicit properties and attributes via namespaces", () => {
+      const [val, setVal] = createSignal("initial");
+      const result = sld`<input prop:value=${val} title=${"hello"} />` as Node[];
+      const input = result[0] as HTMLInputElement;
+
+      expect(input.value).toBe("initial");
+      expect(input.getAttribute("title")).toBe("hello");
+
+      setVal("updated");
+              flush()
+
+      expect(input.value).toBe("updated");
+    });
+
+    it("handles mixed static and dynamic attribute parts", () => {
+      const [welcoming] = createSignal("hello");
+      const result = sld`
+        <h1 title=${() => `${welcoming()} John ${"Smith"}`}></h1>
+      ` as HTMLElement[]; 
+
+      expect(result[0].title).toBe("hello John Smith");
+    });
+
+    it("handles multi-line, complex, and unquoted-style attributes", () => {
+      const result = sld`
+        <div
+          multiline="
+            foo
+            bar
+          "
+          lorem ipsum
+        ></div>` as HTMLElement[];
+
+      const div = result[0];
+
+      expect(div.getAttribute("multiline")).toContain("foo");
+      expect(div.getAttribute("multiline")).toContain("bar");
+      expect(div.hasAttribute("lorem")).toBe(true);
+      expect(div.hasAttribute("ipsum")).toBe(true);
+    });
+
+    it("correctly handles JSON-like strings in attributes", () => {
+      const result = sld`
+        <lume-box uniforms='{ "iTime": { "value": 0 } }'></lume-box>
+      ` as HTMLElement[];
+
+      expect(result[0].getAttribute("uniforms")).toBe('{ "iTime": { "value": 0 } }');
+    });
+  });
+
+  describe("Expressions and Reactivity", () => {
+    it("handles expressions inside text", () => {
+      const name = "World";
+      const result = sld`<div>Hello ${name}!</div>` as Node[];
+      const el = result[0] as HTMLElement;
+      expect(el.textContent).toBe("Hello World!");
+    });
+
+    it("handles multiple expressions", () => {
+      const [count, setCount] = createSignal(0);
+      const name = "Counter";
+      const result = sld`<div>${name}: ${count}</div>` as Node[];
+      const el = result[0] as HTMLElement;
+
+      expect(el.textContent).toBe("Counter: 0");
+      setCount(5);
+              flush()
+
+      expect(el.textContent).toBe("Counter: 5");
+    });
+
+    it("handles sibling expressions and static text correctly", () => {
+      const [a] = createSignal("A");
+      const [b] = createSignal("B");
+
+      const result = sld`<div>${a} - ${b} !</div>` as Node[];
+      const el = result[0] as HTMLDivElement;
+
+      expect(el.textContent).toBe("A - B !");
+    });
+
+    it("trims whitespace correctly while preserving nested spaces", () => {
+      const name = "John";
+      const result = sld`
+        <div>
+          <b>Hello, my name is: <i> ${name}</i></b>
+        </div>
+      ` as HTMLElement[];
+
+      const b = result[0].querySelector("b")!;
+      expect(b.textContent).toBe("Hello, my name is: John");
+    });
+
+    it("handles dynamic attributes", () => {
+      const [visible, setVisible] = createSignal(true);
+      const result = sld`<div hidden=${!visible}>Content</div>` as Node[];
+      const el = result[0] as HTMLElement;
+
+      expect(el.hasAttribute("hidden")).toBe(false);
+      setVisible(false);
+              flush()
+
+      expect(el.hasAttribute("hidden")).toBe(false);
+    });
+  });
+
+  describe("Logic and Control Flow", () => {
+    it("works with Solid's <Show> component", () => {
+      const [visible, setVisible] = createSignal(false);
+      const result = sld`<div>
+        <Show when=${visible}>
+          <span id="target">I am visible</span>
+        </Show>
+        </div>` as Node[];
+
+      const container = document.createElement("div");
+      container.append(...result);
+      document.body.appendChild(container);
+
+      expect(container.querySelector("#target")).toBeNull();
+
+      setVisible(true);
+              flush()
+
+      expect(container.querySelector("#target")).not.toBeNull();
+      expect(container.querySelector("#target")?.textContent).toBe("I am visible");
+    });
+
+    it("works with Solid's <For> component", () => {
+      const [items, setItems] = createSignal(["A", "B"]);
+      const result = sld`
+        <ul>
+          <For each=${items}>
+            ${(item: string) => sld`<li>${item}</li>`}
+          </For>
+        </ul>` as Node[];
+
+      const container = document.createElement("div");
+      container.append(...result);
+
+      expect(container.querySelectorAll("li").length).toBe(2);
+
+      setItems(["A", "B", "C"]);
+              flush()
+
+      expect(container.querySelectorAll("li").length).toBe(3);
+    });
+  });
+
+  describe("Events and Refs", () => {
+    it("handles refs and event listeners correctly", () => {
+      let elementRef: HTMLDivElement | undefined;
+      let clickCount = 0;
+
+      const result = sld`
+      <div 
+        ref=${(el: HTMLDivElement) => (elementRef = el)} 
+        on:click=${() => clickCount++}
+      >Click me</div>` as Node[];
+
+      const el = result[0] as HTMLDivElement;
+
+      expect(elementRef).toBe(el);
+      el.click();
+      expect(clickCount).toBe(1);
+    });
+
+    it("integrates bound, delegated, and native listener events", () => {
+      const exec = { bound: false, delegated: false, listener: false };
+
+      const result = sld`
+        <div id="main">
+          <button onclick=${() => (exec.bound = true)}>Bound</button>
+          <button onClick=${[(v: any) => (exec.delegated = v), true]}>Delegated</button>
+          <button on:click=${() => (exec.listener = true)}>Listener</button>
+        </div>
+      ` as HTMLElement[];
+      document.body.append(...result);
+
+      const [btn1, btn2, btn3] = result[0].querySelectorAll("button");
+
+      expect(btn1.innerText).toBe("Bound");
+      expect(btn2.innerText).toBe("Delegated");
+      expect(btn3.innerText).toBe("Listener");
+
+      btn1.click();
+      btn2.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      btn3.click();
+
+      expect(exec.delegated).toBe(true);
+      expect(exec.listener).toBe(true);
+    });
+
+    it("captures refs across components and elements", () => {
+      let linkRef: HTMLAnchorElement | undefined;
+      const result = sld`
+        <div>
+          <a href="/" ref=${(el: HTMLAnchorElement) => (linkRef = el)}>Link</a>
+        </div>
+      ` as HTMLElement[];
+
+      expect(linkRef).toBe(result[0].querySelector("a"));
+    });
+  });
+
+  describe("Custom Components", () => {
+    it("passes children correctly to registered components", () => {
+      const Wrapper = (props: { children: any }) => sld`<section>${props.children}</section>`;
+      const localSld = createSLD({ Wrapper });
+
+      const result = localSld`
+      <Wrapper>
+        <span>Inside</span>
+      </Wrapper>` as Node[];
+
+      const section = result[0] as HTMLElement;
+      expect(section.tagName).toBe("SECTION");
+      expect(section.querySelector("span")?.textContent).toBe("Inside");
+    });
+
+    it("handles deep nesting with custom components", () => {
+      const Box = (props: any) => sld`<div class="box">${props.children}</div>`;
+      const localSld = createSLD({ Box });
+
+      const result = localSld`
+        <Box>
+          <ul>
+            <li><Box>Item 1</Box></li>
+            <li><Box>Item 2</Box></li>
+          </ul>
+        </Box>` as Node[];
+
+      const container = document.createElement("div");
+      container.append(...result);
+      expect(container.querySelectorAll(".box").length).toBe(3);
+      expect(container.querySelector("li")?.textContent).toBe("Item 1");
+    });
+  });
+
+  describe("Special Elements and Namespaces", () => {
+    it("treats <script> and <style> as raw text", () => {
+      const result = sld`
+        <style>
+          body > div { color: red; }
+        </style>` as Node[];
+
+      expect(result[0].textContent).toContain("body > div");
+      expect((result[0] as HTMLElement).tagName).toBe("STYLE");
+    });
+
+    it("maintains SVG namespace across nested dynamic paths", () => {
+      const [radius, setRadius] = createSignal(10);
+      const result = sld`
+      <svg>
+        <g>
+          <circle r=${radius} />
+        </g>
+      </svg>` as Node[];
+
+      const svg = result[0] as SVGSVGElement;
+      const circle = svg.querySelector("circle")!;
+
+      expect(circle.namespaceURI).toBe("http://www.w3.org/2000/svg");
+      expect(circle.getAttribute("r")).toBe("10");
+
+      setRadius(20);
+      flush()
+      expect(circle.getAttribute("r")).toBe("20");
+    });
+
+    it("handles template elements correctly", () => {
+      const nodes = sld`${"hole"}<template>Count: ${() => 1}</template>` as Node[];
+      document.body.append(...nodes);
+      expect(nodes[2].textContent).toEqual("Count: 1");
+    });
+
+    it("handles mathml elements", () => {
+      const Frac = () => sld`<mfrac>
+      <mn>1</mn>
+      <mn>3</mn>
+    </mfrac>`;
+
+      const result = sld.define({ Frac }).sld`<p>
+      The fraction
+      <math>
+        <Frac />
+      </math>
+      is not a decimal number.
+    </p>` as Node[];
+
+      document.body.append(...result);
+      expect(document.querySelector("math")).toBeTruthy();
+    });
+  });
+
+  describe("HTML Entities and Encoding", () => {
+    it("handles html encodings", () => {
+      const elem = sld`&copy;<span>&gt;</span>` as Node[];
+      expect(elem[0].textContent).toEqual("\u00A9");
+      expect(elem[1].textContent).toEqual(">");
+    });
+  });
+
+  describe("Edge Cases and Error Handling", () => {
+    it("handles empty templates", () => {
+      const result = sld``;
+      expect(result).toEqual([]);
+    });
+
+    it("handles whitespace-only templates", () => {
+      const result = sld`   `;
+      expect(result).toBe("   ");
+    });
+
+    it("handles weird whitespace and line breaks in tags", () => {
+      const result = sld`
+        <div 
+          id="test
+          "
+          class = 
+            "spaced"
+        >  Text  </div>` as Node[];
+      const el = result[0] as HTMLElement;
+      expect(el.id).toBe(`test
+          `);
+      expect(el.className).toBe("spaced");
+      expect(el.textContent?.trim()).toBe("Text");
+    });
+
+    it("ignores HTML comments and their contents", () => {
+      const signal = () => "HIDDEN";
+      const result = sld`
+        <div>
+            <!-- This is a comment with an expression: ${signal()} -->
+          <p>Visible</p>
+        </div>` as Node[];
+
+      const container = document.createElement("div");
+      container.append(...result);
+      expect(container.innerHTML).not.toContain("HIDDEN");
+      expect(container.querySelector("p")?.textContent).toBe("Visible");
+    });
+  });
+
+  describe("Complex DOM Integration Tests", () => {
+    describe("Advanced Attribute Scenarios", () => {
+      it("handles multiple spread attributes with complex override behavior", () => {
+        const baseProps = { class: "base", id: "base-id" };
+        const overrideProps = { class: "override", "data-override": true };
+        const finalId = "final-id";
+
+        const result =
+          sld`<div ...${baseProps} ...${overrideProps} id=${finalId} class="final">Content</div>` as Node[];
+        const el = result[0] as HTMLElement;
+
+        expect(el.className).toBe("final");
+        expect(el.id).toBe("final-id");
+        expect(el.getAttribute("data-override")).toBe("");
+        expect(el.textContent).toBe("Content");
+      });
+
+      it("handles mixed quoted and unquoted attributes with expressions", () => {
+        const [dynamicClass, setClass] = createSignal("active");
+        const [dynamicId] = createSignal("dynamic-123");
+        const staticTitle = "Static Title";
+
+        const result =
+          sld`<button class=${() => `btn-${dynamicClass()}`} id=${dynamicId} title=${staticTitle} disabled=${dynamicClass() === "active"}>Click</button>` as Node[];
+        const button = result[0] as HTMLButtonElement;
+
+        expect(button.className).toBe("btn-active");
+        expect(button.id).toBe("dynamic-123");
+        expect(button.title).toBe("Static Title");
+        expect(button.disabled).toBe(true);
+        expect(button.textContent).toBe("Click");
+
+        setClass("inactive");
+                flush()
+
+        expect(button.className).toBe("btn-inactive");
+      });
+
+      it("handles boolean attributes with dynamic expressions", () => {
+        const [enabled, setEnabled] = createSignal(true);
+        const [checked, setChecked] = createSignal(false);
+
+        const result =
+          sld`<input type="checkbox" disabled=${() => !enabled()} checked=${checked} readonly />` as Node[];
+        const input = result[0] as HTMLInputElement;
+
+        expect(input.disabled).toBe(false);
+        expect(input.checked).toBe(false);
+        expect(input.hasAttribute("readonly")).toBe(true);
+
+        setEnabled(false);
+        setChecked(true);
+                flush()
+
+        expect(input.disabled).toBe(true);
+        expect(input.checked).toBe(true);
+      });
+
+      it("handles style attribute with mixed static and dynamic values", () => {
+        const [color, setColor] = createSignal("red");
+        const result =
+          sld`<div style=${() => `color: ${color()}; background: blue; padding: ${10}px`}>Styled content</div>` as Node[];
+        const el = result[0] as HTMLElement;
+
+        expect(el.style.color).toBe("red");
+        expect(el.style.backgroundColor).toBe("blue");
+        expect(el.style.padding).toBe("10px");
+
+        setColor("green");
+                flush()
+
+        expect(el.style.color).toBe("green");
+      });
+
+      it("handles class attribute with complex expressions", () => {
+        const [isActive, setActive] = createSignal(true);
+        const [theme, setTheme] = createSignal("dark");
+
+        const result =
+          sld`<div class=${()=>`${isActive() ? "active" : "inactive"} theme-${theme()} static-class`}>Mixed classes</div>` as Node[];
+        const el = result[0] as HTMLElement;
+
+        expect(el.className).toBe("active theme-dark static-class");
+
+        setActive(false);
+        setTheme("light");
+                flush()
+
+        expect(el.className).toBe("inactive theme-light static-class");
+      });
+    });
+
+    describe("Reactive DOM Updates", () => {
+      it("updates DOM when multiple signals change simultaneously", () => {
+        const [count, setCount] = createSignal(0);
+        const [text, setText] = createSignal("Initial");
+
+        const result = sld`<div>
+          <span class=${() => `count-${count()}`}>Count: ${count}</span>
+          <span class=${() => `text-${text()}`}>Text: ${text}</span>
+        </div>` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+
+        const countSpan = container.querySelector(".count-0")!;
+        const textSpan = container.querySelector(".text-Initial")!;
+
+        expect(countSpan.className).toBe("count-0");
+        expect(countSpan.textContent).toBe("Count: 0");
+        expect(textSpan.className).toBe("text-Initial");
+        expect(textSpan.textContent).toBe("Text: Initial");
+
+        setCount(5);
+        setText("Updated");
+                flush()
+
+
+        expect(countSpan.className).toBe("count-5");
+        expect(countSpan.textContent).toBe("Count: 5");
+        expect(textSpan.className).toBe("text-Updated");
+        expect(textSpan.textContent).toBe("Text: Updated");
+      });
+
+      it("handles conditional attributes with boolean logic", () => {
+        const [visible, setVisible] = createSignal(true);
+        const [disabled, setDisabled] = createSignal(false);
+
+        const result = sld`<button 
+          hidden=${() => !visible()}
+          disabled=${disabled}
+          aria-hidden=${() => !visible()}
+          class=${() => (visible() ? "visible" : "hidden")}
+        >Button</button>` as Node[];
+        const button = result[0] as HTMLButtonElement;
+
+        expect(button.hidden).toBe(false);
+        expect(button.disabled).toBe(false);
+        expect(button.getAttribute("aria-hidden")).toBe(null);
+        expect(button.className).toBe("visible");
+
+        setVisible(false);
+        setDisabled(true);
+                flush()
+
+
+        expect(button.hidden).toBe(true);
+        expect(button.disabled).toBe(true);
+        expect(button.getAttribute("aria-hidden")).toBe("");
+        expect(button.className).toBe("hidden");
+      });
+    });
+
+    describe("Event Handling Integration", () => {
+      it("handles multiple event types with proper cleanup", () => {
+        let clickCount = 0;
+        let mouseOverCount = 0;
+        let inputChangeCount = 0;
+
+        const result = sld`<div>
+          <button on:click=${() => clickCount++}>Click me</button>
+          <span on:mouseover=${() => mouseOverCount++}>Hover me</span>
+          <input on:input=${() => inputChangeCount++} />
+        </div>` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+        document.body.append(container);
+
+        const button = container.querySelector("button")!;
+        const hoverDiv = container.querySelector("span")!;
+        const input = container.querySelector("input")!;
+
+        button.click();
+        hoverDiv.dispatchEvent(new MouseEvent("mouseover"));
+
+        expect(clickCount).toBe(1);
+        expect(mouseOverCount).toBe(1);
+      });
+
+      it("handles event delegation with stopPropagation", () => {
+        const events: string[] = [];
+
+        const result = sld`<div onClick=${() => events.push("parent")}>
+          <button onClick=${(e: Event) => {
+            e.stopPropagation();
+            events.push("child");
+          }}>Child</button>
+        </div>` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+        document.body.append(container);
+
+        const button = container.querySelector("button")!;
+        button.click();
+
+        expect(events.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe("Form Element Integration", () => {
+      it("handles form controls with reactive values", () => {
+        const [value, setValue] = createSignal("initial");
+        const [checked, setChecked] = createSignal(false);
+
+        const result = sld`<form>
+          <input type="text" value=${value} />
+          <input type="checkbox" checked=${checked} />
+          <select value=${value}>
+            <option value="initial">Option 1</option>
+            <option value="updated">Option 2</option>
+          </select>
+        </form>` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+        document.body.append(container);
+
+        const textInput = container.querySelector("input[type='text']") as HTMLInputElement;
+        const checkboxInput = container.querySelector("input[type='checkbox']") as HTMLInputElement;
+        const select = container.querySelector("select") as HTMLSelectElement;
+
+        expect(textInput.value).toBe("initial");
+        expect(checkboxInput.checked).toBe(false);
+        expect(select.value).toBe("initial");
+
+        setValue("updated");
+        setChecked(true);
+        flush()
+
+
+        expect(textInput.value).toBe("updated");
+        expect(checkboxInput.checked).toBe(true);
+        expect(select.value).toBe("updated");
+      });
+
+      it("handles textarea with raw text content", () => {
+        const [content, setContent] = createSignal("Initial content");
+
+        const result = sld`<textarea>${content}</textarea>` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+
+        const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+        expect(textarea.value).toBe("Initial content");
+
+        setContent("Updated content");
+                flush()
+
+        expect(textarea.value).toBe("Updated content");
+      });
+    });
+
+    describe("List and Table Rendering", () => {
+      it("renders table with dynamic rows and cells", () => {
+        const [rows, setRows] = createSignal([
+          ["Cell 1", "Cell 2", "Cell 3"],
+          ["Cell 4", "Cell 5", "Cell 6"],
+        ]);
+
+        const result = sld`<table>
+          <thead>
+            <tr><th>Col 1</th><th>Col 2</th><th>Col 3</th></tr>
+          </thead>
+          <tbody>
+            <For each=${rows}>
+              ${(row: string[]) => sld`
+                <tr>
+                  <For each=${row}>
+                    ${(cell: string) => sld`<td>${cell}</td>`}
+                  </For>
+                </tr>
+              `}
+            </For>
+          </tbody>
+        </table>` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+
+        const table = container.querySelector("table")!;
+        const tbody = table.querySelector("tbody")!;
+        const trElements = tbody.querySelectorAll("tr");
+
+        expect(trElements.length).toBe(2);
+
+        const firstRowCells = trElements[0].querySelectorAll("td");
+        expect(firstRowCells.length).toBe(3);
+        expect(firstRowCells[0].textContent).toBe("Cell 1");
+        expect(firstRowCells[1].textContent).toBe("Cell 2");
+        expect(firstRowCells[2].textContent).toBe("Cell 3");
+      });
+
+      it("renders ordered and unordered lists with nested items", () => {
+        const [items, setItems] = createSignal([
+          { text: "Item 1", children: ["Subitem 1.1", "Subitem 1.2"] },
+          { text: "Item 2", children: [] },
+        ]);
+
+        const result = sld`<div>
+          <ul>
+            <For each=${items}>
+              ${(item: any) => sld`
+                <li class="parent-item">
+                  ${item.text}
+                  <ol>
+                    <For each=${item.children}>
+                      ${(child: string) => sld`<li class="child-item">${child}</li>`}
+                    </For>
+                  </ol>
+                </li>
+              `}
+            </For>
+          </ul>
+        </div>` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+
+        const parentItems = container.querySelectorAll(".parent-item");
+        expect(parentItems.length).toBe(2);
+
+        const childItems = container.querySelectorAll(".child-item");
+        expect(childItems.length).toBe(2);
+        expect(childItems[0].textContent).toBe("Subitem 1.1");
+        expect(childItems[1].textContent).toBe("Subitem 1.2");
+      });
+    });
+
+    describe("Media and Resource Elements", () => {
+      it("handles img element with reactive src and alt", () => {
+        const [src, setSrc] = createSignal("image1.jpg");
+        const [alt, setAlt] = createSignal("Image 1");
+
+        const result = sld`<img src=${src} alt=${alt} width="100" height="100" />` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+
+        const img = container.querySelector("img") as HTMLImageElement;
+        expect(img.src).toContain("image1.jpg");
+        expect(img.alt).toBe("Image 1");
+        expect(img.width).toBe(100);
+        expect(img.height).toBe(100);
+
+        setSrc("image2.jpg");
+        setAlt("Image 2");
+
+        flush()
+
+        expect(img.src).toContain("image2.jpg");
+        expect(img.alt).toBe("Image 2");
+      });
+
+      it("handles link and meta elements correctly", () => {
+        const result = sld`<head>
+          <link rel="stylesheet" href="style.css" />
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+        </head>` as Node[];
+        const container = document.createElement("div");
+        container.append(...result);
+
+        const link = container.querySelector("link") as HTMLLinkElement;
+        expect(link.rel).toBe("stylesheet");
+        expect(link.href).toContain("style.css");
+
+        const charsetMeta = container.querySelector("meta[charset]") as HTMLMetaElement;
+        expect(charsetMeta.getAttribute("charset")).toBe("utf-8");
+
+        const viewportMeta = container.querySelector('meta[name="viewport"]') as HTMLMetaElement;
+        expect(viewportMeta.content).toBe("width=device-width, initial-scale=1");
+      });
+    });
+  });
+
+  describe("Dynamic Components", () => {
+    it("renders dynamic component with expression as tag name", () => {
+      const Comp = (props: any) => sld`<div>Dynamic</div>`;
+      const result = sld.define({ Comp }).sld`<${Comp} />` as Node[];
+      const container = document.createElement("div");
+      container.append(...result);
+      expect(container.innerHTML).toBe("<div>Dynamic</div>");
+    });
+
+    it("renders dynamic component with children", () => {
+      const Comp = (props: any) => sld`<section>${props.children}</section>`;
+      const result = sld.define({ Comp }).sld`<${Comp}><span>content</span></${Comp}>` as Node[];
+      const container = document.createElement("div");
+      container.append(...result);
+      expect(container.querySelector("section")?.innerHTML).toContain("<span>content</span>");
+    });
+
+    // it("renders dynamic component with shorthand close tag", () => {
+    //   const Comp = (props: any) => sld`<section>${props.children}</section>`;
+    //   const result = sld.define({ Comp }).sld`<Comp>text<//>` as Node[];
+    //   const container = document.createElement("div");
+    //   container.append(...result);
+    //   expect(container.querySelector("section")?.textContent).toBe("text");
+    // });
+
+      it("renders dynamic component with shorthand close tag", () => {
+      const Comp = (props: any) => sld`<section>${props.children}</section>`;
+      const result = sld.define({ Comp }).sld`<${Comp}>text<//>` as Node[];
+      const container = document.createElement("div");
+      container.append(...result);
+      expect(container.querySelector("section")?.textContent).toBe("text");
+    });
+
+
+  });
+
+  describe("GitHub Issues Compatibility", () => {
+    it("https://github.com/ryansolid/dom-expressions/issues/156", () => {
+      const elements =
+        sld`<div><For each=${() => [1, 2, 3]}>${(n: number) => sld`<h1>${n}</h1>`}</For></div>` as Node[];
+      const container = document.createElement("div");
+      container.append(...elements);
+      expect(container.innerHTML).toBe(
+        "<div><h1>1<!--+--></h1><h1>2<!--+--></h1><h1>3<!--+--></h1><!--For--></div>",
+      );
+    });
+
+    it("https://github.com/ryansolid/dom-expressions/issues/248", () => {
+      const Comp = (props: any) => sld`<div>${props.children}</div>`;
+      const result = sld.define({ Comp }).sld`<Comp>test "ups"</Comp>` as Node[];
+      const container = document.createElement("div");
+      container.append(...result)
+      expect(container.innerHTML).toBe('<div>test "ups"<!--+--></div>');
+    });
+
+    it("https://github.com/ryansolid/dom-expressions/issues/268", () => {
+      const elements = sld`
+    <div id="div">Test</div>
+    <style>
+      #div {
+        color:${() => "red"};
+        background-color:blue;
+      }
+    </style>
+  ` as Node[];
+      const container = document.createElement("div");
+      container.append(...elements);
+      document.body.append(container);
+      expect(container.innerHTML).toEqual(
+        `<div id="div">Test</div><style>
+      #div {
+        color:red<!--+-->;
+        background-color:blue;
+      }
+    </style>`,
+      );
+    });
+
+    it("https://github.com/ryansolid/dom-expressions/issues/269", () => {
+      const elements = sld``;
+      expect(elements).toEqual([]);
+    });
+
+    it("https://github.com/ryansolid/dom-expressions/issues/399", () => {
+      const Foo = (props: any) => sld`${props.bar}`;
+      const result = sld.define({ Foo }).sld`<Foo bar></Foo>`;
+      expect(result).toEqual(true);
+    });
+
+    // it("https://github.com/solidjs/solid/issues/1996", () => {
+    //   const [elem] = sld`<some-el attr:foo="123">inspect element</some-el>` as HTMLElement[];
+    //   expect(elem.hasAttribute("foo")).toEqual(true);
+    // });
+
+    it("https://github.com/solidjs/solid/issues/2299", () => {
+      const nodes = sld`
+    foo: ${123}
+    bar: ${456}
+  ` as Node[];
+
+      expect(nodes[0]).toEqual("\n    foo: ");
+      expect(nodes[1]).toEqual(123);
+    });
+
+    it("template element edge case", () => {
+      const elem = sld`
+    <div>
+      <template>
+        <h1>${123}</h1>
+      </template>
+    </div>
+  `;
+      expect(elem);
+    });
+  });
+});

--- a/packages/sld-dom-expressions/tests/tokenize.test.ts
+++ b/packages/sld-dom-expressions/tests/tokenize.test.ts
@@ -1,0 +1,930 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLOSE_TAG_TOKEN,
+  EQUALS_TOKEN,
+  EXPRESSION_TOKEN,
+  IDENTIFIER_TOKEN,
+  OPEN_TAG_TOKEN,
+  SLASH_TOKEN,
+  STRING_TOKEN,
+  TEXT_TOKEN,
+  tokenize
+} from "../src/tokenize";
+import { RawTextElements } from "./core.js";
+
+function tokenizeTemplate(strings: TemplateStringsArray, ...values: any[]) {
+  return tokenize(strings, RawTextElements);
+}
+
+describe("basic tags", () => {
+  it("should tokenize opening tag", () => {
+    const tokens = tokenizeTemplate`<div`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      }
+    ]);
+  });
+
+  it("should tokenize complete tag", () => {
+    const tokens = tokenizeTemplate`<div>`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should tokenize self-closing tag", () => {
+    const tokens = tokenizeTemplate`<div />`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: SLASH_TOKEN
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should tokenize opening and closing tag", () => {
+    const tokens = tokenizeTemplate`<div></div>`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      },
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: SLASH_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+});
+
+describe("attribute values", () => {
+  it("should tokenize quoted string", () => {
+    const tokens = tokenizeTemplate`<div id="hello">`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "id"
+      },
+      {
+        type: EQUALS_TOKEN
+      },
+      {
+        type: STRING_TOKEN,
+        value: "hello",
+        quote: '"'
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should tokenize single quoted string", () => {
+    const tokens = tokenizeTemplate`<div id='hello'>`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "id"
+      },
+      {
+        type: EQUALS_TOKEN
+      },
+      {
+        type: STRING_TOKEN,
+        value: "hello",
+        quote: "'"
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should handle empty quoted string", () => {
+    const tokens = tokenizeTemplate`<div class="">`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "class"
+      },
+      {
+        type: EQUALS_TOKEN
+      },
+      {
+        type: STRING_TOKEN,
+        value: "",
+        quote: '"'
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should handle boolean like attribute", () => {
+    const tokens = tokenizeTemplate`<div enabled bool>`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "enabled"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "bool"
+      },
+
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should handle deeply nested quotes", () => {
+    const tokens = tokenizeTemplate`<div data="value with 'nested' quotes">`;
+
+    expect(tokens).toContainEqual(
+      expect.objectContaining({
+        type: STRING_TOKEN,
+        value: "value with 'nested' quotes",
+        quote: '"'
+      })
+    );
+  });
+
+  it("should handle attribute values with special characters", () => {
+    const tokens = tokenizeTemplate`<div data="!@#$%^&*()_+-=[]{}|;:,.<>?">`;
+
+    expect(tokens).toContainEqual(
+      expect.objectContaining({
+        type: STRING_TOKEN,
+        value: "!@#$%^&*()_+-=[]{}|;:,.<>?",
+        quote: '"'
+      })
+    );
+  });
+
+  it("should handle URL-like attribute values", () => {
+    const tokens = tokenizeTemplate`<a href="https://example.com/path?query=value&other=test#section">`;
+
+    expect(tokens).toContainEqual(
+      expect.objectContaining({
+        type: STRING_TOKEN,
+        value: "https://example.com/path?query=value&other=test#section",
+        quote: '"'
+      })
+    );
+  });
+
+  it("attribute name doesnt trigger raw text", () => {
+    const tokens = tokenizeTemplate`
+            <h1 title=""></h1>
+          `;
+
+    expect(tokens).toEqual([
+      { type: TEXT_TOKEN, value: "\n            " },
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "h1" },
+      { type: IDENTIFIER_TOKEN, value: "title" },
+      { type: EQUALS_TOKEN },
+      { type: STRING_TOKEN, value: "", quote: '"' },
+
+      { type: CLOSE_TAG_TOKEN },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "h1" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: "\n          " }
+    ]);
+  });
+});
+
+describe("expressions", () => {
+  it("should tokenize simple expression", () => {
+    const value = "test";
+    const tokens = tokenizeTemplate`${value}`;
+
+    expect(tokens).toEqual([
+      {
+        type: EXPRESSION_TOKEN,
+        value: 0
+      }
+    ]);
+  });
+
+  it("should tokenize multiple expressions", () => {
+    const a = "first";
+    const b = "second";
+    const tokens = tokenizeTemplate`${a}${b}`;
+
+    expect(tokens).toEqual([
+      {
+        type: EXPRESSION_TOKEN,
+        value: 0
+      },
+      {
+        type: EXPRESSION_TOKEN,
+        value: 1
+      }
+    ]);
+  });
+
+  it("should handle expression in unquoted attribute", () => {
+    const id = "my-id";
+    const tokens = tokenizeTemplate`<div id=${id}>`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "id"
+      },
+      {
+        type: EQUALS_TOKEN
+      },
+      {
+        type: EXPRESSION_TOKEN,
+        value: 0
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should handle mixed text and expressions", () => {
+    const name = "World";
+    const tokens = tokenizeTemplate`Hello ${name}!`;
+
+    expect(tokens).toEqual([
+      {
+        type: TEXT_TOKEN,
+        value: "Hello "
+      },
+      {
+        type: EXPRESSION_TOKEN,
+        value: 0
+      },
+      {
+        type: TEXT_TOKEN,
+        value: "!"
+      }
+    ]);
+  });
+
+  it("should handle data attributes with hyphens and underscores", () => {
+    const tokens = tokenizeTemplate`<div data-my_value="test" data_other-name="value">`;
+
+    const attrNames = tokens.filter(
+      t => t.type === IDENTIFIER_TOKEN && (t.value as string).includes("data")
+    );
+    expect(attrNames.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("whitespace handling", () => {
+  it("should skip whitespace inside tags", () => {
+    const tokens = tokenizeTemplate`< \n  div   id   =   "app"  >`;
+
+    // Should not have whitespace tokens in tag context
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "id"
+      },
+      {
+        type: EQUALS_TOKEN
+      },
+
+      {
+        type: STRING_TOKEN,
+        value: "app",
+        quote: '"'
+      },
+
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should preserve text content whitespace", () => {
+    const tokens = tokenizeTemplate`  Hello World  `;
+
+    expect(tokens).toEqual([
+      {
+        type: TEXT_TOKEN,
+        value: "  Hello World  "
+      }
+    ]);
+  });
+
+  it("should handle multiline content with preserved whitespace", () => {
+    const tokens = tokenizeTemplate`<div>
+        Hello
+      </div>`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      },
+      {
+        type: TEXT_TOKEN,
+        value: "\n        Hello\n      "
+      },
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: SLASH_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should handle tabs and mixed whitespace", () => {
+    const tokens = tokenizeTemplate`\tHello\nWorld `;
+
+    expect(tokens).toEqual([
+      {
+        type: TEXT_TOKEN,
+        value: "\tHello\nWorld "
+      }
+    ]);
+  });
+
+  it("should handle whitespace around expressions", () => {
+    const name = "test";
+    const tokens = tokenizeTemplate`  ${name}  `;
+
+    expect(tokens).toEqual([
+      {
+        type: TEXT_TOKEN,
+        value: "  "
+      },
+      {
+        type: EXPRESSION_TOKEN,
+        value: 0
+      },
+      {
+        type: TEXT_TOKEN,
+        value: "  "
+      }
+    ]);
+  });
+});
+
+describe("edge cases", () => {
+  it("should handle empty template", () => {
+    const tokens = tokenizeTemplate``;
+
+    expect(tokens).toEqual([]);
+  });
+
+  it("should handle only whitespace", () => {
+    const tokens = tokenizeTemplate`   `;
+
+    expect(tokens).toEqual([
+      {
+        type: TEXT_TOKEN,
+        value: "   "
+      }
+    ]);
+  });
+
+  it("should handle special characters in text", () => {
+    const tokens = tokenizeTemplate`Hello & goodbye`;
+
+    expect(tokens).toEqual([
+      {
+        type: TEXT_TOKEN,
+        value: "Hello & goodbye"
+      }
+    ]);
+  });
+
+  it("should handle consecutive expressions", () => {
+    const a = "first";
+    const b = "second";
+    const tokens = tokenizeTemplate`${a}${b}`;
+
+    expect(tokens).toEqual([
+      {
+        type: EXPRESSION_TOKEN,
+        value: 0
+      },
+      {
+        type: EXPRESSION_TOKEN,
+        value: 1
+      }
+    ]);
+  });
+
+  it("should handle 1 letter tags", () => {
+    const tokens = tokenizeTemplate`<tr class=${0}>
+                  <td class="col-md-1" textContent=${1} />
+                  <td class="col-md-4">
+                    <a onClick=${2} textContent=${3} />
+                  </td>
+                  <td class="col-md-1">
+                    <a onClick=${4}>
+                      <span class="glyphicon glyphicon-remove" aria-hidden="true" />
+                    </a>
+                  </td>
+                  <td class="col-md-6" />
+                </tr>`;
+    expect(tokens.filter(t => t.type === IDENTIFIER_TOKEN && t.value === "a").length).toBe(3);
+  });
+});
+
+describe("special characters in names", () => {
+  it("should tokenize tag with hyphens", () => {
+    const tokens = tokenizeTemplate`<my-component />`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "my-component"
+      },
+      {
+        type: SLASH_TOKEN
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should tokenize tag with periods", () => {
+    const tokens = tokenizeTemplate`<my.component />`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "my.component"
+      },
+      {
+        type: SLASH_TOKEN
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should tokenize tag with colons", () => {
+    const tokens = tokenizeTemplate`<svg:rect />`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "svg:rect"
+      },
+      {
+        type: SLASH_TOKEN
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should tokenize tag with underscores", () => {
+    const tokens = tokenizeTemplate`<my_component />`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "my_component"
+      },
+      {
+        type: SLASH_TOKEN
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+
+  it("should tokenize attribute with -_.:$", () => {
+    const tokens = tokenizeTemplate`<div data-id data_id data.id data:id dataid$>`;
+
+    expect(tokens).toEqual([
+      {
+        type: OPEN_TAG_TOKEN
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "div"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "data-id"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "data_id"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "data.id"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "data:id"
+      },
+      {
+        type: IDENTIFIER_TOKEN,
+        value: "dataid$"
+      },
+      {
+        type: CLOSE_TAG_TOKEN
+      }
+    ]);
+  });
+});
+
+describe("invalid syntax", () => {
+  it("should throw with extra <", () => {
+    expect(() => tokenizeTemplate`<<div / >`).toThrow();
+  });
+
+  it("should throw with extra <", () => {
+    expect(() => tokenizeTemplate`<div / <>`).toThrow();
+  });
+
+  it("should throw on invalid identofier", () => {
+    expect(() => tokenizeTemplate`<.div />`).toThrow();
+  });
+
+  it("should throw on invalid identofier", () => {
+    expect(() => tokenizeTemplate`<div @fa />`).toThrow();
+  });
+
+  it("should throw on invalid identofier", () => {
+    expect(() => tokenizeTemplate`<div 0fa />`).toThrow();
+  });
+});
+
+describe("bad but valid syntaxes", () => {
+  it("should handle multiple attributes in tight syntax", () => {
+    const tokens = tokenizeTemplate`<div a="1"b="2"c="3">`;
+
+    const attrNames = tokens.filter(
+      t => t.type === IDENTIFIER_TOKEN && t.value && /^[abc]$/.test(t.value as string)
+    );
+    expect(attrNames).toHaveLength(3);
+  });
+
+  it("should handle attribute without value but with slash", () => {
+    const tokens = tokenizeTemplate`<div required/>`;
+
+    expect(tokens).toContainEqual(
+      expect.objectContaining({
+        type: IDENTIFIER_TOKEN,
+        value: "required"
+      })
+    );
+    expect(tokens).toContainEqual(
+      expect.objectContaining({
+        type: SLASH_TOKEN
+      })
+    );
+  });
+
+  it("should handle whitespace variations", () => {
+    const tokens = tokenizeTemplate`<div   id   =   "value"   />`;
+
+    expect(tokens).toContainEqual(
+      expect.objectContaining({
+        type: IDENTIFIER_TOKEN,
+        value: "id"
+      })
+    );
+    expect(tokens).toContainEqual(
+      expect.objectContaining({
+        type: STRING_TOKEN,
+        value: "value"
+      })
+    );
+  });
+});
+
+describe("handling of raw text elements", () => {
+  it("should tokenize content inside <script> as text", () => {
+    const tokens = tokenizeTemplate`<script>const a = 5<10;</script>`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "script" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: "const a = 5<10;" },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "script" },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should tokenize content inside <style> as text", () => {
+    const tokens = tokenizeTemplate`<style>.class > span { color: red; }</style>`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "style" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: ".class > span { color: red; }" },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "style" },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should tokenize content inside <textarea> as text", () => {
+    const tokens = tokenizeTemplate`<textarea>This is <span>not parsed</span>.</textarea>`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: "This is <span>not parsed</span>." },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should handle raw text elements with attributes and expressions", () => {
+    const tokens = tokenizeTemplate`<textarea type=${0}><span>${1}</span></textarea>`;
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: IDENTIFIER_TOKEN, value: "type" },
+      { type: EQUALS_TOKEN },
+      { type: EXPRESSION_TOKEN, value: 0 },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: "<span>" },
+      { type: EXPRESSION_TOKEN, value: 1 },
+      { type: TEXT_TOKEN, value: "</span>" },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should handle raw text elements and white space in tags", () => {
+    const tokens = tokenizeTemplate`<   textarea  >  ${0}<  /   textarea   >`;
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: `  ` },
+      { type: EXPRESSION_TOKEN, value: 0 },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should handle nested raw text elements", () => {
+    const tokens = tokenizeTemplate`<textarea><textarea>const a = 5;</textarea></textarea>`;
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: "<textarea>const a = 5;" },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should handle self-closing raw text elements", () => {
+    const tokens = tokenizeTemplate`<textarea ${0} />Text`;
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "textarea" },
+      { type: EXPRESSION_TOKEN, value: 0 },
+      { type: SLASH_TOKEN },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: "Text" }
+    ]);
+  });
+});
+
+describe("dynamic component tags", () => {
+  it("should tokenize dynamic opening tag with expression", () => {
+    const Comp = "Comp";
+    const tokens = tokenizeTemplate`<${Comp}>`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: EXPRESSION_TOKEN, value: 0 },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should tokenize dynamic self-closing tag", () => {
+    const Comp = "Comp";
+    const tokens = tokenizeTemplate`<${Comp} />`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: EXPRESSION_TOKEN, value: 0 },
+      { type: SLASH_TOKEN },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should tokenize dynamic closing tag", () => {
+    const Comp = "Comp";
+    const tokens = tokenizeTemplate`<${Comp}></${Comp}>`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: EXPRESSION_TOKEN, value: 0 },
+      { type: CLOSE_TAG_TOKEN },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: EXPRESSION_TOKEN, value: 1 },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should tokenize shorthand close tag", () => {
+    const tokens = tokenizeTemplate`<Comp>content<//>`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "Comp" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: "content" },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should tokenize dynamic tag with attributes", () => {
+    const Comp = "Comp";
+    const tokens = tokenizeTemplate`<${Comp} id="test" />`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: EXPRESSION_TOKEN, value: 0 },
+      { type: IDENTIFIER_TOKEN, value: "id" },
+      { type: EQUALS_TOKEN },
+      { type: STRING_TOKEN, value: "test", quote: '"' },
+      { type: SLASH_TOKEN },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+});
+
+describe("comments handling", () => {
+  it("should not tokenzie comments", () => {
+    const tokens = tokenizeTemplate`<div><!-- This is a comment --></div>`;
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "div" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "div" },
+      { type: CLOSE_TAG_TOKEN }
+    ]);
+  });
+
+  it("should handle comments with special characters", () => {
+    const tokens = tokenizeTemplate`<!-- Special chars: <>&'" -->`;
+    expect(tokens).toEqual([]);
+  });
+
+  it("should handle comments with expressions inside", () => {
+    const value = "test";
+    const tokens = tokenizeTemplate`<!-- Comment with ${value} inside -->`;
+    expect(tokens).toEqual([]);
+  });
+});

--- a/packages/sld-dom-expressions/tsconfig.json
+++ b/packages/sld-dom-expressions/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "declaration": true,
+    "outDir": "dist",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sld-dom-expressions/vitest.config.ts
+++ b/packages/sld-dom-expressions/vitest.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+import { preview } from "@vitest/browser-preview";
+import path from "path"
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      provider: preview(),
+      // headless: true,
+      screenshotFailures: false,
+      instances: [{ browser: "chromium" }],
+    },
+    // environment:"node",
+    // include:[
+    //   "./tests/parse.test.ts",
+    //   "./tests/tokenize.test.ts"
+    // ]
+  },
+  resolve: {
+    alias: {
+      // Option 1: Using an absolute path (Recommended)
+      'rxcore': path.resolve(__dirname, './tests/core'),
+      
+      // Option 2: Using a relative path (Works in most setups)
+      // 'rxcore': './test/core'
+    },
+  },
+});


### PR DESCRIPTION
[Discord discussion] (https://discordapp.com/channels/722131463138705510/1394408373176369202)

# Overview
## Goals:
- Provide an alternative to current html tagged template literals to more closely match JSX for no-build
- Avoid using a RegExp parser to prevent parsing edge cases.

### Main Differences to html
- Components can be registered by string to an instance of the `sld` template.
- Custom tokenizer + parser vs regex

## Future Tooling Opportunities 
- https://github.com/[danielrkling/sld-tools](https://github.com/danielrkling/sld-tools)
- Syntax Highlighter
- Formatter
- Typescript Plugin
- JSX <--> sld transformers

# Development Notes

## Template Setup (Cached)
1. Templates gets parsed into JSX-like AST.
2. Loop through AST to build template elements for any root node or component node with element children with the same tree structure. Static attributes are applied to the template and removed from AST. Holes and Components locations are marked with Comment Nodes.
5. AST and template elements get cached per template literal.

## Template Run
1. Template is cloned.
2. Clone is walked though in sync with the AST. (Text Nodes skipped)
4. Dynamic properties are collected from AST and applied via `spread`.
5. When insert or component Comment nodes are hit, they are applied with `insert`

## Performance
- 1.25 in js-framework-benchmark (Compiled Solid ~ 1.10)