### PR TITLE
[next] default to `true` shorthand attributes on DOMWithState transformation

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -510,7 +510,9 @@ export function transformSpecialCaseAttributes(path, tagName, isSSR) {
   }
 
   for (const { propName, attr } of transforms) {
-    const value = t.cloneNode(attr.node.value?.expression ?? attr.node.value);
+    const value = attr.node.value == null
+      ? t.booleanLiteral(true)
+      : t.cloneNode(attr.node.value.expression ?? attr.node.value);
 
     const isDefault =
       propName.includes("default") ||

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
@@ -389,3 +389,9 @@ const template94 = <div>
 </div>
 
 const template95 = <a xmlns="http://www.w3.org/2000/svg">xml link partial</a>
+
+const template96 = <video src="test.mp4" muted/>
+
+function MyVideo() {
+  return <video src="test.mp4" muted />
+}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -73,7 +73,8 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div><h1><a href="/">Welcome</a></h1></di
   _tmpl$52 = /*#__PURE__*/ _$template(
     `<div><textarea></textarea><textarea></textarea><textarea></textarea><textarea></textarea><textarea></textarea><textarea>static content</textarea><textarea>static content</textarea></div>`
   ),
-  _tmpl$53 = /*#__PURE__*/ _$template(`<svg><a>xml link partial</a></svg>`, 2);
+  _tmpl$53 = /*#__PURE__*/ _$template(`<svg><a>xml link partial</a></svg>`, 2),
+  _tmpl$54 = /*#__PURE__*/ _$template(`<video src="test.mp4"muted></video>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -957,4 +958,8 @@ const template94 = (() => {
   return _el$127;
 })();
 const template95 = _tmpl$53();
+const template96 = _tmpl$54();
+function MyVideo() {
+  return _tmpl$54();
+}
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/code.js
@@ -361,3 +361,16 @@ const template90 = <div style={{}}/>
 const template91 = <video something={{value:{value:1+1}}}/>
 
 const template92 = <div style="duplicate1" style="duplicate2"/>
+
+const template93 = <div>
+  <video muted={true}/>
+  <video muted={false}/>
+  <video defaultMuted={false} muted={dynamicProperty()}/>
+  <video defaultMuted={true} muted={dynamicProperty()}/>
+  <video defaultMuted={dynamicAttribute()} muted={dynamicProperty()}/>
+  <video src="test.mp4" muted/>
+</div>
+
+function MyVideo() {
+  return <video src="test.mp4" muted />
+}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -66,7 +66,11 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div><h1><a href=/>Welcome`),
   _tmpl$47 = /*#__PURE__*/ _$template(`<button type=button>`),
   _tmpl$48 = /*#__PURE__*/ _$template(`<div style="padding-left:clamp(2px, 2px, 2px)">`),
   _tmpl$49 = /*#__PURE__*/ _$template(`<div style="a:clamp(2px, 2px, 2px)">`),
-  _tmpl$50 = /*#__PURE__*/ _$template(`<div style=duplicate2>`);
+  _tmpl$50 = /*#__PURE__*/ _$template(`<div style=duplicate2>`),
+  _tmpl$51 = /*#__PURE__*/ _$template(
+    `<div><video muted></video><video></video><video></video><video muted></video><video></video><video src=test.mp4 muted>`
+  ),
+  _tmpl$52 = /*#__PURE__*/ _$template(`<video src=test.mp4 muted>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -878,4 +882,28 @@ const template91 = (() => {
   return _el$111;
 })();
 const template92 = _tmpl$50();
+const template93 = (() => {
+  var _el$113 = _tmpl$51(),
+    _el$114 = _el$113.firstChild,
+    _el$115 = _el$114.nextSibling,
+    _el$116 = _el$115.nextSibling,
+    _el$117 = _el$116.nextSibling,
+    _el$118 = _el$117.nextSibling;
+  _$effect(dynamicProperty, _v$ => {
+    _el$116.muted = _v$;
+  });
+  _$effect(dynamicProperty, _v$ => {
+    _el$117.muted = _v$;
+  });
+  _$effect(dynamicAttribute, _v$ => {
+    _el$118.defaultMuted = _v$;
+  });
+  _$effect(dynamicProperty, _v$ => {
+    _el$118.muted = _v$;
+  });
+  return _el$113;
+})();
+function MyVideo() {
+  return _tmpl$52();
+}
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/code.js
@@ -385,3 +385,12 @@ const template94 = <div>
   <textarea value="static content"/>
   <textarea value="static content">I get replaced</textarea>
 </div>
+
+const template95 = <div>
+  <video muted={true}/>
+  <video muted={false}/>
+  <video defaultMuted={false} muted={dynamicProperty()}/>
+  <video defaultMuted={true} muted={dynamicProperty()}/>
+  <video defaultMuted={dynamicAttribute()} muted={dynamicProperty()}/>
+  <video src="test.mp4" muted/>
+</div>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
@@ -66,6 +66,10 @@ var _tmpl$ = ['<a href="/" class="', '">Welcome</a>'],
     "</textarea><textarea>",
     "</textarea><textarea></textarea><textarea>",
     "</textarea><textarea>static content</textarea><textarea>static content</textarea></div>"
+  ],
+  _tmpl$53 = [
+    "<div><video muted></video><video></video><video></video><video muted></video><video",
+    '></video><video src="test.mp4" muted></video></div>'
   ];
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
@@ -664,4 +668,8 @@ const template94 = (() => {
     _v$44 = _$ssrRunInScope(() => _$escape(dynamicContent())),
     _v$45 = _$ssrRunInScope(() => _$escape(dynamicContent()));
   return _$ssr(_tmpl$52, _v$42, _v$43, _v$44, _v$45);
+})();
+const template95 = (() => {
+  var _v$46 = _$ssrRunInScope(() => _$ssrAttribute("muted", _$escape(dynamicAttribute(), true)));
+  return _$ssr(_tmpl$53, _v$46);
 })();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/code.js
@@ -326,3 +326,16 @@ const template88 = (
 
 const template89 = <div style={{ }} />;
 const template90 = <div data-test={state.flag || undefined} />;
+
+const template91 = <div>
+  <video muted={true}/>
+  <video muted={false}/>
+  <video defaultMuted={false} muted={dynamicProperty()}/>
+  <video defaultMuted={true} muted={dynamicProperty()}/>
+  <video defaultMuted={dynamicAttribute()} muted={dynamicProperty()}/>
+  <video src="test.mp4" muted/>
+</div>
+
+function MyVideo() {
+  return <video src="test.mp4" muted />
+}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
@@ -59,7 +59,13 @@ var _tmpl$ = ['<a href="/" class="', '">Welcome</a>'],
   _tmpl$45 = ["<div", '><video poster="1.jpg"></video></div>'],
   _tmpl$46 = ["<div", "><video></video></div>"],
   _tmpl$47 = ["<button", ' type="button"', ' style="', '" class="', '">', "</button>"],
-  _tmpl$48 = ["<div", "", "></div>"];
+  _tmpl$48 = ["<div", "", "></div>"],
+  _tmpl$49 = [
+    "<div",
+    "><video muted></video><video></video><video></video><video muted></video><video",
+    '></video><video src="test.mp4" muted></video></div>'
+  ],
+  _tmpl$50 = ["<video", ' src="test.mp4" muted></video>'];
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -747,3 +753,14 @@ const template90 = (() => {
     ]);
   return _$ssr(_tmpl$48, _v$112, _v$113[0]);
 })();
+const template91 = (() => {
+  var _v$114 = _$ssrHydrationKey(),
+    _v$115 = _$ssrRunInScope(() => _$ssrAttribute("muted", _$escape(dynamicAttribute(), true)));
+  return _$ssr(_tmpl$49, _v$114, _v$115);
+})();
+function MyVideo() {
+  return (() => {
+    var _v$116 = _$ssrHydrationKey();
+    return _$ssr(_tmpl$50, _v$116);
+  })();
+}

--- a/packages/dom-expressions/test/dom/spread.spec.jsx
+++ b/packages/dom-expressions/test/dom/spread.spec.jsx
@@ -346,6 +346,22 @@ describe("spread children caching", () => {
   });
 });
 
+describe("video with static muted", () => {
+  it("should set defaultMuted via the muted HTML attribute", () => {
+    let video, disposer;
+
+    createRoot(dispose => {
+      disposer = dispose;
+      video = <video ref={video} src="test.mp4" muted />;
+    });
+
+    expect(video).toBeDefined();
+    expect(video.defaultMuted).toBe(true);
+    expect(video.getAttribute("src")).toBe("test.mp4");
+    disposer();
+  });
+});
+
 describe("DOM with state props", () => {
   it("resyncs spread input value when the DOM drifts", () => {
     let input, disposer;

--- a/packages/dom-expressions/test/ssr/jsx.spec.jsx
+++ b/packages/dom-expressions/test/ssr/jsx.spec.jsx
@@ -167,6 +167,14 @@ describe("fragments", () => {
   });
 });
 
+describe("video with static muted", () => {
+  it("renders video with muted attribute and src", () => {
+    const res = r.renderToString(() => <video src="test.mp4" muted />);
+    expect(res).toContain("muted");
+    expect(res).toContain('src="test.mp4"');
+  });
+});
+
 // avoid double escaping - https://github.com/ryansolid/dom-expressions/issues/393
 {
   const a = ["<"];


### PR DESCRIPTION
reported in #500 

JSX shorthand attributes like `<video muted />` have a null value node, pr sets it to `true`. 

This is handled in all other places (checked it), Id this but somehow got lost so adds it back 
