### PR TITLE
[next] Forbid `select value` (class/classList problem) and ask for `option.selected` instead

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -297,17 +297,6 @@ export function setAttr(path, elem, name, value, { dynamic, prevId, tagName }) {
       t.memberExpression(elem, t.identifier(name)),
       value
     );
-    // handle select/options... TODO: consider other ways in the future
-    // TODO: there may be a race condition here
-    if (name === "value" && tagName === "select") {
-      return t.logicalExpression(
-        "||",
-        t.callExpression(t.identifier("queueMicrotask"), [
-          t.arrowFunctionExpression([], assignment)
-        ]),
-        assignment
-      );
-    }
     if (
       (name === "value" || name === "defaultValue") &&
       (tagName === "input" || tagName === "textarea") &&

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -529,6 +529,12 @@ const template41 = (() => {
     _el$56 = _el$55.firstChild,
     _el$57 = _el$56.nextSibling;
   _$effect(
+    () => state.color,
+    _v$ => {
+      _$setAttribute(_el$55, "value", _v$);
+    }
+  );
+  _$effect(
     () => Color.Red,
     _v$ => {
       _el$56.value = _v$;
@@ -538,12 +544,6 @@ const template41 = (() => {
     () => Color.Blue,
     _v$ => {
       _el$57.value = _v$;
-    }
-  );
-  _$effect(
-    () => state.color,
-    _v$ => {
-      queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
     }
   );
   return _el$55;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -522,6 +522,12 @@ const template41 = (() => {
     _el$56 = _el$55.firstChild,
     _el$57 = _el$56.nextSibling;
   _$effect(
+    () => state.color,
+    _v$ => {
+      _$setAttribute(_el$55, "value", _v$);
+    }
+  );
+  _$effect(
     () => Color.Red,
     _v$ => {
       _el$56.value = _v$;
@@ -531,12 +537,6 @@ const template41 = (() => {
     () => Color.Blue,
     _v$ => {
       _el$57.value = _v$;
-    }
-  );
-  _$effect(
-    () => state.color,
-    _v$ => {
-      queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
     }
   );
   return _el$55;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -536,6 +536,12 @@ const template41 = (() => {
     _el$60 = _el$59.firstChild,
     _el$61 = _el$60.nextSibling;
   _$effect(
+    () => state.color,
+    _v$ => {
+      _$setAttribute(_el$59, "value", _v$);
+    }
+  );
+  _$effect(
     () => Color.Red,
     _v$ => {
       _el$60.value = _v$;
@@ -545,12 +551,6 @@ const template41 = (() => {
     () => Color.Blue,
     _v$ => {
       _el$61.value = _v$;
-    }
-  );
-  _$effect(
-    () => state.color,
-    _v$ => {
-      queueMicrotask(() => (_el$59.value = _v$)) || (_el$59.value = _v$);
     }
   );
   return _el$59;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -519,6 +519,12 @@ const template41 = (() => {
     _el$56 = _el$55.firstChild,
     _el$57 = _el$56.nextSibling;
   _$effect(
+    () => state.color,
+    _v$ => {
+      _$setAttribute(_el$55, "value", _v$);
+    }
+  );
+  _$effect(
     () => Color.Red,
     _v$ => {
       _el$56.value = _v$;
@@ -528,12 +534,6 @@ const template41 = (() => {
     () => Color.Blue,
     _v$ => {
       _el$57.value = _v$;
-    }
-  );
-  _$effect(
-    () => state.color,
-    _v$ => {
-      queueMicrotask(() => (_el$55.value = _v$)) || (_el$55.value = _v$);
     }
   );
   return _el$55;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_fixtures__/attributeExpressions/output.js
@@ -368,10 +368,10 @@ const template40 = (() => {
   return _$ssr(_tmpl$18, _v$21[0]);
 })();
 const template41 = (() => {
-  var _v$22 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(state.color, true))),
+  var _v$22 = _$ssrRunInScope([() => _$ssrAttribute("value", _$escape(state.color, true))]),
     _v$23 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(Color.Red, true))),
     _v$24 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(Color.Blue, true)));
-  return _$ssr(_tmpl$25, _v$22, _v$23, _v$24);
+  return _$ssr(_tmpl$25, _v$22[0], _v$23, _v$24);
 })();
 const template42 = _$ssr(_tmpl$26);
 const template43 = _$ssr(_tmpl$27);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
@@ -430,10 +430,10 @@ const template40 = (() => {
 })();
 const template41 = (() => {
   var _v$56 = _$ssrHydrationKey(),
-    _v$57 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(state.color, true))),
+    _v$57 = _$ssrRunInScope([() => _$ssrAttribute("value", _$escape(state.color, true))]),
     _v$58 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(Color.Red, true))),
     _v$59 = _$ssrRunInScope(() => _$ssrAttribute("value", _$escape(Color.Blue, true)));
-  return _$ssr(_tmpl$25, _v$56, _v$57, _v$58, _v$59);
+  return _$ssr(_tmpl$25, _v$56, _v$57[0], _v$58, _v$59);
 })();
 const template42 = (() => {
   var _v$60 = _$ssrHydrationKey();

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -523,9 +523,7 @@ function assignProp(node, prop, value, prev, skipRef, nodeName) {
   ) {
     if (hasNamespace) prop = prop.slice(5);
     else if (isHydrating(node)) return value; // TODO IS this correct?
-    if (prop === "value" && nodeName === "SELECT")
-      queueMicrotask(() => (node.value = value)) || (node.value = value);
-    else node[prop] = value;
+    node[prop] = value;
   } else {
     const ns = hasNamespace && Namespaces[prop.split(":")[0]];
     if (ns) setAttributeNS(node, ns, prop, value);

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -1,6 +1,5 @@
 const DOMWithState = {
   INPUT: { value: 1, defaultValue: 1, checked: 1, defaultChecked: 1 },
-  SELECT: { value: 1 },
   OPTION: { value: 1, selected: 1, defaultSelected: 1 },
   TEXTAREA: { value: 1, defaultValue: 1 },
   VIDEO: { muted: 1, defaultMuted: 1 },

--- a/packages/dom-expressions/src/jsx-h.d.ts
+++ b/packages/dom-expressions/src/jsx-h.d.ts
@@ -1871,8 +1871,9 @@ export namespace JSX {
 
     // special cases locked to properties
 
-    value?: FunctionMaybe<string | string[] | number | RemoveProperty>;
-    /** @error use `<select value={..}/>` instead */
+    /** @error use `<option selected={..}/>` instead */
+    value?: never;
+    /** @error use `<option selected={..}/>` instead */
     "prop:value"?: never;
 
     // for sanity

--- a/packages/dom-expressions/src/jsx.d.ts
+++ b/packages/dom-expressions/src/jsx.d.ts
@@ -1864,8 +1864,9 @@ export namespace JSX {
 
     // special cases locked to properties
 
-    value?: string | string[] | number | RemoveProperty;
-    /** @error use `<select value={..}/>` instead */
+    /** @error use `<option selected={..}/>` instead */
+    value?: never;
+    /** @error use `<option selected={..}/>` instead */
     "prop:value"?: never;
 
     // for sanity

--- a/packages/dom-expressions/test/dom/forms.spec.jsx
+++ b/packages/dom-expressions/test/dom/forms.spec.jsx
@@ -213,12 +213,16 @@ describe("form reset restores default* props", () => {
       dispose = d;
       document.body.appendChild(
         <form ref={form}>
-          <select ref={select} value={sel()}>
-            <option value="1">One</option>
-            <option value="2" defaultSelected={true}>
+          <select ref={select}>
+            <option value="1" selected={sel() === "1"}>
+              One
+            </option>
+            <option value="2" defaultSelected={true} selected={sel() === "2"}>
               Two
             </option>
-            <option value="3">Three</option>
+            <option value="3" selected={sel() === "3"}>
+              Three
+            </option>
           </select>
           <button type="reset">Reset</button>
         </form>

--- a/packages/dom-expressions/test/dom/forms.spec.jsx
+++ b/packages/dom-expressions/test/dom/forms.spec.jsx
@@ -244,6 +244,39 @@ describe("form reset restores default* props", () => {
     });
   });
 
+  it("select: options loaded asynchronously — value signal selects option 2 once it exists", async () => {
+    let select, dispose;
+    const [options, setOptions] = createSignal([]);
+    const [sel] = createSignal("2");
+
+    createRoot(d => {
+      dispose = d;
+      document.body.appendChild(
+        <select ref={select}>
+          {options().map(v => (
+            <option value={v} selected={v === sel()}>
+              {v}
+            </option>
+          ))}
+        </select>
+      );
+    });
+
+    // No options yet — nothing can be selected.
+    expect(select.options.length).toBe(0);
+
+    // Simulate options arriving from a promise that resolves after 200ms.
+    await new Promise(resolve => setTimeout(resolve, 200));
+    setOptions(["1", "2", "3"]);
+    flush();
+
+    expect(select.options.length).toBe(3);
+    expect(select.value).toBe("2");
+    expect(select.options[1].selected).toBe(true);
+
+    dispose();
+  });
+
   it("multi-select: defaultSelected on multiple options is the reset target", () => {
     let select, form, dispose;
     // Two options have defaultSelected={true}; the dynamic `selected` signals


### PR DESCRIPTION
This PR addresses 2 issues

1. The issue that there are two ways to change what's selected in a `<select>`. One is via `select.value`, and the other is via its options `option.selected`.  (class/classList problem) dom with state will also find this issue when effect re-runs.
2. The other is that `options` can be loaded async, that's why we have the brittle workaround/hack `queueMicrotask`  when its select and value prop. (but Im actually not sure if for solid async a simple queueMicrotask would have worked 100% of the time)

This PR forbids `select.value` similarly how we forbid `<input prop:value={}/>`, and for toggling what's selected you just use the `option`s.  This is what's being suggested in the issues when people have found this difficulty.

1 may be reason enough, but in the case of 2, what worries me the most is that you ship something that works with the queueMicrotask hack, then you make options async and queueMicrotask stops working. So what you ship broke unexpectedly.
 