### PR TITLE
[next] implements `defaultValue` and friends

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -1,7 +1,6 @@
 import * as t from "@babel/types";
 
 import {
-  DOMWithState,
   ChildProperties,
   SVGNamespace,
   DelegatedEvents,
@@ -30,7 +29,6 @@ import {
   escapeHTML,
   convertJSXIdentifier,
   transformCondition,
-  transformSpecialCaseAttributes,
   trimWhitespace,
   inlineCallExpression,
   hasStaticMarker,
@@ -110,10 +108,6 @@ export function transformElement(path, info) {
     } else {
       xmlnsAttr && xmlnsAttr.remove();
     }
-  }
-
-  if (DOMWithState[tagName.toUpperCase()]) {
-    transformSpecialCaseAttributes(path, tagName);
   }
 
   let config = getConfig(path),
@@ -298,6 +292,7 @@ export function setAttr(path, elem, name, value, { dynamic, prevId, tagName }) {
         value
       ]);
     }
+
     const assignment = t.assignmentExpression(
       "=",
       t.memberExpression(elem, t.identifier(name)),
@@ -315,12 +310,12 @@ export function setAttr(path, elem, name, value, { dynamic, prevId, tagName }) {
       );
     }
     if (
-      name === "value" &&
+      (name === "value" || name === "defaultValue") &&
       (tagName === "input" || tagName === "textarea") &&
       !t.isStringLiteral(value) &&
       !t.isNumericLiteral(value)
     ) {
-      // prevents undefined on input/textarea.value, fallback to empty string
+      // prevents undefined on input/textarea.value/defaultValue, fallback to empty string
       return t.assignmentExpression(
         "=",
         t.memberExpression(elem, t.identifier("value")),

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -318,7 +318,7 @@ export function setAttr(path, elem, name, value, { dynamic, prevId, tagName }) {
       // prevents undefined on input/textarea.value/defaultValue, fallback to empty string
       return t.assignmentExpression(
         "=",
-        t.memberExpression(elem, t.identifier("value")),
+        t.memberExpression(elem, t.identifier(name)),
         t.logicalExpression("??", value, t.stringLiteral(""))
       );
     }

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/transform.js
@@ -13,8 +13,10 @@ import {
   transformCondition,
   getStaticExpression,
   escapeHTML,
-  getConfig
+  getConfig,
+  transformSpecialCaseAttributes
 } from "./utils";
+import { DOMWithState } from "dom-expressions/src/constants";
 import transformComponent from "./component";
 import transformFragmentChildren from "./fragment";
 
@@ -24,6 +26,26 @@ export function transformJSX(path, state) {
   const config = getConfig(path);
 
   const replace = transformThis(path);
+
+  // Pre-pass: normalize stateful DOM attributes (value/defaultValue/checked/etc)
+  // BEFORE transformNode runs so the parent's detectExpressions sees the
+  // resulting `prop:*` attributes and reserves an element id when needed.
+  // Decide per-element which renderer it will go to (mirrors transformElement),
+  // so dynamic mode (generate: "dynamic" + renderers: [{ name: "dom", ... }])
+  // is handled correctly.
+  const visit = p => {
+    const tagName = getTagName(p.node);
+    if (isComponent(tagName)) return;
+    if (!DOMWithState[tagName.toUpperCase()]) return;
+    const tagRenderer = (config.renderers ?? []).find(r => r.elements.includes(tagName));
+    const willBeDOM = tagRenderer?.name === "dom" || config.generate === "dom";
+    const willBeSSR = !willBeDOM && config.generate === "ssr";
+    if (!willBeDOM && !willBeSSR) return;
+    transformSpecialCaseAttributes(p, tagName, willBeSSR);
+  };
+  if (t.isJSXElement(path.node)) visit(path);
+  path.traverse({ JSXElement: visit });
+
   const result = transformNode(
     path,
     t.isJSXFragment(path.node)

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -484,65 +484,69 @@ export function getAttributeNamed(path, name) {
 }
 
 function renameAttribute(attr, name) {
+  const original = attr.node.name;
   const [ns, propName] = name.split(":");
   if (propName) {
     attr
       .get("name")
-      .replaceWith(t.jsxNamespacedName(t.jsxIdentifier(ns), t.jsxIdentifier(propName)));
+      .replaceWith(
+        t.inherits(t.jsxNamespacedName(t.jsxIdentifier(ns), t.jsxIdentifier(propName)), original)
+      );
   } else {
-    attr.get("name").replaceWith(t.jsxIdentifier(name));
+    attr.get("name").replaceWith(t.inherits(t.jsxIdentifier(name), original));
   }
 }
 
 export function transformSpecialCaseAttributes(path, tagName, isSSR) {
   tagName = tagName.toUpperCase();
+  const transforms = [];
 
   for (const propName in DOMWithState[tagName]) {
+    if (propName.startsWith("prop:")) continue;
     const attr = getAttributeNamed(path, propName);
-    const prop = getAttributeNamed(path, "prop:" + propName);
+    if (attr) {
+      transforms.push({ propName, attr });
+    }
+  }
 
-    if (attr && !prop) {
-      /** Transforms `attr` into `prop:`. When `prop:` is not present. */
+  for (const { propName, attr } of transforms) {
+    const value = t.cloneNode(attr.node.value?.expression ?? attr.node.value);
 
-      const value = attr.node.value?.expression ? attr.node.value.expression : attr.node.value;
+    const isDefault =
+      propName.includes("default") ||
+      !getAttributeNamed(path, "default" + propName[0].toUpperCase() + propName.slice(1));
 
-      /** If value is not dynamic, leave it as is */
-      if (
-        !t.isStringLiteral(value) &&
-        !t.isNumericLiteral(value) &&
-        !t.isBooleanLiteral(value) &&
-        !t.isNullLiteral(value)
-      ) {
-        // value is dynamic
-        renameAttribute(attr, "prop:" + propName);
+    const defaultAttrName = propName.replace("default", "").toLowerCase();
 
-        // `value` is not present, only `prop:value`, SSR `value`
-        if (isSSR) {
-          // <textarea value=""/> doesnt exists
-          if (tagName === "TEXTAREA" && propName === "value") {
-            path.set("children", [t.jsxExpressionContainer(value)]);
-          } else {
-            addAttribute(path, t.jsxIdentifier(propName), t.jsxExpressionContainer(value));
-          }
-        }
+    const isLiteral =
+      t.isStringLiteral(value) ||
+      t.isNumericLiteral(value) ||
+      t.isBooleanLiteral(value) ||
+      t.isNullLiteral(value);
+
+    if (
+      isDefault &&
+      tagName === "TEXTAREA" &&
+      defaultAttrName === "value" &&
+      !t.isNullLiteral(value)
+    ) {
+      let child;
+      if (t.isStringLiteral(value)) {
+        child = t.jsxText(value.value);
+        // filterChildren reads child.extra.raw for JSXText nodes
+        child.extra = { raw: value.value, rawValue: value.value };
       } else {
-        // value is not dynamic
-        // `prop:value` is not present, only `value`
-        // <textarea value=""/> doesnt exists
-        if (tagName === "TEXTAREA" && propName === "value") {
-          attr.remove();
-          path.set("children", [t.jsxExpressionContainer(value)]);
-        }
+        child = t.jsxExpressionContainer(value);
       }
-    } else if (attr) {
-      // `prop:value` and `value` are present
-      // <textarea value=""/> doesnt exists
-      if (tagName === "TEXTAREA" && propName === "value") {
-        const value = attr.node.value?.expression ? attr.node.value.expression : attr.node.value;
-
-        attr.remove();
-        path.set("children", [t.jsxExpressionContainer(value)]);
+      path.node.children = [child];
+      attr.remove();
+    } else if (isDefault && (isLiteral || isSSR)) {
+      // should inline
+      if (propName !== defaultAttrName) {
+        renameAttribute(attr, defaultAttrName);
       }
+    } else {
+      renameAttribute(attr, "prop:" + propName);
     }
   }
 }
@@ -569,5 +573,5 @@ export function wrapWithTag(path, tagName) {
     false
   );
 
-  path.replaceWith(wrapper);
+  path.replaceWith(t.inherits(wrapper, path.node));
 }

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -528,7 +528,12 @@ export function transformSpecialCaseAttributes(path, tagName, isSSR) {
       isDefault &&
       tagName === "TEXTAREA" &&
       defaultAttrName === "value" &&
-      !t.isNullLiteral(value)
+      !t.isNullLiteral(value) &&
+      // Only fold into children when SSR (HTML output needs the text content)
+      // or when the value is a static literal (template-inlined HTML attribute
+      // on parse). For dynamic DOM, prop:* survives the textarea "dirty" flag
+      // and preserves any user-supplied children.
+      (isSSR || isLiteral)
     ) {
       let child;
       if (t.isStringLiteral(value)) {

--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
@@ -1,6 +1,6 @@
 import * as t from "@babel/types";
 import { decode } from "html-entities";
-import { ChildProperties, DOMWithState } from "dom-expressions/src/constants";
+import { ChildProperties } from "dom-expressions/src/constants";
 import VoidElements from "../VoidElements";
 import {
   evaluateAndInline,
@@ -16,8 +16,7 @@ import {
   isDynamic,
   isComponent,
   convertJSXIdentifier,
-  inlineCallExpression,
-  transformSpecialCaseAttributes
+  inlineCallExpression
 } from "../shared/utils";
 import { transformNode, getCreateTemplate } from "../shared/transform";
 import { createTemplate } from "./template";
@@ -56,10 +55,6 @@ export function transformElement(path, info) {
     .forEach(attr => {
       evaluateAndInline(attr.node.value, attr.get("value"));
     });
-
-  if (DOMWithState[tagName.toUpperCase()]) {
-    transformSpecialCaseAttributes(path, tagName, true);
-  }
 
   const config = getConfig(path);
   if (tagName === "script" || tagName === "style") path.doNotEscape = true;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
@@ -363,38 +363,29 @@ const template91 = <video something={{value:{value:1+1}}}/>
 const template92 = <div style="duplicate1" style="duplicate2"/>
 
 const template93 = <div>
-  static inlined, prop:value in effect
-  <input value="static attribute" prop:value={dynamicProperty()}/>
-  value in effect, prop:value inlined
-  <input value={dynamicAttribute()} prop:value="static property"/>
-  static
-  <input value={"static attribute"}/>
-  <input prop:value={"static property"}/>
-  dynamic property
+  <input defaultValue="static attribute" value={dynamicProperty()}/>
+  <input defaultValue={dynamicAttribute()} value="static property"/>
+  <input defaultValue={"static attribute"}/>
+  <input value={"static property"}/>
   <input value={dynamicProperty()}/>
-  <input prop:value={dynamicProperty()}/>
-  dynamic attribute/property
-  <input value={dynamicAttribute()} prop:value={dynamicProperty()}/>
-  inlined muted
+  <input defaultValue={dynamicAttribute()} value={dynamicProperty()}/>
+  <video defaultMuted={true}/>
+  <video defaultMuted={false}/>
   <video muted={true}/>
-  not inlined muted
   <video muted={false}/>
-  not inlined muted dynamic muted property
-  <video muted={false} prop:muted={dynamicProperty()}/>
-  inlined muted dynamic muted property
-  <video muted={true} prop:muted={dynamicProperty()}/>
-  dynamic attribute muted, dynamic muted property
-  <video muted={dynamicAttribute()} prop:muted={dynamicProperty()}/>
+  <video defaultMuted={false} muted={dynamicProperty()}/>
+  <video defaultMuted={true} muted={dynamicProperty()}/>
+  <video defaultMuted={dynamicAttribute()} muted={dynamicProperty()}/>
 </div>
 
 const template94 = <div>
   <textarea value={dynamicProperty()}/>
   <textarea value={dynamicProperty()}>{dynamicContent()}</textarea>
-  <textarea value={dynamicContent()} prop:value={dynamicProperty()}/>
-  <textarea prop:value={dynamicProperty()}/>
+  <textarea defaultValue={dynamicContent()} value={dynamicProperty()}/>
+  <textarea value={dynamicProperty()}/>
   <textarea>{dynamicContent()}</textarea>
-  <textarea value="static content"/>
-  <textarea value="static content">I get replaced</textarea>
+  <textarea defaultValue="static content"/>
+  <textarea defaultValue="static content">I get replaced</textarea>
 </div>
 
 const template95 = <a xmlns="http://www.w3.org/2000/svg">xml link partial</a>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -68,7 +68,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div><h1><a href="/">Welcome</a></h1></di
   _tmpl$49 = /*#__PURE__*/ _$template(`<div style="a:clamp(2px, 2px, 2px)"></div>`),
   _tmpl$50 = /*#__PURE__*/ _$template(`<div style="duplicate2"></div>`),
   _tmpl$51 = /*#__PURE__*/ _$template(
-    `<div>static inlined, prop:value in effect<input value="static attribute">value in effect, prop:value inlined<input>static<input value="static attribute"><input>dynamic property<input><input>dynamic attribute/property<input>inlined muted<video muted></video>not inlined muted<video></video>not inlined muted dynamic muted property<video></video>inlined muted dynamic muted property<video muted></video>dynamic attribute muted, dynamic muted property<video></video></div>`
+    `<div><input value="static attribute"><input><input value="static attribute"><input value="static property"><input><input><video muted></video><video></video><video muted></video><video></video><video></video><video muted></video><video></video></div>`
   ),
   _tmpl$52 = /*#__PURE__*/ _$template(
     `<div><textarea></textarea><textarea></textarea><textarea></textarea><textarea></textarea><textarea></textarea><textarea>static content</textarea><textarea>static content</textarea></div>`
@@ -899,73 +899,53 @@ const template93 = (() => {
     _el$123 = _el$122.nextSibling,
     _el$124 = _el$123.nextSibling,
     _el$125 = _el$124.nextSibling,
-    _el$126 = _el$125.nextSibling,
-    _el$127 = _el$126.nextSibling,
-    _el$128 = _el$127.nextSibling,
-    _el$129 = _el$128.nextSibling,
-    _el$130 = _el$129.nextSibling,
-    _el$131 = _el$130.nextSibling,
-    _el$132 = _el$131.nextSibling,
-    _el$133 = _el$132.nextSibling,
-    _el$134 = _el$133.nextSibling,
-    _el$135 = _el$134.nextSibling;
-  _el$117.value = "static property";
-  _el$120.value = "static property";
+    _el$126 = _el$125.nextSibling;
+  _el$115.value = "static property";
   _$effect(dynamicProperty, _v$ => {
+    _el$114.value = _v$ ?? "";
+  });
+  _$effect(dynamicAttribute, _v$ => {
     _el$115.value = _v$ ?? "";
   });
-  _$effect(dynamicAttribute, _v$ => {
-    _$setAttribute(_el$117, "value", _v$);
-  });
   _$effect(dynamicProperty, _v$ => {
-    _el$122.value = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$123.value = _v$ ?? "";
+    _el$118.value = _v$ ?? "";
   });
   _$effect(dynamicAttribute, _v$ => {
-    _$setAttribute(_el$125, "value", _v$);
+    _el$119.value = _v$ ?? "";
   });
   _$effect(dynamicProperty, _v$ => {
-    _el$125.value = _v$ ?? "";
+    _el$119.value = _v$ ?? "";
   });
   _$effect(dynamicProperty, _v$ => {
-    _el$131.muted = _v$;
+    _el$124.muted = _v$;
   });
   _$effect(dynamicProperty, _v$ => {
-    _el$133.muted = _v$;
+    _el$125.muted = _v$;
   });
   _$effect(dynamicAttribute, _v$ => {
-    _$setAttribute(_el$135, "muted", _v$);
+    _el$126.defaultMuted = _v$;
   });
   _$effect(dynamicProperty, _v$ => {
-    _el$135.muted = _v$;
+    _el$126.muted = _v$;
   });
   return _el$113;
 })();
 const template94 = (() => {
-  var _el$136 = _tmpl$52(),
-    _el$137 = _el$136.firstChild,
-    _el$138 = _el$137.nextSibling,
-    _el$139 = _el$138.nextSibling,
-    _el$140 = _el$139.nextSibling,
-    _el$141 = _el$140.nextSibling;
-  _$insert(_el$138, dynamicContent);
-  _$insert(_el$139, dynamicContent);
-  _$insert(_el$141, dynamicContent);
+  var _el$127 = _tmpl$52(),
+    _el$128 = _el$127.firstChild,
+    _el$129 = _el$128.nextSibling,
+    _el$130 = _el$129.nextSibling,
+    _el$131 = _el$130.nextSibling,
+    _el$132 = _el$131.nextSibling;
+  _$insert(_el$128, dynamicProperty);
+  _$insert(_el$129, dynamicProperty);
+  _$insert(_el$130, dynamicContent);
+  _$insert(_el$131, dynamicProperty);
+  _$insert(_el$132, dynamicContent);
   _$effect(dynamicProperty, _v$ => {
-    _el$137.value = _v$ ?? "";
+    _el$130.value = _v$ ?? "";
   });
-  _$effect(dynamicProperty, _v$ => {
-    _el$138.value = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$139.value = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$140.value = _v$ ?? "";
-  });
-  return _el$136;
+  return _el$127;
 })();
 const template95 = _tmpl$53();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -937,13 +937,22 @@ const template94 = (() => {
     _el$130 = _el$129.nextSibling,
     _el$131 = _el$130.nextSibling,
     _el$132 = _el$131.nextSibling;
-  _$insert(_el$128, dynamicProperty);
-  _$insert(_el$129, dynamicProperty);
-  _$insert(_el$130, dynamicContent);
-  _$insert(_el$131, dynamicProperty);
+  _$insert(_el$129, dynamicContent);
   _$insert(_el$132, dynamicContent);
   _$effect(dynamicProperty, _v$ => {
+    _el$128.value = _v$ ?? "";
+  });
+  _$effect(dynamicProperty, _v$ => {
+    _el$129.value = _v$ ?? "";
+  });
+  _$effect(dynamicContent, _v$ => {
+    _el$130.defaultValue = _v$ ?? "";
+  });
+  _$effect(dynamicProperty, _v$ => {
     _el$130.value = _v$ ?? "";
+  });
+  _$effect(dynamicProperty, _v$ => {
+    _el$131.value = _v$ ?? "";
   });
   return _el$127;
 })();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -905,13 +905,13 @@ const template93 = (() => {
     _el$114.value = _v$ ?? "";
   });
   _$effect(dynamicAttribute, _v$ => {
-    _el$115.value = _v$ ?? "";
+    _el$115.defaultValue = _v$ ?? "";
   });
   _$effect(dynamicProperty, _v$ => {
     _el$118.value = _v$ ?? "";
   });
   _$effect(dynamicAttribute, _v$ => {
-    _el$119.value = _v$ ?? "";
+    _el$119.defaultValue = _v$ ?? "";
   });
   _$effect(dynamicProperty, _v$ => {
     _el$119.value = _v$ ?? "";

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
@@ -24,7 +24,7 @@ var _tmpl$ = ['<a href="/" class="', '">Welcome</a>'],
   _tmpl$14 = ['<button class="', '" type="button">Write</button>'],
   _tmpl$15 = ['<button class="', '">Hi</button>'],
   _tmpl$16 = ['<div class="', '"></div>'],
-  _tmpl$17 = ["<div><input", "", " readonly", "><input", "", "", "", "></div>"],
+  _tmpl$17 = ["<div><input", "", "", " readonly><input", "", "", "", "></div>"],
   _tmpl$18 = ['<div style="', '"></div>'],
   _tmpl$19 = '<div data="&quot;hi&quot;" data2="&quot;"></div>',
   _tmpl$20 = ["<div", ">", "</div>"],
@@ -227,23 +227,23 @@ const template19 = _$ssr(
   ])
 );
 const template20 = (() => {
-  var _v$9 = _$ssrRunInScope([
+  var _v$10 = _$ssrRunInScope([
       () => _$ssrAttribute("min", _$escape(min(), true)),
       () => _$ssrAttribute("max", _$escape(max(), true)),
       () => _$ssrAttribute("min", _$escape(min(), true)),
       () => _$ssrAttribute("max", _$escape(max(), true))
     ]),
-    _v$10 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(s(), true))),
+    _v$9 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(s(), true))),
     _v$11 = _$ssrRunInScope(() => _$ssrAttribute("checked", _$escape(s2(), true)));
   return _$ssr(
     _tmpl$17,
-    _v$9[0],
-    _v$9[1],
-    _v$10,
-    _v$9[2],
-    _v$9[3],
-    _$ssrAttribute("readonly", _$escape(value, true)),
-    _v$11
+    _v$9,
+    _v$10[0],
+    _v$10[1],
+    _v$11,
+    _v$10[2],
+    _v$10[3],
+    _$ssrAttribute("readonly", _$escape(value, true))
   );
 })();
 const template21 = (() => {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
@@ -25,7 +25,7 @@ var _tmpl$ = ['<a href="/" class="', '">Welcome</a>'],
   _tmpl$14 = ["<button", ' class="', '" type="button">Write</button>'],
   _tmpl$15 = ["<button", ' class="', '">Hi</button>'],
   _tmpl$16 = ["<div", ' class="', '"></div>'],
-  _tmpl$17 = ["<div", "><input", "", " readonly", "><input", "", "", "", "></div>"],
+  _tmpl$17 = ["<div", "><input", "", "", " readonly><input", "", "", "", "></div>"],
   _tmpl$18 = ["<div", ' style="', '"></div>'],
   _tmpl$19 = ["<div", ' data="&quot;hi&quot;" data2="&quot;"></div>'],
   _tmpl$20 = ["<div", "", ">", "</div>"],
@@ -255,24 +255,24 @@ const template19 = (() => {
 })();
 const template20 = (() => {
   var _v$24 = _$ssrHydrationKey(),
-    _v$25 = _$ssrRunInScope([
+    _v$26 = _$ssrRunInScope([
       () => _$ssrAttribute("min", _$escape(min(), true)),
       () => _$ssrAttribute("max", _$escape(max(), true)),
       () => _$ssrAttribute("min", _$escape(min(), true)),
       () => _$ssrAttribute("max", _$escape(max(), true))
     ]),
-    _v$26 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(s(), true))),
+    _v$25 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(s(), true))),
     _v$27 = _$ssrRunInScope(() => _$ssrAttribute("checked", _$escape(s2(), true)));
   return _$ssr(
     _tmpl$17,
     _v$24,
-    _v$25[0],
-    _v$25[1],
-    _v$26,
-    _v$25[2],
-    _v$25[3],
-    _$ssrAttribute("readonly", _$escape(value, true)),
-    _v$27
+    _v$25,
+    _v$26[0],
+    _v$26[1],
+    _v$27,
+    _v$26[2],
+    _v$26[3],
+    _$ssrAttribute("readonly", _$escape(value, true))
   );
 })();
 const template21 = (() => {

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -265,7 +265,7 @@ export function assign(node, props, skipChildren, prevProps = {}, skipRef = fals
   for (const prop in prevProps) {
     if (!(prop in props)) {
       if (prop === "children") continue;
-      prevProps[prop] = assignProp(node, prop, null, prevProps[prop], skipRef, nodeName, prevProps);
+      prevProps[prop] = assignProp(node, prop, null, prevProps[prop], skipRef, nodeName);
     }
   }
   for (const prop in props) {
@@ -273,15 +273,7 @@ export function assign(node, props, skipChildren, prevProps = {}, skipRef = fals
       if (!skipChildren) insertExpression(node, props.children);
       continue;
     }
-    prevProps[prop] = assignProp(
-      node,
-      prop,
-      props[prop],
-      prevProps[prop],
-      skipRef,
-      nodeName,
-      props
-    );
+    prevProps[prop] = assignProp(node, prop, props[prop], prevProps[prop], skipRef, nodeName);
   }
 }
 
@@ -496,10 +488,11 @@ function flattenClassList(list, result) {
   }
 }
 
-function assignProp(node, prop, value, prev, skipRef, nodeName, props) {
+function assignProp(node, prop, value, prev, skipRef, nodeName) {
   if (prop === "style") return (style(node, value, prev), value);
   if (prop === "class") return (className(node, value, prev), value);
   // dom with state may differs from reactive state
+  // reactive state is the source of truth
   if (value === prev && !DOMWithState[nodeName]?.[prop]) return prev;
   if (prop === "ref") {
     if (!skipRef && value) ref(() => value, node);
@@ -512,7 +505,7 @@ function assignProp(node, prop, value, prev, skipRef, nodeName, props) {
     const e = prop.slice(3);
     prev && node.removeEventListener(e, prev, typeof prev !== "function" && prev);
     value && node.addEventListener(e, value, typeof value !== "function" && value);
-  } else if (prop.slice(0, 2) === "on") {
+  } else if (!hasNamespace && prop.slice(0, 2) === "on") {
     const name = prop.slice(2).toLowerCase();
     const delegate = DelegatedEvents.has(name);
     if (!delegate && prev) {
@@ -526,7 +519,7 @@ function assignProp(node, prop, value, prev, skipRef, nodeName, props) {
   } else if (
     (hasNamespace && prop.slice(0, 5) === "prop:") ||
     ChildProperties.has(prop) ||
-    (DOMWithState[nodeName]?.[prop] && !("prop:" + prop in props))
+    DOMWithState[nodeName]?.[prop]
   ) {
     if (hasNamespace) prop = prop.slice(5);
     else if (isHydrating(node)) return value; // TODO IS this correct?

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -1,11 +1,19 @@
 const DOMWithState = {
-  INPUT: { value: 1, checked: 1 },
+  INPUT: { value: 1, defaultValue: 1, checked: 1, defaultChecked: 1 },
   SELECT: { value: 1 },
-  OPTION: { value: 1, selected: 1 },
-  TEXTAREA: { value: 1 },
-  VIDEO: { muted: 1 },
-  AUDIO: { muted: 1 }
+  OPTION: { value: 1, selected: 1, defaultSelected: 1 },
+  TEXTAREA: { value: 1, defaultValue: 1 },
+  VIDEO: { muted: 1, defaultMuted: 1 },
+  AUDIO: { muted: 1, defaultMuted: 1 }
 };
+
+// this is for spreads, spreads will receive "prop:value" and "value"
+// either we do this here once or in spreads remove `prop:` from every key name
+for (const tagName in DOMWithState) {
+  for (const propName in DOMWithState[tagName]) {
+    DOMWithState[tagName]["prop:" + propName] = 1;
+  }
+}
 
 const ChildProperties = /*#__PURE__*/ new Set([
   "innerHTML",

--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -165,7 +165,8 @@ export namespace JSX {
   > = EHandler | BoundEventHandler<T, E, EHandler>;
 
   interface EventHandlerWithOptions<T, E extends Event, EHandler = EventHandler<T, E>>
-    extends AddEventListenerOptions, EventListenerOptions {
+    extends AddEventListenerOptions,
+      EventListenerOptions {
     handleEvent: EHandler;
   }
 
@@ -994,15 +995,15 @@ export namespace JSX {
         ? K extends `on:${infer T}`
           ? T
           : K extends `on${infer T}`
-            ? Lowercase<T>
-            : never
+          ? Lowercase<T>
+          : never
         : never)
     | (keyof EventHandlersElement<any> extends infer K
         ? K extends `on:${infer T}`
           ? T
           : K extends `on${infer T}`
-            ? Lowercase<T>
-            : never
+          ? Lowercase<T>
+          : never
         : never)
     | (string & {});
 
@@ -1026,8 +1027,7 @@ export namespace JSX {
    * 2. Includes `keys` defined by `Element` and `Node` interfaces.
    */
   interface ElementAttributes<T>
-    extends
-      CustomAttributes<T>,
+    extends CustomAttributes<T>,
       PropAttributes,
       OnAttributes<T>,
       EventHandlersElement<T>,
@@ -1526,8 +1526,7 @@ export namespace JSX {
     alt?: FunctionMaybe<string | RemoveAttribute>;
     autocomplete?: FunctionMaybe<HTMLAutocomplete | RemoveAttribute>;
     capture?: FunctionMaybe<"user" | "environment" | RemoveAttribute>;
-    checked?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
-    "prop:checked"?: FunctionMaybe<BooleanProperty | RemoveProperty>;
+
     colorspace?: FunctionMaybe<string | RemoveAttribute>;
     dirname?: FunctionMaybe<string | RemoveAttribute>;
     disabled?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
@@ -1582,8 +1581,6 @@ export namespace JSX {
       | (string & {})
       | RemoveAttribute
     >;
-    value?: FunctionMaybe<string | string[] | number | RemoveAttribute>;
-    "prop:value"?: FunctionMaybe<string | string[] | number | RemoveProperty>;
     width?: FunctionMaybe<number | string | RemoveAttribute>;
 
     /** @non-standard */
@@ -1593,6 +1590,24 @@ export namespace JSX {
     align?: FunctionMaybe<string | RemoveAttribute>;
     /** @deprecated */
     usemap?: FunctionMaybe<string | RemoveAttribute>;
+
+    // special cases locked to properties
+
+    checked?: FunctionMaybe<BooleanProperty | RemoveProperty>;
+    /** @error use `<input checked={..}/>` instead */
+    "prop:checked"?: never;
+
+    defaultChecked?: FunctionMaybe<BooleanProperty | RemoveProperty>;
+    /** @error use `<input defaultChecked={..}/>` instead */
+    "prop:defaultChecked"?: never;
+
+    value?: FunctionMaybe<string | string[] | number | RemoveProperty>;
+    /** @error use `<input value={..}/>` instead */
+    "prop:value"?: never;
+
+    defaultValue?: FunctionMaybe<string | string[] | number | RemoveProperty>;
+    /** @error use `<input defaultValue={..}/>` instead */
+    "prop:defaultValue"?: never;
   }
   interface ModHTMLAttributes<T> extends HTMLAttributes<T> {
     cite?: FunctionMaybe<string | RemoveAttribute>;
@@ -1663,8 +1678,7 @@ export namespace JSX {
     crossorigin?: FunctionMaybe<HTMLCrossorigin | RemoveAttribute>;
     disableremoteplayback?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
     loop?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
-    muted?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
-    "prop:muted"?: FunctionMaybe<BooleanProperty | RemoveProperty>;
+
     preload?: FunctionMaybe<
       "none" | "metadata" | "auto" | EnumeratedAcceptsEmpty | RemoveAttribute
     >;
@@ -1678,6 +1692,16 @@ export namespace JSX {
 
     /** @deprecated */
     mediagroup?: FunctionMaybe<string | RemoveAttribute>;
+
+    // special cases locked to properties
+
+    muted?: FunctionMaybe<BooleanProperty | RemoveProperty>;
+    /** @error use `<video/audio muted={..}/>` instead */
+    "prop:muted"?: never;
+
+    defaultMuted?: FunctionMaybe<BooleanProperty | RemoveProperty>;
+    /** @error use `<video/audio defaultMuted={..}/>` instead */
+    "prop:defaultMuted"?: never;
   }
   interface MenuHTMLAttributes<T> extends HTMLAttributes<T> {
     /** @deprecated */
@@ -1770,10 +1794,27 @@ export namespace JSX {
   interface OptionHTMLAttributes<T> extends HTMLAttributes<T> {
     disabled?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
     label?: FunctionMaybe<string | RemoveAttribute>;
-    selected?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
-    "prop:selected"?: FunctionMaybe<BooleanProperty | RemoveProperty>;
-    value?: FunctionMaybe<string | string[] | number | RemoveAttribute>;
-    "prop:value"?: FunctionMaybe<string | string[] | number | RemoveProperty>;
+
+    // special cases locked to properties
+
+    selected?: FunctionMaybe<BooleanProperty | RemoveProperty>;
+    /** @error use `<option selected={..}/>` instead */
+    "prop:selected"?: never;
+
+    defaultSelected?: FunctionMaybe<BooleanProperty | RemoveProperty>;
+    /** @error use `<option defaultSelected={..}/>` instead */
+    "prop:defaultSelected"?: never;
+
+    value?: FunctionMaybe<string | string[] | number | RemoveProperty>;
+    /** @error use `<option value={..}/>` instead */
+    "prop:value"?: never;
+
+    // for sanity
+
+    /** @error This doesn't exists for `<option/>` */
+    "prop:defaultValue"?: never;
+    /** @error This doesn't exists for `<option/>` */
+    defaultValue?: never;
   }
   interface OutputHTMLAttributes<T> extends HTMLAttributes<T> {
     for?: FunctionMaybe<string | RemoveAttribute>;
@@ -1827,8 +1868,24 @@ export namespace JSX {
     name?: FunctionMaybe<string | RemoveAttribute>;
     required?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
     size?: FunctionMaybe<number | string | RemoveAttribute>;
-    value?: FunctionMaybe<string | string[] | number | RemoveAttribute>;
-    "prop:value"?: FunctionMaybe<string | string[] | number | RemoveProperty>;
+
+    // special cases locked to properties
+
+    value?: FunctionMaybe<string | string[] | number | RemoveProperty>;
+    /** @error use `<select value={..}/>` instead */
+    "prop:value"?: never;
+
+    // for sanity
+
+    /** @error use `<option defaultSelected={..}/>` instead */
+    defaultSelected?: never;
+    /** @error use `<option defaultSelected={..}/>` instead */
+    "prop:defaultSelected"?: never;
+
+    /** @error use `<option defaultSelected={..}/>` instead */
+    selected?: never;
+    /** @error use `<option defaultSelected={..}/>` instead */
+    "prop:selected"?: never;
   }
   interface HTMLSlotElementAttributes<T> extends HTMLAttributes<T> {
     name?: FunctionMaybe<string | RemoveAttribute>;
@@ -1902,9 +1959,17 @@ export namespace JSX {
     readonly?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
     required?: FunctionMaybe<BooleanAttribute | RemoveAttribute>;
     rows?: FunctionMaybe<number | string | RemoveAttribute>;
-    value?: FunctionMaybe<string | string[] | number | RemoveAttribute>;
-    "prop:value"?: FunctionMaybe<string | string[] | number | RemoveProperty>;
     wrap?: FunctionMaybe<"hard" | "soft" | "off" | RemoveAttribute>;
+
+    // special cases locked to properties
+
+    value?: FunctionMaybe<string | string[] | number | RemoveProperty>;
+    /** @error use `<textarea value={..}/>` instead */
+    "prop:value"?: never;
+
+    defaultValue?: FunctionMaybe<string | string[] | number | RemoveProperty>;
+    /** @error use `<textarea defaultValue={..}/>` instead */
+    "prop:defaultValue"?: never;
   }
   interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
     abbr?: FunctionMaybe<string | RemoveAttribute>;
@@ -2234,7 +2299,9 @@ export namespace JSX {
     visibility?: FunctionMaybe<"visible" | "hidden" | "collapse" | "inherit" | RemoveAttribute>;
   }
   interface AnimationElementSVGAttributes<T>
-    extends SVGAttributes<T>, ExternalResourceSVGAttributes, ConditionalProcessingSVGAttributes {
+    extends SVGAttributes<T>,
+      ExternalResourceSVGAttributes,
+      ConditionalProcessingSVGAttributes {
     // TODO TimeEvent is currently undefined on TS
     onBegin?: EventHandlerUnion<T, Event> | undefined;
     "on:begin"?: EventHandlerWithOptionsUnion<T, Event> | undefined;
@@ -2248,8 +2315,7 @@ export namespace JSX {
     "on:repeat"?: EventHandlerWithOptionsUnion<T, Event> | undefined;
   }
   interface ContainerElementSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
@@ -2263,7 +2329,8 @@ export namespace JSX {
         | "color-rendering"
       > {}
   interface FilterPrimitiveElementSVGAttributes<T>
-    extends SVGAttributes<T>, Pick<PresentationSVGAttributes, "color-interpolation-filters"> {
+    extends SVGAttributes<T>,
+      Pick<PresentationSVGAttributes, "color-interpolation-filters"> {
     height?: FunctionMaybe<number | string | RemoveAttribute>;
     result?: FunctionMaybe<string | RemoveAttribute>;
     width?: FunctionMaybe<number | string | RemoveAttribute>;
@@ -2282,15 +2349,16 @@ export namespace JSX {
     viewBox?: FunctionMaybe<string | RemoveAttribute>;
   }
   interface GradientElementSVGAttributes<T>
-    extends SVGAttributes<T>, ExternalResourceSVGAttributes, StylableSVGAttributes {
+    extends SVGAttributes<T>,
+      ExternalResourceSVGAttributes,
+      StylableSVGAttributes {
     gradientTransform?: FunctionMaybe<string | RemoveAttribute>;
     gradientUnits?: FunctionMaybe<SVGUnits | RemoveAttribute>;
     href?: FunctionMaybe<string | RemoveAttribute>;
     spreadMethod?: FunctionMaybe<"pad" | "reflect" | "repeat" | RemoveAttribute>;
   }
   interface GraphicsElementSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
         | "clip-rule"
@@ -2306,12 +2374,12 @@ export namespace JSX {
       > {}
   interface LightSourceElementSVGAttributes<T> extends SVGAttributes<T> {}
   interface NewViewportSVGAttributes<T>
-    extends SVGAttributes<T>, Pick<PresentationSVGAttributes, "overflow" | "clip"> {
+    extends SVGAttributes<T>,
+      Pick<PresentationSVGAttributes, "overflow" | "clip"> {
     viewBox?: FunctionMaybe<string | RemoveAttribute>;
   }
   interface ShapeElementSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
         | "color"
@@ -2330,8 +2398,7 @@ export namespace JSX {
         | "pathLength"
       > {}
   interface TextContentElementSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
         | "font-family"
@@ -2372,16 +2439,14 @@ export namespace JSX {
     zoomAndPan?: FunctionMaybe<"disable" | "magnify" | RemoveAttribute>;
   }
   interface AnimateSVGAttributes<T>
-    extends
-      AnimationElementSVGAttributes<T>,
+    extends AnimationElementSVGAttributes<T>,
       AnimationAttributeTargetSVGAttributes,
       AnimationTimingSVGAttributes,
       AnimationValueSVGAttributes,
       AnimationAdditionSVGAttributes,
       Pick<PresentationSVGAttributes, "color-interpolation" | "color-rendering"> {}
   interface AnimateMotionSVGAttributes<T>
-    extends
-      AnimationElementSVGAttributes<T>,
+    extends AnimationElementSVGAttributes<T>,
       AnimationTimingSVGAttributes,
       AnimationValueSVGAttributes,
       AnimationAdditionSVGAttributes {
@@ -2391,8 +2456,7 @@ export namespace JSX {
     rotate?: FunctionMaybe<number | string | "auto" | "auto-reverse" | RemoveAttribute>;
   }
   interface AnimateTransformSVGAttributes<T>
-    extends
-      AnimationElementSVGAttributes<T>,
+    extends AnimationElementSVGAttributes<T>,
       AnimationAttributeTargetSVGAttributes,
       AnimationTimingSVGAttributes,
       AnimationValueSVGAttributes,
@@ -2400,8 +2464,7 @@ export namespace JSX {
     type?: FunctionMaybe<"translate" | "scale" | "rotate" | "skewX" | "skewY" | RemoveAttribute>;
   }
   interface CircleSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       StylableSVGAttributes,
@@ -2412,8 +2475,7 @@ export namespace JSX {
     r?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface ClipPathSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2422,16 +2484,14 @@ export namespace JSX {
     clipPathUnits?: FunctionMaybe<SVGUnits | RemoveAttribute>;
   }
   interface DefsSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
       TransformableSVGAttributes {}
   interface DescSVGAttributes<T> extends SVGAttributes<T>, StylableSVGAttributes {}
   interface EllipseSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2444,15 +2504,13 @@ export namespace JSX {
     ry?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeBlendSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       DoubleInputFilterSVGAttributes,
       StylableSVGAttributes {
     mode?: FunctionMaybe<"normal" | "multiply" | "screen" | "darken" | "lighten" | RemoveAttribute>;
   }
   interface FeColorMatrixSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     type?: FunctionMaybe<
@@ -2461,13 +2519,11 @@ export namespace JSX {
     values?: FunctionMaybe<string | RemoveAttribute>;
   }
   interface FeComponentTransferSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {}
   interface FeCompositeSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       DoubleInputFilterSVGAttributes,
       StylableSVGAttributes {
     k1?: FunctionMaybe<number | string | RemoveAttribute>;
@@ -2479,8 +2535,7 @@ export namespace JSX {
     >;
   }
   interface FeConvolveMatrixSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     bias?: FunctionMaybe<number | string | RemoveAttribute>;
@@ -2494,8 +2549,7 @@ export namespace JSX {
     targetY?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeDiffuseLightingSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "lighting-color"> {
@@ -2504,8 +2558,7 @@ export namespace JSX {
     surfaceScale?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeDisplacementMapSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       DoubleInputFilterSVGAttributes,
       StylableSVGAttributes {
     scale?: FunctionMaybe<number | string | RemoveAttribute>;
@@ -2517,8 +2570,7 @@ export namespace JSX {
     elevation?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeDropShadowSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       FilterPrimitiveElementSVGAttributes<T>,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "flood-color" | "flood-opacity"> {
@@ -2527,8 +2579,7 @@ export namespace JSX {
     stdDeviation?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeFloodSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "flood-color" | "flood-opacity"> {}
   interface FeFuncSVGAttributes<T> extends SVGAttributes<T> {
@@ -2541,34 +2592,31 @@ export namespace JSX {
     type?: FunctionMaybe<"identity" | "table" | "discrete" | "linear" | "gamma" | RemoveAttribute>;
   }
   interface FeGaussianBlurSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     stdDeviation?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeImageSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes {
     href?: FunctionMaybe<string | RemoveAttribute>;
     preserveAspectRatio?: FunctionMaybe<SVGPreserveAspectRatio | RemoveAttribute>;
   }
   interface FeMergeSVGAttributes<T>
-    extends FilterPrimitiveElementSVGAttributes<T>, StylableSVGAttributes {}
+    extends FilterPrimitiveElementSVGAttributes<T>,
+      StylableSVGAttributes {}
   interface FeMergeNodeSVGAttributes<T> extends SVGAttributes<T>, SingleInputFilterSVGAttributes {}
   interface FeMorphologySVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     operator?: FunctionMaybe<"erode" | "dilate" | RemoveAttribute>;
     radius?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeOffsetSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     dx?: FunctionMaybe<number | string | RemoveAttribute>;
@@ -2580,8 +2628,7 @@ export namespace JSX {
     z?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeSpecularLightingSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "lighting-color"> {
@@ -2601,12 +2648,12 @@ export namespace JSX {
     z?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface FeTileSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {}
   interface FeTurbulanceSVGAttributes<T>
-    extends FilterPrimitiveElementSVGAttributes<T>, StylableSVGAttributes {
+    extends FilterPrimitiveElementSVGAttributes<T>,
+      StylableSVGAttributes {
     baseFrequency?: FunctionMaybe<number | string | RemoveAttribute>;
     numOctaves?: FunctionMaybe<number | string | RemoveAttribute>;
     seed?: FunctionMaybe<number | string | RemoveAttribute>;
@@ -2614,7 +2661,9 @@ export namespace JSX {
     type?: FunctionMaybe<"fractalNoise" | "turbulence" | RemoveAttribute>;
   }
   interface FilterSVGAttributes<T>
-    extends SVGAttributes<T>, ExternalResourceSVGAttributes, StylableSVGAttributes {
+    extends SVGAttributes<T>,
+      ExternalResourceSVGAttributes,
+      StylableSVGAttributes {
     filterRes?: FunctionMaybe<number | string | RemoveAttribute>;
     filterUnits?: FunctionMaybe<SVGUnits | RemoveAttribute>;
     height?: FunctionMaybe<number | string | RemoveAttribute>;
@@ -2624,8 +2673,7 @@ export namespace JSX {
     y?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface ForeignObjectSVGAttributes<T>
-    extends
-      NewViewportSVGAttributes<T>,
+    extends NewViewportSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2637,16 +2685,14 @@ export namespace JSX {
     y?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface GSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
       TransformableSVGAttributes,
       Pick<PresentationSVGAttributes, "clip-path" | "display" | "visibility"> {}
   interface ImageSVGAttributes<T>
-    extends
-      NewViewportSVGAttributes<T>,
+    extends NewViewportSVGAttributes<T>,
       GraphicsElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       StylableSVGAttributes,
@@ -2660,8 +2706,7 @@ export namespace JSX {
     y?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface LineSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2680,8 +2725,7 @@ export namespace JSX {
     y2?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface MarkerSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
       FitToViewBoxSVGAttributes,
@@ -2694,8 +2738,7 @@ export namespace JSX {
     refY?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface MaskSVGAttributes<T>
-    extends
-      Omit<ContainerElementSVGAttributes<T>, "opacity" | "filter">,
+    extends Omit<ContainerElementSVGAttributes<T>, "opacity" | "filter">,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2710,8 +2753,7 @@ export namespace JSX {
   interface MetadataSVGAttributes<T> extends SVGAttributes<T> {}
   interface MPathSVGAttributes<T> extends SVGAttributes<T> {}
   interface PathSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2722,8 +2764,7 @@ export namespace JSX {
     pathLength?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface PatternSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2739,8 +2780,7 @@ export namespace JSX {
     y?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface PolygonSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2750,8 +2790,7 @@ export namespace JSX {
     points?: FunctionMaybe<string | RemoveAttribute>;
   }
   interface PolylineSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2768,8 +2807,7 @@ export namespace JSX {
     r?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface RectSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2784,17 +2822,17 @@ export namespace JSX {
     y?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface SetSVGAttributes<T>
-    extends AnimationElementSVGAttributes<T>, StylableSVGAttributes, AnimationTimingSVGAttributes {}
+    extends AnimationElementSVGAttributes<T>,
+      StylableSVGAttributes,
+      AnimationTimingSVGAttributes {}
   interface StopSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "stop-color" | "stop-opacity"> {
     offset?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface SvgSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       NewViewportSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2817,16 +2855,14 @@ export namespace JSX {
     version?: FunctionMaybe<string | RemoveAttribute>;
   }
   interface SwitchSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
       TransformableSVGAttributes,
       Pick<PresentationSVGAttributes, "display" | "visibility"> {}
   interface SymbolSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       NewViewportSVGAttributes<T>,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2842,8 +2878,7 @@ export namespace JSX {
     y?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface TextSVGAttributes<T>
-    extends
-      TextContentElementSVGAttributes<T>,
+    extends TextContentElementSVGAttributes<T>,
       GraphicsElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2859,8 +2894,7 @@ export namespace JSX {
     y?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface TextPathSVGAttributes<T>
-    extends
-      TextContentElementSVGAttributes<T>,
+    extends TextContentElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2874,8 +2908,7 @@ export namespace JSX {
     startOffset?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface TSpanSVGAttributes<T>
-    extends
-      TextContentElementSVGAttributes<T>,
+    extends TextContentElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2893,8 +2926,7 @@ export namespace JSX {
   }
   /** @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use */
   interface UseSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       StylableSVGAttributes,
       ConditionalProcessingSVGAttributes,
       GraphicsElementSVGAttributes<T>,
@@ -2908,8 +2940,7 @@ export namespace JSX {
     y?: FunctionMaybe<number | string | RemoveAttribute>;
   }
   interface ViewSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       ExternalResourceSVGAttributes,
       FitToViewBoxSVGAttributes,
       ZoomAndPanSVGAttributes {
@@ -4194,5 +4225,8 @@ export namespace JSX {
   }
 
   interface IntrinsicElements
-    extends HTMLElementTags, HTMLElementDeprecatedTags, SVGElementTags, MathMLElementTags {}
+    extends HTMLElementTags,
+      HTMLElementDeprecatedTags,
+      SVGElementTags,
+      MathMLElementTags {}
 }

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -162,7 +162,8 @@ export namespace JSX {
   > = EHandler | BoundEventHandler<T, E, EHandler>;
 
   interface EventHandlerWithOptions<T, E extends Event, EHandler = EventHandler<T, E>>
-    extends AddEventListenerOptions, EventListenerOptions {
+    extends AddEventListenerOptions,
+      EventListenerOptions {
     handleEvent: EHandler;
   }
 
@@ -995,15 +996,15 @@ export namespace JSX {
         ? K extends `on:${infer T}`
           ? T
           : K extends `on${infer T}`
-            ? Lowercase<T>
-            : never
+          ? Lowercase<T>
+          : never
         : never)
     | (keyof EventHandlersElement<any> extends infer K
         ? K extends `on:${infer T}`
           ? T
           : K extends `on${infer T}`
-            ? Lowercase<T>
-            : never
+          ? Lowercase<T>
+          : never
         : never)
     | (string & {});
 
@@ -1027,8 +1028,7 @@ export namespace JSX {
    * 2. Includes `keys` defined by `Element` and `Node` interfaces.
    */
   interface ElementAttributes<T>
-    extends
-      CustomAttributes<T>,
+    extends CustomAttributes<T>,
       PropAttributes,
       OnAttributes<T>,
       EventHandlersElement<T>,
@@ -1526,8 +1526,7 @@ export namespace JSX {
     alt?: string | RemoveAttribute;
     autocomplete?: HTMLAutocomplete | RemoveAttribute;
     capture?: "user" | "environment" | RemoveAttribute;
-    checked?: BooleanAttribute | RemoveAttribute;
-    "prop:checked"?: BooleanProperty | RemoveProperty;
+
     colorspace?: string | RemoveAttribute;
     dirname?: string | RemoveAttribute;
     disabled?: BooleanAttribute | RemoveAttribute;
@@ -1581,8 +1580,6 @@ export namespace JSX {
       | "week"
       | (string & {})
       | RemoveAttribute;
-    value?: string | string[] | number | RemoveAttribute;
-    "prop:value"?: string | string[] | number | RemoveProperty;
     width?: number | string | RemoveAttribute;
 
     /** @non-standard */
@@ -1592,6 +1589,24 @@ export namespace JSX {
     align?: string | RemoveAttribute;
     /** @deprecated */
     usemap?: string | RemoveAttribute;
+
+    // special cases locked to properties
+
+    checked?: BooleanProperty | RemoveProperty;
+    /** @error use `<input checked={..}/>` instead */
+    "prop:checked"?: never;
+
+    defaultChecked?: BooleanProperty | RemoveProperty;
+    /** @error use `<input defaultChecked={..}/>` instead */
+    "prop:defaultChecked"?: never;
+
+    value?: string | string[] | number | RemoveProperty;
+    /** @error use `<input value={..}/>` instead */
+    "prop:value"?: never;
+
+    defaultValue?: string | string[] | number | RemoveProperty;
+    /** @error use `<input defaultValue={..}/>` instead */
+    "prop:defaultValue"?: never;
   }
   interface ModHTMLAttributes<T> extends HTMLAttributes<T> {
     cite?: string | RemoveAttribute;
@@ -1661,8 +1676,7 @@ export namespace JSX {
     crossorigin?: HTMLCrossorigin | RemoveAttribute;
     disableremoteplayback?: BooleanAttribute | RemoveAttribute;
     loop?: BooleanAttribute | RemoveAttribute;
-    muted?: BooleanAttribute | RemoveAttribute;
-    "prop:muted"?: BooleanProperty | RemoveProperty;
+
     preload?: "none" | "metadata" | "auto" | EnumeratedAcceptsEmpty | RemoveAttribute;
     src?: string | RemoveAttribute;
 
@@ -1674,6 +1688,16 @@ export namespace JSX {
 
     /** @deprecated */
     mediagroup?: string | RemoveAttribute;
+
+    // special cases locked to properties
+
+    muted?: BooleanProperty | RemoveProperty;
+    /** @error use `<video/audio muted={..}/>` instead */
+    "prop:muted"?: never;
+
+    defaultMuted?: BooleanProperty | RemoveProperty;
+    /** @error use `<video/audio defaultMuted={..}/>` instead */
+    "prop:defaultMuted"?: never;
   }
   interface MenuHTMLAttributes<T> extends HTMLAttributes<T> {
     /** @deprecated */
@@ -1765,10 +1789,27 @@ export namespace JSX {
   interface OptionHTMLAttributes<T> extends HTMLAttributes<T> {
     disabled?: BooleanAttribute | RemoveAttribute;
     label?: string | RemoveAttribute;
-    selected?: BooleanAttribute | RemoveAttribute;
-    "prop:selected"?: BooleanProperty | RemoveProperty;
-    value?: string | string[] | number | RemoveAttribute;
-    "prop:value"?: string | string[] | number | RemoveProperty;
+
+    // special cases locked to properties
+
+    selected?: BooleanProperty | RemoveProperty;
+    /** @error use `<option selected={..}/>` instead */
+    "prop:selected"?: never;
+
+    defaultSelected?: BooleanProperty | RemoveProperty;
+    /** @error use `<option defaultSelected={..}/>` instead */
+    "prop:defaultSelected"?: never;
+
+    value?: string | string[] | number | RemoveProperty;
+    /** @error use `<option value={..}/>` instead */
+    "prop:value"?: never;
+
+    // for sanity
+
+    /** @error This doesn't exists for `<option/>` */
+    "prop:defaultValue"?: never;
+    /** @error This doesn't exists for `<option/>` */
+    defaultValue?: never;
   }
   interface OutputHTMLAttributes<T> extends HTMLAttributes<T> {
     for?: string | RemoveAttribute;
@@ -1820,8 +1861,24 @@ export namespace JSX {
     name?: string | RemoveAttribute;
     required?: BooleanAttribute | RemoveAttribute;
     size?: number | string | RemoveAttribute;
-    value?: string | string[] | number | RemoveAttribute;
-    "prop:value"?: string | string[] | number | RemoveProperty;
+
+    // special cases locked to properties
+
+    value?: string | string[] | number | RemoveProperty;
+    /** @error use `<select value={..}/>` instead */
+    "prop:value"?: never;
+
+    // for sanity
+
+    /** @error use `<option defaultSelected={..}/>` instead */
+    defaultSelected?: never;
+    /** @error use `<option defaultSelected={..}/>` instead */
+    "prop:defaultSelected"?: never;
+
+    /** @error use `<option defaultSelected={..}/>` instead */
+    selected?: never;
+    /** @error use `<option defaultSelected={..}/>` instead */
+    "prop:selected"?: never;
   }
   interface HTMLSlotElementAttributes<T> extends HTMLAttributes<T> {
     name?: string | RemoveAttribute;
@@ -1895,9 +1952,17 @@ export namespace JSX {
     readonly?: BooleanAttribute | RemoveAttribute;
     required?: BooleanAttribute | RemoveAttribute;
     rows?: number | string | RemoveAttribute;
-    value?: string | string[] | number | RemoveAttribute;
-    "prop:value"?: string | string[] | number | RemoveProperty;
     wrap?: "hard" | "soft" | "off" | RemoveAttribute;
+
+    // special cases locked to properties
+
+    value?: string | string[] | number | RemoveProperty;
+    /** @error use `<textarea value={..}/>` instead */
+    "prop:value"?: never;
+
+    defaultValue?: string | string[] | number | RemoveProperty;
+    /** @error use `<textarea defaultValue={..}/>` instead */
+    "prop:defaultValue"?: never;
   }
   interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
     abbr?: string | RemoveAttribute;
@@ -2224,7 +2289,9 @@ export namespace JSX {
     visibility?: "visible" | "hidden" | "collapse" | "inherit" | RemoveAttribute;
   }
   interface AnimationElementSVGAttributes<T>
-    extends SVGAttributes<T>, ExternalResourceSVGAttributes, ConditionalProcessingSVGAttributes {
+    extends SVGAttributes<T>,
+      ExternalResourceSVGAttributes,
+      ConditionalProcessingSVGAttributes {
     // TODO TimeEvent is currently undefined on TS
     onBegin?: EventHandlerUnion<T, Event> | undefined;
     "on:begin"?: EventHandlerWithOptionsUnion<T, Event> | undefined;
@@ -2238,8 +2305,7 @@ export namespace JSX {
     "on:repeat"?: EventHandlerWithOptionsUnion<T, Event> | undefined;
   }
   interface ContainerElementSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
@@ -2253,7 +2319,8 @@ export namespace JSX {
         | "color-rendering"
       > {}
   interface FilterPrimitiveElementSVGAttributes<T>
-    extends SVGAttributes<T>, Pick<PresentationSVGAttributes, "color-interpolation-filters"> {
+    extends SVGAttributes<T>,
+      Pick<PresentationSVGAttributes, "color-interpolation-filters"> {
     height?: number | string | RemoveAttribute;
     result?: string | RemoveAttribute;
     width?: number | string | RemoveAttribute;
@@ -2272,15 +2339,16 @@ export namespace JSX {
     viewBox?: string | RemoveAttribute;
   }
   interface GradientElementSVGAttributes<T>
-    extends SVGAttributes<T>, ExternalResourceSVGAttributes, StylableSVGAttributes {
+    extends SVGAttributes<T>,
+      ExternalResourceSVGAttributes,
+      StylableSVGAttributes {
     gradientTransform?: string | RemoveAttribute;
     gradientUnits?: SVGUnits | RemoveAttribute;
     href?: string | RemoveAttribute;
     spreadMethod?: "pad" | "reflect" | "repeat" | RemoveAttribute;
   }
   interface GraphicsElementSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
         | "clip-rule"
@@ -2296,12 +2364,12 @@ export namespace JSX {
       > {}
   interface LightSourceElementSVGAttributes<T> extends SVGAttributes<T> {}
   interface NewViewportSVGAttributes<T>
-    extends SVGAttributes<T>, Pick<PresentationSVGAttributes, "overflow" | "clip"> {
+    extends SVGAttributes<T>,
+      Pick<PresentationSVGAttributes, "overflow" | "clip"> {
     viewBox?: string | RemoveAttribute;
   }
   interface ShapeElementSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
         | "color"
@@ -2320,8 +2388,7 @@ export namespace JSX {
         | "pathLength"
       > {}
   interface TextContentElementSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       Pick<
         PresentationSVGAttributes,
         | "font-family"
@@ -2362,16 +2429,14 @@ export namespace JSX {
     zoomAndPan?: "disable" | "magnify" | RemoveAttribute;
   }
   interface AnimateSVGAttributes<T>
-    extends
-      AnimationElementSVGAttributes<T>,
+    extends AnimationElementSVGAttributes<T>,
       AnimationAttributeTargetSVGAttributes,
       AnimationTimingSVGAttributes,
       AnimationValueSVGAttributes,
       AnimationAdditionSVGAttributes,
       Pick<PresentationSVGAttributes, "color-interpolation" | "color-rendering"> {}
   interface AnimateMotionSVGAttributes<T>
-    extends
-      AnimationElementSVGAttributes<T>,
+    extends AnimationElementSVGAttributes<T>,
       AnimationTimingSVGAttributes,
       AnimationValueSVGAttributes,
       AnimationAdditionSVGAttributes {
@@ -2381,8 +2446,7 @@ export namespace JSX {
     rotate?: number | string | "auto" | "auto-reverse" | RemoveAttribute;
   }
   interface AnimateTransformSVGAttributes<T>
-    extends
-      AnimationElementSVGAttributes<T>,
+    extends AnimationElementSVGAttributes<T>,
       AnimationAttributeTargetSVGAttributes,
       AnimationTimingSVGAttributes,
       AnimationValueSVGAttributes,
@@ -2390,8 +2454,7 @@ export namespace JSX {
     type?: "translate" | "scale" | "rotate" | "skewX" | "skewY" | RemoveAttribute;
   }
   interface CircleSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       StylableSVGAttributes,
@@ -2402,8 +2465,7 @@ export namespace JSX {
     r?: number | string | RemoveAttribute;
   }
   interface ClipPathSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2412,16 +2474,14 @@ export namespace JSX {
     clipPathUnits?: SVGUnits | RemoveAttribute;
   }
   interface DefsSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
       TransformableSVGAttributes {}
   interface DescSVGAttributes<T> extends SVGAttributes<T>, StylableSVGAttributes {}
   interface EllipseSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2434,28 +2494,24 @@ export namespace JSX {
     ry?: number | string | RemoveAttribute;
   }
   interface FeBlendSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       DoubleInputFilterSVGAttributes,
       StylableSVGAttributes {
     mode?: "normal" | "multiply" | "screen" | "darken" | "lighten" | RemoveAttribute;
   }
   interface FeColorMatrixSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     type?: "matrix" | "saturate" | "hueRotate" | "luminanceToAlpha" | RemoveAttribute;
     values?: string | RemoveAttribute;
   }
   interface FeComponentTransferSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {}
   interface FeCompositeSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       DoubleInputFilterSVGAttributes,
       StylableSVGAttributes {
     k1?: number | string | RemoveAttribute;
@@ -2465,8 +2521,7 @@ export namespace JSX {
     operator?: "over" | "in" | "out" | "atop" | "xor" | "arithmetic" | RemoveAttribute;
   }
   interface FeConvolveMatrixSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     bias?: number | string | RemoveAttribute;
@@ -2480,8 +2535,7 @@ export namespace JSX {
     targetY?: number | string | RemoveAttribute;
   }
   interface FeDiffuseLightingSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "lighting-color"> {
@@ -2490,8 +2544,7 @@ export namespace JSX {
     surfaceScale?: number | string | RemoveAttribute;
   }
   interface FeDisplacementMapSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       DoubleInputFilterSVGAttributes,
       StylableSVGAttributes {
     scale?: number | string | RemoveAttribute;
@@ -2503,8 +2556,7 @@ export namespace JSX {
     elevation?: number | string | RemoveAttribute;
   }
   interface FeDropShadowSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       FilterPrimitiveElementSVGAttributes<T>,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "flood-color" | "flood-opacity"> {
@@ -2513,8 +2565,7 @@ export namespace JSX {
     stdDeviation?: number | string | RemoveAttribute;
   }
   interface FeFloodSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "flood-color" | "flood-opacity"> {}
   interface FeFuncSVGAttributes<T> extends SVGAttributes<T> {
@@ -2527,34 +2578,31 @@ export namespace JSX {
     type?: "identity" | "table" | "discrete" | "linear" | "gamma" | RemoveAttribute;
   }
   interface FeGaussianBlurSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     stdDeviation?: number | string | RemoveAttribute;
   }
   interface FeImageSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes {
     href?: string | RemoveAttribute;
     preserveAspectRatio?: SVGPreserveAspectRatio | RemoveAttribute;
   }
   interface FeMergeSVGAttributes<T>
-    extends FilterPrimitiveElementSVGAttributes<T>, StylableSVGAttributes {}
+    extends FilterPrimitiveElementSVGAttributes<T>,
+      StylableSVGAttributes {}
   interface FeMergeNodeSVGAttributes<T> extends SVGAttributes<T>, SingleInputFilterSVGAttributes {}
   interface FeMorphologySVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     operator?: "erode" | "dilate" | RemoveAttribute;
     radius?: number | string | RemoveAttribute;
   }
   interface FeOffsetSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {
     dx?: number | string | RemoveAttribute;
@@ -2566,8 +2614,7 @@ export namespace JSX {
     z?: number | string | RemoveAttribute;
   }
   interface FeSpecularLightingSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "lighting-color"> {
@@ -2587,12 +2634,12 @@ export namespace JSX {
     z?: number | string | RemoveAttribute;
   }
   interface FeTileSVGAttributes<T>
-    extends
-      FilterPrimitiveElementSVGAttributes<T>,
+    extends FilterPrimitiveElementSVGAttributes<T>,
       SingleInputFilterSVGAttributes,
       StylableSVGAttributes {}
   interface FeTurbulanceSVGAttributes<T>
-    extends FilterPrimitiveElementSVGAttributes<T>, StylableSVGAttributes {
+    extends FilterPrimitiveElementSVGAttributes<T>,
+      StylableSVGAttributes {
     baseFrequency?: number | string | RemoveAttribute;
     numOctaves?: number | string | RemoveAttribute;
     seed?: number | string | RemoveAttribute;
@@ -2600,7 +2647,9 @@ export namespace JSX {
     type?: "fractalNoise" | "turbulence" | RemoveAttribute;
   }
   interface FilterSVGAttributes<T>
-    extends SVGAttributes<T>, ExternalResourceSVGAttributes, StylableSVGAttributes {
+    extends SVGAttributes<T>,
+      ExternalResourceSVGAttributes,
+      StylableSVGAttributes {
     filterRes?: number | string | RemoveAttribute;
     filterUnits?: SVGUnits | RemoveAttribute;
     height?: number | string | RemoveAttribute;
@@ -2610,8 +2659,7 @@ export namespace JSX {
     y?: number | string | RemoveAttribute;
   }
   interface ForeignObjectSVGAttributes<T>
-    extends
-      NewViewportSVGAttributes<T>,
+    extends NewViewportSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2623,16 +2671,14 @@ export namespace JSX {
     y?: number | string | RemoveAttribute;
   }
   interface GSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
       TransformableSVGAttributes,
       Pick<PresentationSVGAttributes, "clip-path" | "display" | "visibility"> {}
   interface ImageSVGAttributes<T>
-    extends
-      NewViewportSVGAttributes<T>,
+    extends NewViewportSVGAttributes<T>,
       GraphicsElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       StylableSVGAttributes,
@@ -2646,8 +2692,7 @@ export namespace JSX {
     y?: number | string | RemoveAttribute;
   }
   interface LineSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2666,8 +2711,7 @@ export namespace JSX {
     y2?: number | string | RemoveAttribute;
   }
   interface MarkerSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
       FitToViewBoxSVGAttributes,
@@ -2680,8 +2724,7 @@ export namespace JSX {
     refY?: number | string | RemoveAttribute;
   }
   interface MaskSVGAttributes<T>
-    extends
-      Omit<ContainerElementSVGAttributes<T>, "opacity" | "filter">,
+    extends Omit<ContainerElementSVGAttributes<T>, "opacity" | "filter">,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2696,8 +2739,7 @@ export namespace JSX {
   interface MetadataSVGAttributes<T> extends SVGAttributes<T> {}
   interface MPathSVGAttributes<T> extends SVGAttributes<T> {}
   interface PathSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2708,8 +2750,7 @@ export namespace JSX {
     pathLength?: number | string | RemoveAttribute;
   }
   interface PatternSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2725,8 +2766,7 @@ export namespace JSX {
     y?: number | string | RemoveAttribute;
   }
   interface PolygonSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2736,8 +2776,7 @@ export namespace JSX {
     points?: string | RemoveAttribute;
   }
   interface PolylineSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2754,8 +2793,7 @@ export namespace JSX {
     r?: number | string | RemoveAttribute;
   }
   interface RectSVGAttributes<T>
-    extends
-      GraphicsElementSVGAttributes<T>,
+    extends GraphicsElementSVGAttributes<T>,
       ShapeElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2770,17 +2808,17 @@ export namespace JSX {
     y?: number | string | RemoveAttribute;
   }
   interface SetSVGAttributes<T>
-    extends AnimationElementSVGAttributes<T>, StylableSVGAttributes, AnimationTimingSVGAttributes {}
+    extends AnimationElementSVGAttributes<T>,
+      StylableSVGAttributes,
+      AnimationTimingSVGAttributes {}
   interface StopSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       StylableSVGAttributes,
       Pick<PresentationSVGAttributes, "color" | "stop-color" | "stop-opacity"> {
     offset?: number | string | RemoveAttribute;
   }
   interface SvgSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       NewViewportSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2803,16 +2841,14 @@ export namespace JSX {
     version?: string | RemoveAttribute;
   }
   interface SwitchSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
       TransformableSVGAttributes,
       Pick<PresentationSVGAttributes, "display" | "visibility"> {}
   interface SymbolSVGAttributes<T>
-    extends
-      ContainerElementSVGAttributes<T>,
+    extends ContainerElementSVGAttributes<T>,
       NewViewportSVGAttributes<T>,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2828,8 +2864,7 @@ export namespace JSX {
     y?: number | string | RemoveAttribute;
   }
   interface TextSVGAttributes<T>
-    extends
-      TextContentElementSVGAttributes<T>,
+    extends TextContentElementSVGAttributes<T>,
       GraphicsElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
@@ -2845,8 +2880,7 @@ export namespace JSX {
     y?: number | string | RemoveAttribute;
   }
   interface TextPathSVGAttributes<T>
-    extends
-      TextContentElementSVGAttributes<T>,
+    extends TextContentElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2860,8 +2894,7 @@ export namespace JSX {
     startOffset?: number | string | RemoveAttribute;
   }
   interface TSpanSVGAttributes<T>
-    extends
-      TextContentElementSVGAttributes<T>,
+    extends TextContentElementSVGAttributes<T>,
       ConditionalProcessingSVGAttributes,
       ExternalResourceSVGAttributes,
       StylableSVGAttributes,
@@ -2879,8 +2912,7 @@ export namespace JSX {
   }
   /** @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use */
   interface UseSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       StylableSVGAttributes,
       ConditionalProcessingSVGAttributes,
       GraphicsElementSVGAttributes<T>,
@@ -2894,8 +2926,7 @@ export namespace JSX {
     y?: number | string | RemoveAttribute;
   }
   interface ViewSVGAttributes<T>
-    extends
-      SVGAttributes<T>,
+    extends SVGAttributes<T>,
       ExternalResourceSVGAttributes,
       FitToViewBoxSVGAttributes,
       ZoomAndPanSVGAttributes {
@@ -4180,5 +4211,8 @@ export namespace JSX {
   }
 
   interface IntrinsicElements
-    extends HTMLElementTags, HTMLElementDeprecatedTags, SVGElementTags, MathMLElementTags {}
+    extends HTMLElementTags,
+      HTMLElementDeprecatedTags,
+      SVGElementTags,
+      MathMLElementTags {}
 }

--- a/packages/dom-expressions/test/dom/forms.spec.jsx
+++ b/packages/dom-expressions/test/dom/forms.spec.jsx
@@ -1,0 +1,661 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Asserts that JSX `default*` props (defaultValue, defaultChecked,
+ * defaultSelected, defaultMuted) reach the corresponding IDL property and
+ * survive `form.reset()`, while the dynamic props (value/checked/selected/
+ * muted) drive the live state through the reactive system.
+ *
+ * The babel-plugin-jsx-dom-expressions pipeline must:
+ *   1. Set the *default* on the element so the browser uses it for reset.
+ *   2. Set the *current* via a reactive effect so updates flow through.
+ *   3. Not conflate the two — `form.reset()` walks defaults, signals stay put.
+ */
+import { createRoot, createSignal, flush } from "@solidjs/signals";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("form reset restores default* props", () => {
+  it("text input: defaultValue persists, dynamic value drives current state", () => {
+    let input, form, dispose;
+    const [text, setText] = createSignal("dynamic initial");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <input ref={input} type="text" defaultValue="static default" value={text()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(input.value).toBe("dynamic initial");
+    expect(input.defaultValue).toBe("static default");
+
+    setText("dynamic changed");
+    flush();
+    expect(input.value).toBe("dynamic changed");
+    expect(input.defaultValue).toBe("static default");
+
+    form.reset();
+    expect(input.value).toBe("static default");
+    expect(text()).toBe("dynamic changed"); // signal untouched by reset
+
+    setText("dynamic after reset");
+    flush();
+    expect(input.value).toBe("dynamic after reset");
+
+    dispose();
+  });
+
+  it("number input: defaultValue persists, dynamic value drives current state", () => {
+    let input, form, dispose;
+    const [num, setNum] = createSignal("7");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <input
+            ref={input}
+            type="number"
+            min="0"
+            max="100"
+            defaultValue="42"
+            value={num()}
+          />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(input.value).toBe("7");
+    expect(input.defaultValue).toBe("42");
+
+    setNum("13");
+    flush();
+    expect(input.value).toBe("13");
+
+    form.reset();
+    expect(input.value).toBe("42");
+
+    dispose();
+  });
+
+  it("checkbox: defaultChecked persists, dynamic checked drives current state", () => {
+    let input, form, dispose;
+    const [flag, setFlag] = createSignal(false);
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <input ref={input} type="checkbox" defaultChecked={true} checked={flag()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(input.checked).toBe(false); // dynamic wins
+    expect(input.defaultChecked).toBe(true);
+
+    setFlag(true);
+    flush();
+    expect(input.checked).toBe(true);
+    expect(input.defaultChecked).toBe(true);
+
+    form.reset();
+    expect(input.checked).toBe(true); // back to default (which happens to also be true)
+    expect(flag()).toBe(true);
+
+    setFlag(false);
+    flush();
+    expect(input.checked).toBe(false);
+
+    form.reset();
+    expect(input.checked).toBe(true); // reset restores defaultChecked
+    expect(flag()).toBe(false); // signal untouched
+
+    dispose();
+  });
+
+  it("radio group: defaultChecked on one radio is the reset target", () => {
+    let r1, r2, r3, form, dispose;
+    const [selected, setSelected] = createSignal("1");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <input
+            ref={r1}
+            type="radio"
+            name="g"
+            value="1"
+            checked={selected() === "1"}
+          />
+          <input
+            ref={r2}
+            type="radio"
+            name="g"
+            value="2"
+            defaultChecked={true}
+            checked={selected() === "2"}
+          />
+          <input
+            ref={r3}
+            type="radio"
+            name="g"
+            value="3"
+            checked={selected() === "3"}
+          />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(r1.checked).toBe(true);
+    expect(r2.checked).toBe(false);
+    expect(r3.checked).toBe(false);
+    expect(r2.defaultChecked).toBe(true);
+
+    setSelected("3");
+    flush();
+    expect(r1.checked).toBe(false);
+    expect(r2.checked).toBe(false);
+    expect(r3.checked).toBe(true);
+
+    form.reset();
+    expect(r1.checked).toBe(false);
+    expect(r2.checked).toBe(true); // the defaulted radio
+    expect(r3.checked).toBe(false);
+
+    dispose();
+  });
+
+  it("textarea: defaultValue persists, dynamic value drives current state", () => {
+    let textarea, form, dispose;
+    const [body, setBody] = createSignal("dynamic body");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <textarea ref={textarea} defaultValue="static default body" value={body()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(textarea.value).toBe("dynamic body");
+    expect(textarea.defaultValue).toBe("static default body");
+
+    setBody("changed");
+    flush();
+    expect(textarea.value).toBe("changed");
+    expect(textarea.defaultValue).toBe("static default body");
+
+    form.reset();
+    expect(textarea.value).toBe("static default body");
+    expect(body()).toBe("changed"); // signal untouched
+
+    dispose();
+  });
+
+  it("select with defaultSelected option: reset returns to that option", () => {
+    let select, form, dispose;
+    const [sel, setSel] = createSignal("3");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <select ref={select} value={sel()}>
+            <option value="1">One</option>
+            <option value="2" defaultSelected={true}>
+              Two
+            </option>
+            <option value="3">Three</option>
+          </select>
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    // queueMicrotask wrapping in select prop:value handler — flush microtasks
+    return Promise.resolve().then(() => {
+      expect(select.value).toBe("3");
+      expect(select.options[1].defaultSelected).toBe(true);
+
+      setSel("1");
+      flush();
+      return Promise.resolve().then(() => {
+        expect(select.value).toBe("1");
+
+        form.reset();
+        expect(select.value).toBe("2"); // back to defaulted option
+        expect(sel()).toBe("1"); // signal untouched
+
+        dispose();
+      });
+    });
+  });
+
+  it("multi-select: defaultSelected on multiple options is the reset target", () => {
+    let select, form, dispose;
+    // Two options have defaultSelected={true}; the dynamic `selected` signals
+    // initially override them so we can prove that reset puts the defaults back.
+    const [s2, setS2] = createSignal(false);
+    const [s4, setS4] = createSignal(false);
+    const [s5, setS5] = createSignal(true);
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <select ref={select} multiple>
+            <option value="1">Item 1</option>
+            <option value="2" defaultSelected={true} selected={s2()}>
+              Item 2
+            </option>
+            <option value="3">Item 3</option>
+            <option value="4" defaultSelected={true} selected={s4()}>
+              Item 4
+            </option>
+            <option value="5" selected={s5()}>
+              Item 5
+            </option>
+          </select>
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    // Initial: dynamic `selected` wins on options 2 and 4 (overriding the
+    // defaults), and option 5 is dynamically selected.
+    expect(select.options[0].selected).toBe(false);
+    expect(select.options[1].selected).toBe(false);
+    expect(select.options[2].selected).toBe(false);
+    expect(select.options[3].selected).toBe(false);
+    expect(select.options[4].selected).toBe(true);
+
+    // defaultSelected on options 2 and 4 must be preserved regardless.
+    expect(select.options[1].defaultSelected).toBe(true);
+    expect(select.options[3].defaultSelected).toBe(true);
+
+    // Move the dynamic selection around.
+    setS2(true);
+    setS5(false);
+    flush();
+    expect(select.options[1].selected).toBe(true);
+    expect(select.options[4].selected).toBe(false);
+
+    // form.reset() walks every option and sets selected ← defaultSelected.
+    form.reset();
+    expect(select.options[0].selected).toBe(false);
+    expect(select.options[1].selected).toBe(true); // defaulted
+    expect(select.options[2].selected).toBe(false);
+    expect(select.options[3].selected).toBe(true); // defaulted
+    expect(select.options[4].selected).toBe(false);
+
+    // Signals untouched by reset.
+    expect(s2()).toBe(true);
+    expect(s4()).toBe(false);
+    expect(s5()).toBe(false);
+
+    dispose();
+  });
+
+  it("video: defaultMuted persists, dynamic muted drives current state", () => {
+    // <video> isn't reset by form.reset(), but defaultMuted/muted should still
+    // be wired to the right IDL properties.
+    let video, dispose;
+    const [muted, setMuted] = createSignal(false);
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <video ref={video} defaultMuted={true} muted={muted()} />
+      );
+    });
+
+    expect(video.muted).toBe(false); // dynamic wins
+    expect(video.defaultMuted).toBe(true);
+
+    setMuted(true);
+    flush();
+    expect(video.muted).toBe(true);
+    expect(video.defaultMuted).toBe(true);
+
+    setMuted(false);
+    flush();
+    expect(video.muted).toBe(false);
+    expect(video.defaultMuted).toBe(true); // never overwritten
+
+    dispose();
+  });
+});
+
+describe("various default/current combinations", () => {
+  // Each test pins down a different combination of static/dynamic default
+  // and static/dynamic current value, so we know which babel branch is
+  // being exercised: template-inlined HTML attribute, prop:* runtime
+  // assignment, or (for textarea) children-as-default.
+
+  it("input: dynamic defaultValue + dynamic value (both via prop:*)", () => {
+    let input, form, dispose;
+    const [def, setDef] = createSignal("default A");
+    const [cur, setCur] = createSignal("current X");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <input ref={input} type="text" defaultValue={def()} value={cur()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(input.value).toBe("current X");
+    expect(input.defaultValue).toBe("default A");
+
+    // Update the default — value should not be touched (input is dirty
+    // because the prop:value effect set it).
+    setDef("default B");
+    flush();
+    expect(input.defaultValue).toBe("default B");
+    expect(input.value).toBe("current X");
+
+    // Update the current — defaultValue should not be touched.
+    setCur("current Y");
+    flush();
+    expect(input.value).toBe("current Y");
+    expect(input.defaultValue).toBe("default B");
+
+    // Reset goes to whatever the latest default was.
+    form.reset();
+    expect(input.value).toBe("default B");
+    expect(def()).toBe("default B");
+    expect(cur()).toBe("current Y"); // signal untouched
+
+    dispose();
+  });
+
+  it("input: dynamic defaultValue alone", () => {
+    let input, form, dispose;
+    const [def, setDef] = createSignal("default A");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <input ref={input} type="text" defaultValue={def()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(input.defaultValue).toBe("default A");
+
+    setDef("default B");
+    flush();
+    expect(input.defaultValue).toBe("default B");
+
+    form.reset();
+    expect(input.value).toBe("default B");
+
+    dispose();
+  });
+
+  it("input: static defaultValue alone (template-inlined)", () => {
+    let input, form, dispose;
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <input ref={input} type="text" defaultValue="static default" />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    // Static literal default gets renamed to the bare HTML attribute, which
+    // initializes both .value and .defaultValue on parse.
+    expect(input.value).toBe("static default");
+    expect(input.defaultValue).toBe("static default");
+
+    // Simulate user editing.
+    input.value = "user typed";
+    expect(input.value).toBe("user typed");
+    expect(input.defaultValue).toBe("static default");
+
+    form.reset();
+    expect(input.value).toBe("static default");
+
+    dispose();
+  });
+
+  it("input: dynamic value alone leaves defaultValue empty", () => {
+    let input, form, dispose;
+    const [cur, setCur] = createSignal("current X");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <input ref={input} type="text" value={cur()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(input.value).toBe("current X");
+    expect(input.defaultValue).toBe("");
+
+    setCur("current Y");
+    flush();
+    expect(input.value).toBe("current Y");
+    expect(input.defaultValue).toBe("");
+
+    // No default to fall back to, so reset clears the field.
+    form.reset();
+    expect(input.value).toBe("");
+    expect(cur()).toBe("current Y"); // signal untouched
+
+    dispose();
+  });
+
+  it("textarea: dynamic value alone leaves defaultValue empty (matches input semantics)", () => {
+    // Mirrors the input test above. In DOM, `<textarea value={dyn}/>` is a
+    // controlled component: prop:value sets `.value`, `.defaultValue` is left
+    // empty, and `form.reset()` returns to "".
+    //
+    // SSR diverges intentionally: the SSR HTML output puts the dynamic value
+    // into the textarea's text content, which the browser uses to initialize
+    // both `.value` and `.defaultValue` on parse — see the SSR test
+    // `"textarea: dynamic value alone → current in text content (no default)"`.
+    let textarea, form, dispose;
+    const [v, setV] = createSignal("current only body");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <textarea ref={textarea} value={v()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(textarea.value).toBe("current only body");
+    expect(textarea.defaultValue).toBe("");
+
+    setV("changed");
+    flush();
+    expect(textarea.value).toBe("changed");
+    expect(textarea.defaultValue).toBe("");
+
+    // No default to fall back to, so reset clears the field.
+    form.reset();
+    expect(textarea.value).toBe("");
+    expect(v()).toBe("changed"); // signal untouched
+
+    dispose();
+  });
+
+  it("textarea: dynamic defaultValue alone (children-as-default)", () => {
+    let textarea, form, dispose;
+    const [def, setDef] = createSignal("dynamic default");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <textarea ref={textarea} defaultValue={def()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    // The babel transform turns dynamic textarea defaultValue into children
+    // (an _$insert call). The browser/jsdom mirrors text content into both
+    // .defaultValue and .value while the textarea isn't dirty.
+    expect(textarea.defaultValue).toBe("dynamic default");
+    expect(textarea.value).toBe("dynamic default");
+
+    setDef("changed default");
+    flush();
+    expect(textarea.defaultValue).toBe("changed default");
+
+    // Simulate user editing.
+    textarea.value = "user typed";
+    expect(textarea.defaultValue).toBe("changed default");
+
+    form.reset();
+    expect(textarea.value).toBe("changed default");
+
+    dispose();
+  });
+
+  it("textarea: dynamic defaultValue + dynamic value", () => {
+    let textarea, form, dispose;
+    const [def, setDef] = createSignal("default A");
+    const [cur, setCur] = createSignal("current X");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <form ref={form}>
+          <textarea ref={textarea} defaultValue={def()} value={cur()} />
+          <button type="reset">Reset</button>
+        </form>
+      );
+    });
+
+    expect(textarea.value).toBe("current X");
+    expect(textarea.defaultValue).toBe("default A");
+
+    setDef("default B");
+    flush();
+    expect(textarea.defaultValue).toBe("default B");
+
+    setCur("current Y");
+    flush();
+    expect(textarea.value).toBe("current Y");
+    expect(textarea.defaultValue).toBe("default B");
+
+    form.reset();
+    expect(textarea.value).toBe("default B");
+    expect(def()).toBe("default B");
+    expect(cur()).toBe("current Y"); // signal untouched
+
+    dispose();
+  });
+});
+
+describe("textarea edge cases (suspected bugs)", () => {
+  // These tests document expected behaviour that the current babel transform
+  // does NOT yet honour. They may fail until `transformSpecialCaseAttributes`
+  // stops folding `<textarea value={...}/>` into children when there's no
+  // `defaultValue` sibling, and stops overwriting user-supplied children.
+
+  it("textarea: dynamic value alone — updates after user typing (Bug B)", () => {
+    let textarea, dispose;
+    const [v, setV] = createSignal("initial");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(<textarea ref={textarea} value={v()} />);
+    });
+
+    expect(textarea.value).toBe("initial");
+
+    // Simulate the user typing — this marks the textarea as "dirty".
+    // Once dirty, replacing child nodes does NOT update `.value` per HTML spec.
+    textarea.value = "user typed";
+    expect(textarea.value).toBe("user typed");
+
+    // Reactive update to the signal: should still flow into `.value` because
+    // the user wrote `value={...}`. With the current babel transform this is
+    // compiled as `_$insert(textarea, v)` (children-based), which silently
+    // stops working after the first user interaction.
+    setV("updated");
+    flush();
+    expect(textarea.value).toBe("updated"); // EXPECTED TO FAIL with current transform
+
+    dispose();
+  });
+
+  it("textarea: dynamic value + dynamic children — children updates remain observable (Bug A)", () => {
+    let textarea, dispose;
+    const [v] = createSignal("from value");
+    const [c, setC] = createSignal("c1");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <textarea ref={textarea} value={v()}>
+          {c()}
+        </textarea>
+      );
+    });
+
+    // The user wrote BOTH a `value` attribute and explicit children. With the
+    // fix, value drives `.value` (via prop:value) and the user's children are
+    // rendered into the textarea's text content (and stay reactive). They no
+    // longer get silently overwritten by the value-as-children insert.
+    expect(textarea.value).toBe("from value"); // value wins for .value
+    expect(textarea.textContent).toBe("c1"); // children rendered into the textarea
+
+    setC("c2");
+    flush();
+    expect(textarea.textContent).toBe("c2"); // children update is observable
+
+    dispose();
+  });
+
+  it("textarea: dynamic children alone — works as plain reactive children", () => {
+    let textarea, dispose;
+    const [c, setC] = createSignal("initial children");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(<textarea ref={textarea}>{c()}</textarea>);
+    });
+
+    // Sanity case: no `value`, no `defaultValue`, just reactive children.
+    // `transformSpecialCaseAttributes` should not touch this element at all.
+    expect(textarea.value).toBe("initial children");
+
+    setC("updated children");
+    flush();
+    expect(textarea.value).toBe("updated children");
+
+    dispose();
+  });
+});

--- a/packages/dom-expressions/test/ssr/forms.spec.jsx
+++ b/packages/dom-expressions/test/ssr/forms.spec.jsx
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Asserts that JSX `default*` props end up in the SSR-rendered HTML so that:
+ *   - The browser parses the HTML with the correct initial state.
+ *   - After hydration, dynamic effects can override `.value`/`.checked`/etc.
+ *   - `form.reset()` returns to the SSR-rendered defaults.
+ *
+ * The babel plugin (with `generate: "ssr"`) should:
+ *   - Rename `defaultValue` → `value` (HTML attribute) for inputs/select/etc.
+ *   - For textarea, fold the default into children (`<textarea>x</textarea>`).
+ *   - Drop `prop:*` from the SSR HTML output (those are runtime-only).
+ */
+import * as r from "../../src/server";
+import { createSignal } from "@solidjs/signals";
+
+describe("SSR renders default* props as HTML", () => {
+  it("input: static defaultValue + dynamic value → default in HTML", () => {
+    const [cur] = createSignal("dynamic current");
+    const html = r.renderToString(() => (
+      <input type="text" defaultValue="static default" value={cur()} />
+    ));
+    expect(html).toContain('value="static default"');
+    expect(html).not.toContain('value="dynamic current"');
+  });
+
+  it("input: dynamic defaultValue + dynamic value → default in HTML", () => {
+    const [def] = createSignal("dynamic default");
+    const [cur] = createSignal("dynamic current");
+    const html = r.renderToString(() => (
+      <input type="text" defaultValue={def()} value={cur()} />
+    ));
+    expect(html).toContain('value="dynamic default"');
+    expect(html).not.toContain('value="dynamic current"');
+  });
+
+  it("input: dynamic defaultValue alone → in HTML", () => {
+    const [def] = createSignal("the default");
+    const html = r.renderToString(() => <input type="text" defaultValue={def()} />);
+    expect(html).toContain('value="the default"');
+  });
+
+  it("input: static defaultValue alone → in HTML", () => {
+    const html = r.renderToString(() => <input type="text" defaultValue="the default" />);
+    expect(html).toContain('value="the default"');
+  });
+
+  it("input: dynamic value alone → current in HTML (no default sibling)", () => {
+    const [cur] = createSignal("current only");
+    const html = r.renderToString(() => <input type="text" value={cur()} />);
+    expect(html).toContain('value="current only"');
+  });
+
+  it("checkbox: defaultChecked={true} + checked={false} → HTML has checked", () => {
+    const html = r.renderToString(() => (
+      <input type="checkbox" defaultChecked={true} checked={false} />
+    ));
+    expect(html).toContain("checked");
+  });
+
+  it("checkbox: defaultChecked={true} + dynamic checked={false} → HTML has checked", () => {
+    const [flag] = createSignal(false);
+    const html = r.renderToString(() => (
+      <input type="checkbox" defaultChecked={true} checked={flag()} />
+    ));
+    expect(html).toContain("checked");
+  });
+
+  it("checkbox: defaultChecked={false} + dynamic checked={true} → HTML has no checked", () => {
+    const [flag] = createSignal(true);
+    const html = r.renderToString(() => (
+      <input type="checkbox" defaultChecked={false} checked={flag()} />
+    ));
+    // The default is unchecked; runtime override happens after hydration.
+    expect(html).not.toContain("checked");
+  });
+
+  it("radio: defaultChecked={true} + dynamic checked={false} → HTML has checked", () => {
+    const [flag] = createSignal(false);
+    const html = r.renderToString(() => (
+      <input type="radio" name="g" value="1" defaultChecked={true} checked={flag()} />
+    ));
+    expect(html).toContain("checked");
+  });
+
+  it("radio group: only the defaulted radio is checked in HTML", () => {
+    const [s1] = createSignal(false);
+    const [s2] = createSignal(false);
+    const [s3] = createSignal(false);
+    const html = r.renderToString(() => (
+      <div>
+        <input type="radio" name="g" value="1" checked={s1()} />
+        <input type="radio" name="g" value="2" defaultChecked={true} checked={s2()} />
+        <input type="radio" name="g" value="3" checked={s3()} />
+      </div>
+    ));
+    // Only the second radio should be checked in the HTML.
+    expect(html).toMatch(/<input[^>]*value="2"[^>]*checked/);
+    expect(html).not.toMatch(/<input[^>]*value="1"[^>]*checked/);
+    expect(html).not.toMatch(/<input[^>]*value="3"[^>]*checked/);
+  });
+
+  it("textarea: static defaultValue + dynamic value → default in text content", () => {
+    const [cur] = createSignal("dynamic body");
+    const html = r.renderToString(() => (
+      <textarea defaultValue="static default body" value={cur()} />
+    ));
+    expect(html).toContain("<textarea>static default body</textarea>");
+  });
+
+  it("textarea: dynamic defaultValue + dynamic value → default in text content", () => {
+    const [def] = createSignal("dynamic default body");
+    const [cur] = createSignal("dynamic body");
+    const html = r.renderToString(() => (
+      <textarea defaultValue={def()} value={cur()} />
+    ));
+    expect(html).toContain("<textarea>dynamic default body</textarea>");
+  });
+
+  it("textarea: dynamic value alone → current in text content (no default)", () => {
+    const [cur] = createSignal("current only body");
+    const html = r.renderToString(() => <textarea value={cur()} />);
+    expect(html).toContain("<textarea>current only body</textarea>");
+  });
+
+  it("textarea: static defaultValue alone → in text content", () => {
+    const html = r.renderToString(() => <textarea defaultValue="just the default" />);
+    expect(html).toContain("<textarea>just the default</textarea>");
+  });
+
+  it("select with defaultSelected option: HTML has selected on the defaulted option", () => {
+    const [cur] = createSignal("3");
+    const html = r.renderToString(() => (
+      <select value={cur()}>
+        <option value="1">One</option>
+        <option value="2" defaultSelected={true}>
+          Two
+        </option>
+        <option value="3">Three</option>
+      </select>
+    ));
+    // The option with defaultSelected should carry the `selected` HTML attr.
+    // We don't pin down exactly where the attribute lands within the option,
+    // just that it's present on the second option's text.
+    expect(html).toMatch(/<option[^>]*value="2"[^>]*selected[^>]*>Two<\/option>|<option[^>]*selected[^>]*value="2"[^>]*>Two<\/option>/);
+  });
+
+  it("multi-select: HTML has selected on each defaulted option", () => {
+    const [s2] = createSignal(false);
+    const [s4] = createSignal(false);
+    const html = r.renderToString(() => (
+      <select multiple>
+        <option value="1">Item 1</option>
+        <option value="2" defaultSelected={true} selected={s2()}>
+          Item 2
+        </option>
+        <option value="3">Item 3</option>
+        <option value="4" defaultSelected={true} selected={s4()}>
+          Item 4
+        </option>
+        <option value="5">Item 5</option>
+      </select>
+    ));
+    // Both defaulted options should carry the `selected` HTML attribute
+    // regardless of the dynamic signals' values.
+    expect(html).toMatch(/<option[^>]*value="2"[^>]*selected[^>]*>[\s\S]*?Item 2/);
+    expect(html).toMatch(/<option[^>]*value="4"[^>]*selected[^>]*>[\s\S]*?Item 4/);
+    // Non-defaulted options must not be selected.
+    expect(html).not.toMatch(/<option[^>]*value="1"[^>]*selected/);
+    expect(html).not.toMatch(/<option[^>]*value="3"[^>]*selected/);
+    expect(html).not.toMatch(/<option[^>]*value="5"[^>]*selected/);
+  });
+
+  it("video: defaultMuted={true} + muted={false} → HTML has muted attribute", () => {
+    const html = r.renderToString(() => <video defaultMuted={true} muted={false} />);
+    expect(html).toContain("muted");
+  });
+});


### PR DESCRIPTION
We decided to special case form fields, just so the expectation of `<input value={signal()}/>` sets current value instead of default value. This made it awkward because `input.value` is now a property instead of an attribute, diverging from everything else. 

This is the demo of what I care about (plain html/progressive enhancement/government website served by solid SSR):
https://playground.solidjs.com/anonymous/b607472f-8869-4df5-a7ca-09d7db35a7d7

Usage:

```jsx
  <input 
    value={dynamicCurrentValue()/static current value} 
    defaultValue={dynamicDefaultValue()/static default value}
/> 
```

Documentation should be at:
https://github.com/solidjs/solid/blob/next/documentation/solid-2.0/07-dom.md

This change has the plus side that form fields are backwards compatible (except for these using attr:)

Notes:
- I thought I was breaking the AST, but it seems the problem was that for the time I was transforming it, it was too late, as some already cached global values such skipId were already set. So had to lift the transformation.
- defaultValue also added to undefined handling
- should check if this breaks hydration, this topic kind of escapes me
- to avoid doing `DOMWithState[propName.replace('prop:')]` for every key in spreads, I just inlined it in `DOMWithState`
- usage of `prop:value` and `prop:defaultValue` is forbidden to avoid double values competing and making the issue harder to deal with it. It's done via types with `"prop:value":never`
- defaultValue or value when defaultValue is not provied get SSRed
- making `<input value="default value" prop:value="current value"/>` work as I attempted before wasn't doable, because `value` cannot be both a property and an attribute at the same time. For the sake of simplicity and to not complicate the experience I think `<input defaultValue="default value" value="current value"/>`  should be fine.  I guess we can revisit in v3 if to remove the special cases..  

Thanks!