### PR TITLE
[next] fix SSR createElement ref handling with spreads

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/ssr/element.js
@@ -551,13 +551,7 @@ function createElement(path, { topLevel, hydratable }) {
             : node.name.name;
 
         if (hasChildren && key === "children") return;
-        if (key === "ref") {
-          if (t.isJSXExpressionContainer(value))
-            results.declarations.push(
-              t.variableDeclarator(path.scope.generateUidIdentifier("_ref$"), value.expression)
-            );
-          return;
-        }
+        if (key === "ref") return;
         if (key.startsWith("prop:") || key.startsWith("on")) return;
         if (t.isJSXExpressionContainer(value))
           if (

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/code.js
@@ -229,3 +229,10 @@ const template32 = <Comp ref={refFn} />
 const template33 = <Comp ref={refConst} />
 
 const template34 = <Comp ref={refUnknown} />
+
+function MyComponent(props) {
+  let el
+  const others = omit(props, "children")
+  return <div ref={el} {...others}>{props.children}</div>
+}
+

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/components/output.js
@@ -1,4 +1,5 @@
 import { template as _$template } from "r-dom";
+import { spread as _$spread } from "r-dom";
 import { memo as _$memo } from "r-dom";
 import { For as _$For } from "r-dom";
 import { createComponent as _$createComponent } from "r-dom";
@@ -515,3 +516,17 @@ const template34 = _$createComponent(Comp, {
       : (refUnknown = r$);
   }
 });
+function MyComponent(props) {
+  let el;
+  const others = omit(props, "children");
+  return (() => {
+    var _el$43 = _tmpl$2();
+    var _ref$8 = el;
+    typeof _ref$8 === "function" || Array.isArray(_ref$8)
+      ? _$ref(() => _ref$8, _el$43)
+      : (el = _el$43);
+    _$spread(_el$43, others, true);
+    _$insert(_el$43, () => props.children);
+    return _el$43;
+  })();
+}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/code.js
@@ -229,3 +229,10 @@ const template32 = <Comp ref={refFn} />
 const template33 = <Comp ref={refConst} />
 
 const template34 = <Comp ref={refUnknown} />
+
+function MyComponent(props) {
+  let el
+  const others = omit(props, "children")
+  return <div ref={el} {...others}>{props.children}</div>
+}
+

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/components/output.js
@@ -1,3 +1,4 @@
+import { ssrElement as _$ssrElement } from "r-server";
 import { memo as _$memo } from "r-server";
 import { For as _$For } from "r-server";
 import { createComponent as _$createComponent } from "r-server";
@@ -453,3 +454,8 @@ const template34 = _$createComponent(Comp, {
       : (refUnknown = r$);
   }
 });
+function MyComponent(props) {
+  let el;
+  const others = omit(props, "children");
+  return _$ssrElement("div", others, () => _$escape(props.children), false);
+}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/code.js
@@ -158,6 +158,13 @@ const template24 = <Component>
   {state.dynamic}
 </Component>
 
-const template25 = <Component> 
+const template25 = <Component>
   <div />
 </Component>
+
+function MyComponent(props) {
+  let el
+  const others = omit(props, "children")
+  return <div ref={el} {...others}>{props.children}</div>
+}
+

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/components/output.js
@@ -1,3 +1,4 @@
+import { ssrElement as _$ssrElement } from "r-server";
 import { memo as _$memo } from "r-server";
 import { For as _$For } from "r-server";
 import { createComponent as _$createComponent } from "r-server";
@@ -405,3 +406,8 @@ const template25 = _$createComponent(Component, {
     return _$ssr(_tmpl$5, _v$40);
   }
 });
+function MyComponent(props) {
+  let el;
+  const others = omit(props, "children");
+  return _$ssrElement("div", others, () => () => _$escape(props.children), true);
+}

