### PR TITLE
[next] removes mouse events that fire too much from default delegated events , allows opt-in

### DIFF
--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -34,17 +34,10 @@ const DelegatedEvents = /*#__PURE__*/ new Set([
   "keydown",
   "keyup",
   "mousedown",
-  "mousemove",
-  "mouseout",
-  "mouseover",
   "mouseup",
   "pointerdown",
-  "pointermove",
-  "pointerout",
-  "pointerover",
   "pointerup",
   "touchend",
-  "touchmove",
   "touchstart"
 ]);
 


### PR DESCRIPTION
Removes mouse events that fire too much from delegated events. 

Delegated means the event is **attached** to the `document` and **never removed**, so these mouse events are always captured, and the DOM walked up for the existence of the page.

This is a topic we have discussed with @fabiospampinato in the past.

It is of my understanding, that delegated events are nice for when you want to bubble an event from a `Portal` to the component that created the portal. That's cool, however, I think this shouldn't be a default for events that fire too much.

Anyway, I may be right on thinking we can still support the events removed in this PR because we are exporting the `Set` named `DelegatedEvents`, and the function `delegateEvents`. 

So my intention is to remove these events from the defaults, but also make sure we can still opt-in into making these events delegated, for people that desire or need to do so. 

Seems like doing the following should be enough, if my intuition is correct

```js
import { delegateEvents } from '@solidjs/web';
delegateEvents(["mouseover"])
```

