### PR TITLE
refactor: incorrect import replacement path in hyper-dom-expressions

### DIFF
--- a/packages/hyper-dom-expressions/babel.config.js
+++ b/packages/hyper-dom-expressions/babel.config.js
@@ -1,4 +1,6 @@
 // babel.config.js
+const path = require('path');
+
 module.exports = {
   presets: ['@babel/preset-env'],
   plugins: [
@@ -6,7 +8,7 @@ module.exports = {
       "babel-plugin-transform-rename-import",
       {
         original: "rxcore",
-        replacement: "../test/core"
+        replacement: path.join(__dirname, '..', 'dom-expressions', 'test', 'core')
       }
     ]
   ]


### PR DESCRIPTION
### Problem

The `babel-plugin-transform-rename-import` plugin is configured to replace the `rxcore` import with a relative path `../test/core`. This path resolves to `packages/test/core` relative to the monorepo root. However, based on the provided repository structure, there is no `packages/test` directory, making this path invalid. This misconfiguration will likely lead to module resolution failures during the build process or runtime errors when `rxcore` is imported, causing the `hyper-dom-expressions` package to be unusable. The `dom-expressions` package correctly points `rxcore` to its local core using `__dirname + "/core"`. It's highly probable that `hyper-dom-expressions` should also point to the `dom-expressions` core.

### Changes

Adjust the `replacement` path to correctly point to the `dom-expressions` core module. You'll need to import `path` at the top of the file.


**Modified files:**
- `packages/hyper-dom-expressions/babel.config.js` (modified)

### Checklist

- [x] Existing tests pass
- [x] Changes reviewed
- [x] No unrelated changes included