--- a/packages/dom-expressions/test/dom/spread.spec.jsx
+++ b/packages/dom-expressions/test/dom/spread.spec.jsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { createMemo, createRoot, createSignal, flush } from "@solidjs/signals";
+import { createMemo, createRoot, createSignal, flush, omit } from "@solidjs/signals";
 
 describe("create element with various spreads", () => {
   it("should properly spread ref, click, attribute, and children", () => {
@@ -342,6 +342,86 @@ describe("spread children caching", () => {
     setList(["x"]);
     flush();
     expect(div.innerHTML).toBe("x");
+    disposer();
+  });
+});
+
+describe("component with ref, omit, spread, and children", () => {
+  it("should forward ref, spread remaining props, and render children", () => {
+    let el, disposer;
+
+    function MyComponent(props) {
+      const others = omit(props, "children");
+      return (
+        <div ref={el} {...others}>
+          {props.children}
+        </div>
+      );
+    }
+
+    createRoot(dispose => {
+      disposer = dispose;
+      <MyComponent class="test" data-id="123">
+        <span>Hello</span>
+      </MyComponent>;
+    });
+
+    expect(el).toBeInstanceOf(HTMLDivElement);
+    expect(el.className).toBe("test");
+    expect(el.getAttribute("data-id")).toBe("123");
+    expect(el.innerHTML).toBe("<span>Hello</span>");
+    disposer();
+  });
+
+  it("should work with a function ref", () => {
+    let el, disposer;
+
+    function MyComponent(props) {
+      const others = omit(props, "children");
+      return (
+        <div ref={e => (el = e)} {...others}>
+          {props.children}
+        </div>
+      );
+    }
+
+    createRoot(dispose => {
+      disposer = dispose;
+      <MyComponent class="test">
+        <span>Hello</span>
+      </MyComponent>;
+    });
+
+    expect(el).toBeInstanceOf(HTMLDivElement);
+    expect(el.className).toBe("test");
+    expect(el.innerHTML).toBe("<span>Hello</span>");
+    disposer();
+  });
+
+  it("should work with a signal ref", () => {
+    let disposer;
+    const [ref, setRef] = createSignal();
+
+    function MyComponent(props) {
+      const others = omit(props, "children");
+      return (
+        <div ref={setRef} {...others}>
+          {props.children}
+        </div>
+      );
+    }
+
+    createRoot(dispose => {
+      disposer = dispose;
+      <MyComponent class="test">
+        <span>Hello</span>
+      </MyComponent>;
+    });
+
+    flush();
+    expect(ref()).toBeInstanceOf(HTMLDivElement);
+    expect(ref().className).toBe("test");
+    expect(ref().innerHTML).toBe("<span>Hello</span>");
     disposer();
   });
 });

--- a/packages/dom-expressions/test/ssr/jsx.spec.jsx
+++ b/packages/dom-expressions/test/ssr/jsx.spec.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import * as r from "../../src/server";
+import { omit } from "@solidjs/signals";
 
 const fixture1 = '<div style="--color:red"></div>';
 const fixture2 = '<div style=""></div>';
@@ -164,6 +165,29 @@ describe("fragments", () => {
     const b = "world";
     const res = r.renderToString(() => <div><>{a}{b}</></div>);
     expect(res).toBe("<div>hello<!--!$-->world</div>");
+  });
+});
+
+describe("component with ref, omit, spread, and children", () => {
+  it("renders component with spread props and children", () => {
+    function MyComponent(props) {
+      let el;
+      const others = omit(props, "children");
+      return (
+        <div ref={el} {...others}>
+          {props.children}
+        </div>
+      );
+    }
+
+    const res = r.renderToString(() => (
+      <MyComponent class="test" data-id="123">
+        <span>Hello</span>
+      </MyComponent>
+    ));
+    expect(res).toContain('class="test"');
+    expect(res).toContain('data-id="123"');
+    expect(res).toContain("<span>Hello</span>");
   });
 });
 


### PR DESCRIPTION
This has been reported also in  #500 

Think this is a regression introduced in making ref arraays and dropping `use`. 

Honestly, Im like 20% confident on this PR. Sounds plausible refs are dropped in ssr. But Im actually not sure because there are other ref handling in some of the ssr outputs (existing before this pr)

Tests passes, and previous tests outputs have not been modified.

Here are claude explanations, sound plausible but idk (the whole ssr/hydration flow escapes me a little bit)

> SSR createElement (spread path) referenced undefined `results` variable when handling ref attributes, causing a crash. Refs on native elements with spreads are now simply skipped in the compiled output since ssrElement already ignores ref props at runtime.

> Adds MyComponent tests (omit + ref + spread + children) to dom and ssr component fixtures, plus DOM runtime tests for assignment ref, function ref, and signal ref patterns.

 