### PR TITLE
[next] Move xml wrappers to template string instead of modifying the ast

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -9,7 +9,6 @@ import {
 } from "dom-expressions/src/constants";
 import VoidElements from "../VoidElements";
 import {
-  addAttribute,
   evaluateAndInline,
   getAttributeNamed,
   getTagName,
@@ -30,8 +29,7 @@ import {
   transformCondition,
   trimWhitespace,
   inlineCallExpression,
-  hasStaticMarker,
-  wrapWithTag
+  hasStaticMarker
 } from "../shared/utils";
 import { transformNode } from "../shared/transform";
 import { InlineElements, BlockElements } from "./constants";
@@ -71,7 +69,7 @@ export function transformElement(path, info) {
     });
 
   let isWrapped = false;
-
+  let wrapperTag = "";
   if (info.topLevel) {
     /**
      * XML handling.
@@ -92,16 +90,12 @@ export function transformElement(path, info) {
         : undefined;
 
       if (SVGElements.has(tagName) || xmlns === Namespaces.svg) {
-        wrapWithTag(path, "svg");
-        path.skip(); // avoid visiting the newly created wrapper
         isWrapped = true;
-        tagName = "svg";
+        wrapperTag = "svg";
         xmlnsAttr && xmlnsAttr.remove();
       } else if (MathMLElements.has(tagName) || xmlns === Namespaces.mathml) {
-        wrapWithTag(path, "math");
-        path.skip(); // avoid visiting the newly created wrapper
         isWrapped = true;
-        tagName = "math";
+        wrapperTag = "math";
         xmlnsAttr && xmlnsAttr.remove();
       }
     } else {
@@ -183,7 +177,10 @@ export function transformElement(path, info) {
   if (config.hydratable && (tagName === "html" || tagName === "head" || tagName === "body")) {
     results.skipTemplate = true;
   }
-
+  if (wrapperTag !== "") {
+    results.template = `<${wrapperTag}>` + results.template;
+    results.templateWithClosingTags = `<${wrapperTag}>` + results.templateWithClosingTags;
+  }
   if (!info.skipId) {
     results.id = path.scope.generateUidIdentifier("el$");
   }
@@ -216,7 +213,10 @@ export function transformElement(path, info) {
     );
     results.postExprs.push(t.expressionStatement(t.callExpression(runHydrationEvents, [])));
   }
-
+  if (wrapperTag !== "") {
+    results.template += `</${wrapperTag}>`;
+    results.templateWithClosingTags += `</${wrapperTag}>`;
+  }
   return results;
 }
 

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
@@ -49,7 +49,7 @@ export function appendTemplates(path, templates) {
       raw: escapeStringForTemplate(template.template)
     };
 
-    const flag = template.isImportNode ? 1 : template.isWrapped ? 2 : null;
+    const flag = template.isWrapped ? 2 : template.isImportNode ? 1 : null;
 
     return t.variableDeclarator(
       template.id,

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -569,14 +569,3 @@ export function isStatefulDOMProperty(tagName, propName) {
 export function addAttribute(path, name, value) {
   path.get("openingElement").pushContainer("attributes", t.jsxAttribute(name, value));
 }
-
-export function wrapWithTag(path, tagName) {
-  const wrapper = t.jsxElement(
-    t.jsxOpeningElement(t.jsxIdentifier(tagName), [], false),
-    t.jsxClosingElement(t.jsxIdentifier(tagName)),
-    [path.node],
-    false
-  );
-
-  path.replaceWith(t.inherits(wrapper, path.node));
-}

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVG/output.js
@@ -13,7 +13,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(
     `<svg width=400 height=180><rect rx=20 ry=20 width=150 height=150 style=fill:red;stroke:black;opacity:0.5>`
   ),
   _tmpl$3 = /*#__PURE__*/ _$template(`<svg width=400 height=180><rect>`),
-  _tmpl$4 = /*#__PURE__*/ _$template(`<svg><rect x=50 y=20 width=150 height=150>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<svg><rect x=50 y=20 width=150 height=150></svg>`, 2),
   _tmpl$5 = /*#__PURE__*/ _$template(`<svg viewBox="0 0 160 40"><a><text x=10 y=25>MDN Web Docs`),
   _tmpl$6 = /*#__PURE__*/ _$template(`<svg viewBox="0 0 160 40"><text x=10 y=25>`);
 const template = _tmpl$();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVGComponentPartial/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVGComponentPartial/code.js
@@ -1,0 +1,5 @@
+const template = (
+  <g>
+    <circle cx={props.cx} cy={props.cy} r="5" fill="red" />
+  </g>
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVGComponentPartial/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/SVGComponentPartial/output.js
@@ -1,0 +1,23 @@
+import { template as _$template } from "r-dom";
+import { setAttribute as _$setAttribute } from "r-dom";
+import { effect as _$effect } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(`<svg><g><circle r=5 fill=red></svg>`, 2);
+const template = (() => {
+  var _el$ = _tmpl$(),
+    _el$2 = _el$.firstChild;
+  _$effect(
+    () => ({
+      e: props.cx,
+      t: props.cy
+    }),
+    ({ e, t }, _p$) => {
+      e !== _p$.e && _$setAttribute(_el$2, "cx", e);
+      t !== _p$.t && _$setAttribute(_el$2, "cy", t);
+    },
+    {
+      e: undefined,
+      t: undefined
+    }
+  );
+  return _el$;
+})();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -52,7 +52,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div><h1><a href=/>Welcome`),
   _tmpl$35 = /*#__PURE__*/ _$template(`<div true>`),
   _tmpl$36 = /*#__PURE__*/ _$template(`<div a b c d f=0 g h l>`),
   _tmpl$37 = /*#__PURE__*/ _$template(`<math display=block><mrow>`),
-  _tmpl$38 = /*#__PURE__*/ _$template(`<math><mrow><mi>x</mi><mo>=`, 2),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<math><mrow><mi>x</mi><mo>=</math>`, 2),
   _tmpl$39 = /*#__PURE__*/ _$template(`<div style=background:red>`),
   _tmpl$40 = /*#__PURE__*/ _$template(
     `<div style=background:red;color:green;margin:3;padding:0.4>`

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVG/output.js
@@ -16,7 +16,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(
     `<svg width=400 height=180><rect rx=20 ry=20 width=150 height=150 style=fill:red;stroke:black;opacity:0.5>`
   ),
   _tmpl$3 = /*#__PURE__*/ _$template(`<svg width=400 height=180><rect>`),
-  _tmpl$4 = /*#__PURE__*/ _$template(`<svg><rect x=50 y=20 width=150 height=150>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<svg><rect x=50 y=20 width=150 height=150></svg>`, 2),
   _tmpl$5 = /*#__PURE__*/ _$template(`<svg viewBox="0 0 160 40"><a><text x=10 y=25>MDN Web Docs`),
   _tmpl$6 = /*#__PURE__*/ _$template(`<svg viewBox="0 0 160 40"><text x=10 y=25>`);
 const template = _$getNextElement(_tmpl$);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVGComponentPartial/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVGComponentPartial/code.js
@@ -1,0 +1,5 @@
+const template = (
+  <g>
+    <circle cx={props.cx} cy={props.cy} r="5" fill="red" />
+  </g>
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVGComponentPartial/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/SVGComponentPartial/output.js
@@ -1,0 +1,24 @@
+import { template as _$template } from "r-dom";
+import { setAttribute as _$setAttribute } from "r-dom";
+import { effect as _$effect } from "r-dom";
+import { getNextElement as _$getNextElement } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(`<svg><g><circle r=5 fill=red></svg>`, 2);
+const template = (() => {
+  var _el$ = _$getNextElement(_tmpl$),
+    _el$2 = _el$.firstChild;
+  _$effect(
+    () => ({
+      e: props.cx,
+      t: props.cy
+    }),
+    ({ e, t }, _p$) => {
+      e !== _p$.e && _$setAttribute(_el$2, "cx", e);
+      t !== _p$.t && _$setAttribute(_el$2, "cy", t);
+    },
+    {
+      e: undefined,
+      t: undefined
+    }
+  );
+  return _el$;
+})();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -54,7 +54,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div><h1><a href=/>Welcome`),
   _tmpl$35 = /*#__PURE__*/ _$template(`<div true>`),
   _tmpl$36 = /*#__PURE__*/ _$template(`<div a b c d f=0 g h l>`),
   _tmpl$37 = /*#__PURE__*/ _$template(`<math display=block><mrow>`),
-  _tmpl$38 = /*#__PURE__*/ _$template(`<math><mrow><mi>x</mi><mo>=`, 2),
+  _tmpl$38 = /*#__PURE__*/ _$template(`<math><mrow><mi>x</mi><mo>=</math>`, 2),
   _tmpl$39 = /*#__PURE__*/ _$template(`<div style=background:red>`),
   _tmpl$40 = /*#__PURE__*/ _$template(
     `<div style=background:red;color:green;margin:3;padding:0.4>`

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/SVG/output.js
@@ -13,7 +13,7 @@ var _tmpl$ = /*#__PURE__*/ _$template(
     `<svg width=400 height=180><rect rx=20 ry=20 width=150 height=150 style=fill:red;stroke:black;opacity:0.5>`
   ),
   _tmpl$3 = /*#__PURE__*/ _$template(`<svg width=400 height=180><rect>`),
-  _tmpl$4 = /*#__PURE__*/ _$template(`<svg><rect x=50 y=20 width=150 height=150>`, 2),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<svg><rect x=50 y=20 width=150 height=150></svg>`, 2),
   _tmpl$5 = /*#__PURE__*/ _$template(`<svg viewBox="0 0 160 40"><a><text x=10 y=25>MDN Web Docs`),
   _tmpl$6 = /*#__PURE__*/ _$template(`<svg viewBox="0 0 160 40"><text x=10 y=25>`);
 const template = _tmpl$();

--- a/packages/dom-expressions/src/client.d.ts
+++ b/packages/dom-expressions/src/client.d.ts
@@ -14,7 +14,13 @@ export function render(
   init?: JSX.Element,
   options?: { owner?: unknown }
 ): () => void;
-export function template(html: string, flag?: number): () => Element;
+/**
+ * @param flag
+ * - `undefined` — clone the template as-is (uses `cloneNode`).
+ * - `1` — use `document.importNode` instead of `cloneNode`.
+ * - `2` — the template html is wrapped; the outer tag is stripped at clone time.
+ */
+export function template(html: string, flag?: 1 | 2): () => Element;
 export function effect<T>(fn: (prev?: T) => T, effect: (value: T, prev?: T) => void, init?: T): void;
 export function memo<T>(fn: () => T, equal: boolean): () => T;
 export function untrack<T>(fn: () => T): T;

--- a/packages/dom-expressions/src/server.d.ts
+++ b/packages/dom-expressions/src/server.d.ts
@@ -129,8 +129,14 @@ export function addEventListener(
 
 /** @deprecated not supported on the server side */
 export function render(code: () => JSX.Element, element: MountableElement): () => void;
-/** @deprecated not supported on the server side */
-export function template(html: string, flag?: number): () => Element;
+/**
+ * @deprecated not supported on the server side
+ * @param flag
+ * - `undefined` — clone the template as-is (uses `cloneNode`).
+ * - `1` — use `document.importNode` instead of `cloneNode`.
+ * - `2` — the template html is wrapped; the outer tag is stripped at clone time.
+ */
+export function template(html: string, flag?: 1 | 2): () => Element;
 /** @deprecated not supported on the server side */
 export function setProperty(node: Element, name: string, value: any): void;
 /** @deprecated not supported on the server side */

--- a/packages/dom-expressions/test/dom/svg.spec.jsx
+++ b/packages/dom-expressions/test/dom/svg.spec.jsx
@@ -59,4 +59,26 @@ describe("create simple svg", () => {
     expect(g.namespaceURI).toBe("http://www.w3.org/2000/svg");
     expect(circle.namespaceURI).toBe("http://www.w3.org/2000/svg");
   });
+
+  it("Children of a component rendered inside <math> receive the MathML namespace", () => {
+    let row, identifier;
+    function Term() {
+      return (
+        <mrow ref={row}>
+          <mi ref={identifier}>x</mi>
+        </mrow>
+      );
+    }
+    function App() {
+      return (
+        <math display="block">
+          <Term />
+        </math>
+      );
+    }
+
+    createRoot(() => <App />);
+    expect(row.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+    expect(identifier.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+  });
 });

--- a/packages/dom-expressions/test/dom/svg.spec.jsx
+++ b/packages/dom-expressions/test/dom/svg.spec.jsx
@@ -37,4 +37,26 @@ describe("create simple svg", () => {
       `<rect x="10" y="50" width="150" height="150" style="fill: red; stroke: black; stroke-width: 5; opacity: 0.5;" class="classy" title="hello"></rect>`
     );
   });
+
+  it("Children of a component rendered inside <svg> receive the SVG namespace", () => {
+    let g, circle;
+    function Dot(props) {
+      return (
+        <g ref={g}>
+          <circle ref={circle} cx={props.cx} cy={props.cy} r={5} fill="red" />
+        </g>
+      );
+    }
+    function App() {
+      return (
+        <svg width={200} height={200}>
+          <Dot cx={100} cy={100} />
+        </svg>
+      );
+    }
+
+    createRoot(() => <App />);
+    expect(g.namespaceURI).toBe("http://www.w3.org/2000/svg");
+    expect(circle.namespaceURI).toBe("http://www.w3.org/2000/svg");
+  });
 });


### PR DESCRIPTION
## Summary
- move xml partial wrapping into template string generation instead of mutating the AST
- keep the namespaceURI runtime coverage added in the original branch and add exact compiler fixtures for the wrapped SVG component partial case
- add a matching MathML runtime namespace test so both wrapped XML paths are covered

## Test plan
- [x] pnpm test -- test/dom.spec.js test/dom-hydratable.spec.js
- [x] pnpm test -- test/dom/svg.spec.jsx

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the compiler generates wrapped SVG/MathML templates (and the `template()` flag selection), which can affect element creation and namespaces at runtime/hydration. Coverage is improved with new fixtures/tests, but template generation is a core path.
> 
> **Overview**
> Moves XML partial wrapping (`svg`/`math`) from **mutating the JSX AST** to **prefixing/suffixing the generated template strings**, and removes the now-unused `wrapWithTag` helper.
> 
> Adjusts `appendTemplates` flag selection so wrapped templates consistently use flag `2` (outer wrapper stripped at clone time), updates TS typings/docs for `template(html, flag?: 1 | 2)`, and refreshes compiler fixtures plus new runtime tests ensuring component children inside `<svg>`/`<math>` get the correct namespace URI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2898b71b8e4fd78a54425218d4eb469bf3bad38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->