### PR TITLE
[next] do not separate dom with state into its own effect

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -907,6 +907,8 @@ function transformAttributes(path, results) {
         ) {
           // own effect
           let nextElem = elem;
+          /*
+
           if (isStatefulDOMProperty(tagName, key)) {
             const effectWrapperId = registerImportMethod(path, config.effectWrapper);
             const v = t.identifier("_v$");
@@ -928,7 +930,7 @@ function transformAttributes(path, results) {
               )
             );
             return;
-          }
+          }*/
           if (key === "textContent") {
             nextElem = attribute.scope.generateUidIdentifier("el$");
             children = t.jsxText(" ");

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -310,30 +310,30 @@ const template20 = (() => {
   _$setAttribute(_el$27, "readonly", value);
   _$effect(
     () => ({
-      e: min(),
-      t: max(),
-      a: min(),
-      o: max()
+      e: s(),
+      t: min(),
+      a: max(),
+      o: s2(),
+      i: min(),
+      n: max()
     }),
-    ({ e, t, a, o }, _p$) => {
-      e !== _p$.e && _$setAttribute(_el$26, "min", e);
-      t !== _p$.t && _$setAttribute(_el$26, "max", t);
-      a !== _p$.a && _$setAttribute(_el$27, "min", a);
-      o !== _p$.o && _$setAttribute(_el$27, "max", o);
+    ({ e, t, a, o, i, n }, _p$) => {
+      _el$26.value = e ?? "";
+      t !== _p$.t && _$setAttribute(_el$26, "min", t);
+      a !== _p$.a && _$setAttribute(_el$26, "max", a);
+      _el$27.checked = o;
+      i !== _p$.i && _$setAttribute(_el$27, "min", i);
+      n !== _p$.n && _$setAttribute(_el$27, "max", n);
     },
     {
       e: undefined,
       t: undefined,
       a: undefined,
-      o: undefined
+      o: undefined,
+      i: undefined,
+      n: undefined
     }
   );
-  _$effect(s, _v$ => {
-    _el$26.value = _v$ ?? "";
-  });
-  _$effect(s2, _v$ => {
-    _el$27.checked = _v$;
-  });
   return _el$25;
 })();
 const template21 = (() => {
@@ -529,21 +529,20 @@ const template41 = (() => {
     _el$56 = _el$55.firstChild,
     _el$57 = _el$56.nextSibling;
   _$effect(
-    () => Color.Red,
-    _v$ => {
-      _el$56.value = _v$;
-    }
-  );
-  _$effect(
-    () => Color.Blue,
-    _v$ => {
-      _el$57.value = _v$;
-    }
-  );
-  _$effect(
-    () => state.color,
-    _v$ => {
-      queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
+    () => ({
+      e: state.color,
+      t: Color.Red,
+      a: Color.Blue
+    }),
+    ({ e, t, a }, _p$) => {
+      queueMicrotask(() => (_el$55.value = e)) || (_el$55.value = e);
+      _el$56.value = t;
+      _el$57.value = a;
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined
     }
   );
   return _el$55;
@@ -901,33 +900,41 @@ const template93 = (() => {
     _el$125 = _el$124.nextSibling,
     _el$126 = _el$125.nextSibling;
   _el$115.value = "static property";
-  _$effect(dynamicProperty, _v$ => {
-    _el$114.value = _v$ ?? "";
-  });
-  _$effect(dynamicAttribute, _v$ => {
-    _el$115.defaultValue = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$118.value = _v$ ?? "";
-  });
-  _$effect(dynamicAttribute, _v$ => {
-    _el$119.defaultValue = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$119.value = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$124.muted = _v$;
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$125.muted = _v$;
-  });
-  _$effect(dynamicAttribute, _v$ => {
-    _el$126.defaultMuted = _v$;
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$126.muted = _v$;
-  });
+  _$effect(
+    () => ({
+      e: dynamicProperty(),
+      t: dynamicAttribute(),
+      a: dynamicProperty(),
+      o: dynamicAttribute(),
+      i: dynamicProperty(),
+      n: dynamicProperty(),
+      s: dynamicProperty(),
+      h: dynamicAttribute(),
+      r: dynamicProperty()
+    }),
+    ({ e, t, a, o, i, n, s, h, r }, _p$) => {
+      _el$114.value = e ?? "";
+      _el$115.defaultValue = t ?? "";
+      _el$118.value = a ?? "";
+      _el$119.defaultValue = o ?? "";
+      _el$119.value = i ?? "";
+      _el$124.muted = n;
+      _el$125.muted = s;
+      _el$126.defaultMuted = h;
+      _el$126.muted = r;
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined,
+      o: undefined,
+      i: undefined,
+      n: undefined,
+      s: undefined,
+      h: undefined,
+      r: undefined
+    }
+  );
   return _el$113;
 })();
 const template94 = (() => {
@@ -939,21 +946,29 @@ const template94 = (() => {
     _el$132 = _el$131.nextSibling;
   _$insert(_el$129, dynamicContent);
   _$insert(_el$132, dynamicContent);
-  _$effect(dynamicProperty, _v$ => {
-    _el$128.value = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$129.value = _v$ ?? "";
-  });
-  _$effect(dynamicContent, _v$ => {
-    _el$130.defaultValue = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$130.value = _v$ ?? "";
-  });
-  _$effect(dynamicProperty, _v$ => {
-    _el$131.value = _v$ ?? "";
-  });
+  _$effect(
+    () => ({
+      e: dynamicProperty(),
+      t: dynamicProperty(),
+      a: dynamicContent(),
+      o: dynamicProperty(),
+      i: dynamicProperty()
+    }),
+    ({ e, t, a, o, i }, _p$) => {
+      _el$128.value = e ?? "";
+      _el$129.value = t ?? "";
+      _el$130.defaultValue = a ?? "";
+      _el$130.value = o ?? "";
+      _el$131.value = i ?? "";
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined,
+      o: undefined,
+      i: undefined
+    }
+  );
   return _el$127;
 })();
 const template95 = _tmpl$53();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -303,30 +303,30 @@ const template20 = (() => {
   _$setAttribute(_el$27, "readonly", value);
   _$effect(
     () => ({
-      e: min(),
-      t: max(),
-      a: min(),
-      o: max()
+      e: s(),
+      t: min(),
+      a: max(),
+      o: s2(),
+      i: min(),
+      n: max()
     }),
-    ({ e, t, a, o }, _p$) => {
-      e !== _p$.e && _$setAttribute(_el$26, "min", e);
-      t !== _p$.t && _$setAttribute(_el$26, "max", t);
-      a !== _p$.a && _$setAttribute(_el$27, "min", a);
-      o !== _p$.o && _$setAttribute(_el$27, "max", o);
+    ({ e, t, a, o, i, n }, _p$) => {
+      _el$26.value = e ?? "";
+      t !== _p$.t && _$setAttribute(_el$26, "min", t);
+      a !== _p$.a && _$setAttribute(_el$26, "max", a);
+      _el$27.checked = o;
+      i !== _p$.i && _$setAttribute(_el$27, "min", i);
+      n !== _p$.n && _$setAttribute(_el$27, "max", n);
     },
     {
       e: undefined,
       t: undefined,
       a: undefined,
-      o: undefined
+      o: undefined,
+      i: undefined,
+      n: undefined
     }
   );
-  _$effect(s, _v$ => {
-    _el$26.value = _v$ ?? "";
-  });
-  _$effect(s2, _v$ => {
-    _el$27.checked = _v$;
-  });
   return _el$25;
 })();
 const template21 = (() => {
@@ -522,21 +522,20 @@ const template41 = (() => {
     _el$56 = _el$55.firstChild,
     _el$57 = _el$56.nextSibling;
   _$effect(
-    () => Color.Red,
-    _v$ => {
-      _el$56.value = _v$;
-    }
-  );
-  _$effect(
-    () => Color.Blue,
-    _v$ => {
-      _el$57.value = _v$;
-    }
-  );
-  _$effect(
-    () => state.color,
-    _v$ => {
-      queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
+    () => ({
+      e: state.color,
+      t: Color.Red,
+      a: Color.Blue
+    }),
+    ({ e, t, a }, _p$) => {
+      queueMicrotask(() => (_el$55.value = e)) || (_el$55.value = e);
+      _el$56.value = t;
+      _el$57.value = a;
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined
     }
   );
   return _el$55;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -307,30 +307,30 @@ const template20 = (() => {
   _$setAttribute(_el$27, "readonly", value);
   _$effect(
     () => ({
-      e: min(),
-      t: max(),
-      a: min(),
-      o: max()
+      e: s(),
+      t: min(),
+      a: max(),
+      o: s2(),
+      i: min(),
+      n: max()
     }),
-    ({ e, t, a, o }, _p$) => {
-      e !== _p$.e && _$setAttribute(_el$26, "min", e);
-      t !== _p$.t && _$setAttribute(_el$26, "max", t);
-      a !== _p$.a && _$setAttribute(_el$27, "min", a);
-      o !== _p$.o && _$setAttribute(_el$27, "max", o);
+    ({ e, t, a, o, i, n }, _p$) => {
+      _el$26.value = e ?? "";
+      t !== _p$.t && _$setAttribute(_el$26, "min", t);
+      a !== _p$.a && _$setAttribute(_el$26, "max", a);
+      _el$27.checked = o;
+      i !== _p$.i && _$setAttribute(_el$27, "min", i);
+      n !== _p$.n && _$setAttribute(_el$27, "max", n);
     },
     {
       e: undefined,
       t: undefined,
       a: undefined,
-      o: undefined
+      o: undefined,
+      i: undefined,
+      n: undefined
     }
   );
-  _$effect(s, _v$ => {
-    _el$26.value = _v$ ?? "";
-  });
-  _$effect(s2, _v$ => {
-    _el$27.checked = _v$;
-  });
   _$runHydrationEvents();
   return _el$25;
 })();
@@ -536,21 +536,20 @@ const template41 = (() => {
     _el$60 = _el$59.firstChild,
     _el$61 = _el$60.nextSibling;
   _$effect(
-    () => Color.Red,
-    _v$ => {
-      _el$60.value = _v$;
-    }
-  );
-  _$effect(
-    () => Color.Blue,
-    _v$ => {
-      _el$61.value = _v$;
-    }
-  );
-  _$effect(
-    () => state.color,
-    _v$ => {
-      queueMicrotask(() => (_el$59.value = _v$)) || (_el$59.value = _v$);
+    () => ({
+      e: state.color,
+      t: Color.Red,
+      a: Color.Blue
+    }),
+    ({ e, t, a }, _p$) => {
+      queueMicrotask(() => (_el$59.value = e)) || (_el$59.value = e);
+      _el$60.value = t;
+      _el$61.value = a;
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined
     }
   );
   return _el$59;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -300,30 +300,30 @@ const template20 = (() => {
   _$setAttribute(_el$27, "readonly", value);
   _$effect(
     () => ({
-      e: min(),
-      t: max(),
-      a: min(),
-      o: max()
+      e: s(),
+      t: min(),
+      a: max(),
+      o: s2(),
+      i: min(),
+      n: max()
     }),
-    ({ e, t, a, o }, _p$) => {
-      e !== _p$.e && _$setAttribute(_el$26, "min", e);
-      t !== _p$.t && _$setAttribute(_el$26, "max", t);
-      a !== _p$.a && _$setAttribute(_el$27, "min", a);
-      o !== _p$.o && _$setAttribute(_el$27, "max", o);
+    ({ e, t, a, o, i, n }, _p$) => {
+      _el$26.value = e ?? "";
+      t !== _p$.t && _$setAttribute(_el$26, "min", t);
+      a !== _p$.a && _$setAttribute(_el$26, "max", a);
+      _el$27.checked = o;
+      i !== _p$.i && _$setAttribute(_el$27, "min", i);
+      n !== _p$.n && _$setAttribute(_el$27, "max", n);
     },
     {
       e: undefined,
       t: undefined,
       a: undefined,
-      o: undefined
+      o: undefined,
+      i: undefined,
+      n: undefined
     }
   );
-  _$effect(s, _v$ => {
-    _el$26.value = _v$ ?? "";
-  });
-  _$effect(s2, _v$ => {
-    _el$27.checked = _v$;
-  });
   return _el$25;
 })();
 const template21 = (() => {
@@ -519,21 +519,20 @@ const template41 = (() => {
     _el$56 = _el$55.firstChild,
     _el$57 = _el$56.nextSibling;
   _$effect(
-    () => Color.Red,
-    _v$ => {
-      _el$56.value = _v$;
-    }
-  );
-  _$effect(
-    () => Color.Blue,
-    _v$ => {
-      _el$57.value = _v$;
-    }
-  );
-  _$effect(
-    () => state.color,
-    _v$ => {
-      queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
+    () => ({
+      e: state.color,
+      t: Color.Red,
+      a: Color.Blue
+    }),
+    ({ e, t, a }, _p$) => {
+      queueMicrotask(() => (_el$55.value = e)) || (_el$55.value = e);
+      _el$56.value = t;
+      _el$57.value = a;
+    },
+    {
+      e: undefined,
+      t: undefined,
+      a: undefined
     }
   );
   return _el$55;


### PR DESCRIPTION
We have already removed the check `previousValue != newValue ? input.value = newValue` for any dom with state, as reactivity is the source of truth for these properties(else the dom value won't match the reactive value). 

As we are doing this, then there is no need to have them in a separated effect. 

However, the only concern, is that in these effects there are other things, mostly just short-circuit with `prev != new` which should be fast enough (specially given its only 1 effect). But className/style I'm not sure if short-circuits. In any case, that's seems like a thing to fix for them, and not fault of dom with state.

Separating in a different effect is already being reported as causing problems, because it changes the order of the props.  https://github.com/solidjs/solid/issues/2532#issuecomment-4236026508






