### PR TITLE
🚀 Feature: Create rollup config for SWC plugin

### DIFF
--- a/packages/swc-plugin-jsx-dom-expressions/rollup.config.js
+++ b/packages/swc-plugin-jsx-dom-expressions/rollup.config.js
@@ -1,0 +1,19 @@
+import nodeResolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import cleanup from "rollup-plugin-cleanup";
+
+export default {
+  input: "src/index.js",
+  output: [
+    {
+      file: "dist/index.cjs",
+      format: "cjs"
+    },
+    {
+      file: "dist/index.js",
+      format: "es"
+    }
+  ],
+  plugins: [nodeResolve(), commonjs(), cleanup()],
+  external: []
+};


### PR DESCRIPTION
## Problem

Create rollup configuration to bundle the SWC plugin package.

**Severity**: `medium`
**File**: `packages/swc-plugin-jsx-dom-expressions/rollup.config.js`

## Solution

Create rollup configuration to bundle the SWC plugin package.

## Changes

- `packages/swc-plugin-jsx-dom-expressions/rollup.config.js` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #10