### PR TITLE
[next] may fix Hydration bug with stateful dom changes

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -494,7 +494,7 @@ function renameAttribute(attr, name) {
   }
 }
 
-export function transformSpecialCaseAttributes(path, tagName, isSSR) {
+export function transformSpecialCaseAttributes(path, tagName) {
   tagName = tagName.toUpperCase();
 
   for (const propName in DOMWithState[tagName]) {
@@ -517,13 +517,13 @@ export function transformSpecialCaseAttributes(path, tagName, isSSR) {
         renameAttribute(attr, "prop:" + propName);
 
         // `value` is not present, only `prop:value`, SSR `value`
-        if (isSSR) {
-          // <textarea value=""/> doesnt exists
-          if (tagName === "TEXTAREA" && propName === "value") {
-            path.set("children", [t.jsxExpressionContainer(value)]);
-          } else {
-            addAttribute(path, t.jsxIdentifier(propName), t.jsxExpressionContainer(value));
-          }
+        // it has to also do same for dom as for hydration ids to match
+
+        // <textarea value=""/> doesnt exists
+        if (tagName === "TEXTAREA" && propName === "value") {
+          path.set("children", [t.jsxExpressionContainer(value)]);
+        } else {
+          addAttribute(path, t.jsxIdentifier(propName), t.jsxExpressionContainer(value));
         }
       } else {
         // value is not dynamic

--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
@@ -116,7 +116,7 @@ function setAttr(tagName, attribute, results, name, value, isDynamic, isBoolean)
   if (isDynamic) {
     attr = t.arrowFunctionExpression([], attr);
 
-    const post = DOMWithState[tagName.toUpperCase()] && DOMWithState[tagName.toUpperCase()][name];
+    const post = isStatefulDOMProperty(tagName, name);
 
     results.templateValues.push(
       hoistExpression(attribute, results, attr, {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -272,6 +272,12 @@ const template14 = (() => {
       _el$19.checked = _v$;
     }
   );
+  _$effect(
+    () => state.visible,
+    _v$ => {
+      _$setAttribute(_el$19, "checked", _v$);
+    }
+  );
   return _el$19;
 })();
 const template15 = _tmpl$10();
@@ -344,8 +350,14 @@ const template20 = (() => {
   _$effect(s, _v$ => {
     _el$26.value = _v$ ?? "";
   });
+  _$effect(s, _v$ => {
+    _$setAttribute(_el$26, "value", _v$);
+  });
   _$effect(s2, _v$ => {
     _el$27.checked = _v$;
+  });
+  _$effect(s2, _v$ => {
+    _$setAttribute(_el$27, "checked", _v$);
   });
   return _el$25;
 })();
@@ -552,15 +564,33 @@ const template41 = (() => {
     }
   );
   _$effect(
+    () => Color.Red,
+    _v$ => {
+      _$setAttribute(_el$56, "value", _v$);
+    }
+  );
+  _$effect(
     () => Color.Blue,
     _v$ => {
       _el$57.value = _v$;
     }
   );
   _$effect(
+    () => Color.Blue,
+    _v$ => {
+      _$setAttribute(_el$57, "value", _v$);
+    }
+  );
+  _$effect(
     () => state.color,
     _v$ => {
       queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
+    }
+  );
+  _$effect(
+    () => state.color,
+    _v$ => {
+      _$setAttribute(_el$55, "value", _v$);
     }
   );
   return _el$55;
@@ -942,6 +972,9 @@ const template93 = (() => {
     _el$122.value = _v$ ?? "";
   });
   _$effect(dynamicProperty, _v$ => {
+    _$setAttribute(_el$122, "value", _v$);
+  });
+  _$effect(dynamicProperty, _v$ => {
     _el$123.value = _v$ ?? "";
   });
   _$effect(dynamicAttribute, _v$ => {
@@ -971,7 +1004,8 @@ const template94 = (() => {
     _el$139 = _el$138.nextSibling,
     _el$140 = _el$139.nextSibling,
     _el$141 = _el$140.nextSibling;
-  _$insert(_el$138, dynamicContent);
+  _$insert(_el$137, dynamicProperty);
+  _$insert(_el$138, dynamicProperty);
   _$insert(_el$139, dynamicContent);
   _$insert(_el$141, dynamicContent);
   _$effect(dynamicProperty, _v$ => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -256,6 +256,12 @@ const template14 = (() => {
       _el$19.checked = _v$;
     }
   );
+  _$effect(
+    () => state.visible,
+    _v$ => {
+      _$setAttribute(_el$19, "checked", _v$);
+    }
+  );
   return _el$19;
 })();
 const template15 = _tmpl$10();
@@ -328,8 +334,14 @@ const template20 = (() => {
   _$effect(s, _v$ => {
     _el$26.value = _v$ ?? "";
   });
+  _$effect(s, _v$ => {
+    _$setAttribute(_el$26, "value", _v$);
+  });
   _$effect(s2, _v$ => {
     _el$27.checked = _v$;
+  });
+  _$effect(s2, _v$ => {
+    _$setAttribute(_el$27, "checked", _v$);
   });
   return _el$25;
 })();
@@ -536,15 +548,33 @@ const template41 = (() => {
     }
   );
   _$effect(
+    () => Color.Red,
+    _v$ => {
+      _$setAttribute(_el$56, "value", _v$);
+    }
+  );
+  _$effect(
     () => Color.Blue,
     _v$ => {
       _el$57.value = _v$;
     }
   );
   _$effect(
+    () => Color.Blue,
+    _v$ => {
+      _$setAttribute(_el$57, "value", _v$);
+    }
+  );
+  _$effect(
     () => state.color,
     _v$ => {
       queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
+    }
+  );
+  _$effect(
+    () => state.color,
+    _v$ => {
+      _$setAttribute(_el$55, "value", _v$);
     }
   );
   return _el$55;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -258,6 +258,12 @@ const template14 = (() => {
       _el$19.checked = _v$;
     }
   );
+  _$effect(
+    () => state.visible,
+    _v$ => {
+      _$setAttribute(_el$19, "checked", _v$);
+    }
+  );
   return _el$19;
 })();
 const template15 = _$getNextElement(_tmpl$10);
@@ -332,8 +338,14 @@ const template20 = (() => {
   _$effect(s, _v$ => {
     _el$26.value = _v$ ?? "";
   });
+  _$effect(s, _v$ => {
+    _$setAttribute(_el$26, "value", _v$);
+  });
   _$effect(s2, _v$ => {
     _el$27.checked = _v$;
+  });
+  _$effect(s2, _v$ => {
+    _$setAttribute(_el$27, "checked", _v$);
   });
   _$runHydrationEvents();
   return _el$25;
@@ -550,15 +562,33 @@ const template41 = (() => {
     }
   );
   _$effect(
+    () => Color.Red,
+    _v$ => {
+      _$setAttribute(_el$60, "value", _v$);
+    }
+  );
+  _$effect(
     () => Color.Blue,
     _v$ => {
       _el$61.value = _v$;
     }
   );
   _$effect(
+    () => Color.Blue,
+    _v$ => {
+      _$setAttribute(_el$61, "value", _v$);
+    }
+  );
+  _$effect(
     () => state.color,
     _v$ => {
       queueMicrotask(() => (_el$59.value = _v$)) || (_el$59.value = _v$);
+    }
+  );
+  _$effect(
+    () => state.color,
+    _v$ => {
+      _$setAttribute(_el$59, "value", _v$);
     }
   );
   return _el$59;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -253,6 +253,12 @@ const template14 = (() => {
       _el$19.checked = _v$;
     }
   );
+  _$effect(
+    () => state.visible,
+    _v$ => {
+      _$setAttribute(_el$19, "checked", _v$);
+    }
+  );
   return _el$19;
 })();
 const template15 = _tmpl$10();
@@ -325,8 +331,14 @@ const template20 = (() => {
   _$effect(s, _v$ => {
     _el$26.value = _v$ ?? "";
   });
+  _$effect(s, _v$ => {
+    _$setAttribute(_el$26, "value", _v$);
+  });
   _$effect(s2, _v$ => {
     _el$27.checked = _v$;
+  });
+  _$effect(s2, _v$ => {
+    _$setAttribute(_el$27, "checked", _v$);
   });
   return _el$25;
 })();
@@ -533,15 +545,33 @@ const template41 = (() => {
     }
   );
   _$effect(
+    () => Color.Red,
+    _v$ => {
+      _$setAttribute(_el$56, "value", _v$);
+    }
+  );
+  _$effect(
     () => Color.Blue,
     _v$ => {
       _el$57.value = _v$;
     }
   );
   _$effect(
+    () => Color.Blue,
+    _v$ => {
+      _$setAttribute(_el$57, "value", _v$);
+    }
+  );
+  _$effect(
     () => state.color,
     _v$ => {
       queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
+    }
+  );
+  _$effect(
+    () => state.color,
+    _v$ => {
+      _$setAttribute(_el$55, "value", _v$);
     }
   );
   return _el$55;


### PR DESCRIPTION
Related to https://github.com/ryansolid/dom-expressions/pull/493/changes

In there we were attempting to SSR stuff that wasnt defined in DOM. Issue is that adding attributes/changing childrens, will make SSR have more effects than DOM, making hydration ids drift.