### PR TITLE
[next] DOM with state handling in mergeProps, and default* check prev

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -1293,7 +1293,7 @@ function processSpreads(path, attributes, { elem, hasChildren, wrapConditionals 
       } else {
         runningObject.push(
           t.objectProperty(
-            t.stringLiteral(key),
+            t.stringLiteral(isLockedDOMProperty(tagName, key) ? key.replace(/^prop:/, "") : key),
             isContainer ? node.value.expression : node.value || t.booleanLiteral(true)
           )
         );

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -26,6 +26,7 @@ import {
   getConfig,
   escapeHTML,
   convertJSXIdentifier,
+  isLockedDOMProperty,
   transformCondition,
   trimWhitespace,
   inlineCallExpression,
@@ -283,8 +284,8 @@ export function setAttr(path, elem, name, value, { dynamic, prevId, tagName }) {
 
   const isChildProp = ChildProperties.has(name);
 
-  if (isChildProp || namespace === "prop") {
-    if (config.hydratable && namespace !== "prop") {
+  if (isChildProp || namespace === "prop" || isLockedDOMProperty(tagName, name)) {
+    if (config.hydratable && namespace !== "prop" && !isLockedDOMProperty(tagName, name)) {
       return t.callExpression(registerImportMethod(path, "setProperty"), [
         elem,
         t.stringLiteral(name),

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -1230,6 +1230,8 @@ function contextToCustomElement(path, results) {
 
 function processSpreads(path, attributes, { elem, hasChildren, wrapConditionals }) {
   const config = getConfig(path);
+  const tagName = getTagName(path.node);
+
   // TODO: skip but collect the names of any properties after the last spread to not overwrite them
   const filteredAttributes = [];
   const spreadArgs = [];
@@ -1266,7 +1268,10 @@ function processSpreads(path, attributes, { elem, hasChildren, wrapConditionals 
       const dynamic =
         isContainer && isDynamic(attribute.get("value").get("expression"), { checkMember: true });
       if (dynamic) {
-        const id = convertJSXIdentifier(node.name);
+        const id = isLockedDOMProperty(tagName, key)
+          ? t.identifier(key.replace(/^prop:/, ""))
+          : convertJSXIdentifier(node.name);
+
         let expr =
           wrapConditionals &&
           (t.isLogicalExpression(node.value.expression) ||
@@ -1279,7 +1284,9 @@ function processSpreads(path, attributes, { elem, hasChildren, wrapConditionals 
             id,
             [],
             t.blockStatement([t.returnStatement(expr.body)]),
-            !t.isValidIdentifier(key)
+            !t.isValidIdentifier(
+              isLockedDOMProperty(tagName, key) ? key.replace(/^prop:/, "") : key
+            )
           )
         );
       } else {

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -477,7 +477,6 @@ export function getAttributeNamed(path, name) {
         const key = t.isJSXNamespacedName(attr.node.name)
           ? `${attr.node.name.namespace.name}:${attr.node.name.name.name}`
           : attr.node.name.name;
-
         return key === name;
       }
     });
@@ -501,22 +500,25 @@ export function transformSpecialCaseAttributes(path, tagName, isSSR) {
   tagName = tagName.toUpperCase();
   const transforms = [];
 
+  let hasOrHadAttribute = {};
+
   for (const propName in DOMWithState[tagName]) {
-    if (propName.startsWith("prop:")) continue;
     const attr = getAttributeNamed(path, propName);
     if (attr) {
+      hasOrHadAttribute[propName] = true;
       transforms.push({ propName, attr });
     }
   }
 
   for (const { propName, attr } of transforms) {
-    const value = attr.node.value == null
-      ? t.booleanLiteral(true)
-      : t.cloneNode(attr.node.value.expression ?? attr.node.value);
+    const value =
+      attr.node.value == null
+        ? t.booleanLiteral(true)
+        : t.cloneNode(attr.node.value.expression ?? attr.node.value);
 
     const isDefault =
       propName.includes("default") ||
-      !getAttributeNamed(path, "default" + propName[0].toUpperCase() + propName.slice(1));
+      !hasOrHadAttribute["default" + propName[0].toUpperCase() + propName.slice(1)];
 
     const defaultAttrName = propName.replace("default", "").toLowerCase();
 
@@ -558,7 +560,7 @@ export function transformSpecialCaseAttributes(path, tagName, isSSR) {
   }
 }
 
-export function isStatefulDOMProperty(tagName, propName) {
+export function isDOMWithState(tagName, propName) {
   tagName = tagName.toUpperCase();
 
   if (propName.includes("prop:")) {
@@ -566,6 +568,14 @@ export function isStatefulDOMProperty(tagName, propName) {
   }
 
   return DOMWithState[tagName]?.[propName];
+}
+
+export function isStatefulDOMProperty(tagName, propName) {
+  return isDOMWithState(tagName, propName) === 1;
+}
+
+export function isLockedDOMProperty(tagName, propName) {
+  return !!isDOMWithState(tagName, propName);
 }
 
 export function addAttribute(path, name, value) {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/code.js
@@ -249,8 +249,6 @@ const template74 = <div><video poster="1.jpg"/></div>
 const template75 = <video prop:poster="1.jpg"/>
 const template76 = <div><video prop:poster="1.jpg"/></div>
 
-// ONCE TESTS
-
 const template77 = <div style={/*@once*/ { width: props.width, height: props.height }} />;
 
 const template78 = (
@@ -263,8 +261,6 @@ const template79 = (
     something={/*@once*/ color()}
   />
 );
-
-// ONCE TESTS SPREADS
 
 const propsSpread = {
   something: color(),
@@ -300,9 +296,8 @@ const template84 = (
   />
 );
 
-// ONCE PROPERTY OF OBJECT ACCESS
+/* https://github.com/ryansolid/dom-expressions/issues/252#issuecomment-1572220563 */
 
-// https://github.com/ryansolid/dom-expressions/issues/252#issuecomment-1572220563
 const styleProp = { style: { width: props.width, height: props.height } };
 const template85 = <div style={/* @once */ styleProp.style} />;
 const template86 = <div style={styleProp.style} />;
@@ -324,7 +319,6 @@ const template88 = (
   </button>
 );
 
-// Style edge cases from main
 {
   <div
     style={{
@@ -395,3 +389,5 @@ const template96 = <video src="test.mp4" muted/>
 function MyVideo() {
   return <video src="test.mp4" muted />
 }
+
+const template97 = <input value={get()} {...{style:"color:red"}}/>

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -74,7 +74,8 @@ var _tmpl$ = /*#__PURE__*/ _$template(`<div><h1><a href="/">Welcome</a></h1></di
     `<div><textarea></textarea><textarea></textarea><textarea></textarea><textarea></textarea><textarea></textarea><textarea>static content</textarea><textarea>static content</textarea></div>`
   ),
   _tmpl$53 = /*#__PURE__*/ _$template(`<svg><a>xml link partial</a></svg>`, 2),
-  _tmpl$54 = /*#__PURE__*/ _$template(`<video src="test.mp4"muted></video>`);
+  _tmpl$54 = /*#__PURE__*/ _$template(`<video src="test.mp4"muted></video>`),
+  _tmpl$55 = /*#__PURE__*/ _$template(`<input>`);
 import * as styles from "./styles.module.css";
 import { binding } from "somewhere";
 function refFn() {}
@@ -661,9 +662,6 @@ const template76 = (() => {
   _el$93.poster = "1.jpg";
   return _el$92;
 })();
-
-// ONCE TESTS
-
 const template77 = (() => {
   var _el$94 = _tmpl$4();
   _$setStyleProperty(_el$94, "width", props.width);
@@ -691,9 +689,6 @@ const template79 = (() => {
   );
   return _el$96;
 })();
-
-// ONCE TESTS SPREADS
-
 const propsSpread = {
   something: color(),
   style: {
@@ -775,9 +770,8 @@ const template84 = (() => {
   return _el$101;
 })();
 
-// ONCE PROPERTY OF OBJECT ACCESS
+/* https://github.com/ryansolid/dom-expressions/issues/252#issuecomment-1572220563 */
 
-// https://github.com/ryansolid/dom-expressions/issues/252#issuecomment-1572220563
 const styleProp = {
   style: {
     width: props.width,
@@ -837,8 +831,6 @@ const template88 = (() => {
   });
   return _el$105;
 })();
-
-// Style edge cases from main
 {
   _tmpl$48();
 }
@@ -936,13 +928,13 @@ const template93 = (() => {
       }
     ) => {
       _el$114.value = e ?? "";
-      _el$115.defaultValue = t ?? "";
+      t !== _p$.t && (_el$115.defaultValue = t ?? "");
       _el$118.value = a ?? "";
-      _el$119.defaultValue = o ?? "";
+      o !== _p$.o && (_el$119.defaultValue = o ?? "");
       _el$119.value = i ?? "";
       _el$124.muted = n;
       _el$125.muted = s;
-      _el$126.defaultMuted = h;
+      h !== _p$.h && (_el$126.defaultMuted = h);
       _el$126.muted = r;
     }
   );
@@ -977,7 +969,7 @@ const template94 = (() => {
     ) => {
       _el$128.value = e ?? "";
       _el$129.value = t ?? "";
-      _el$130.defaultValue = a ?? "";
+      a !== _p$.a && (_el$130.defaultValue = a ?? "");
       _el$130.value = o ?? "";
       _el$131.value = i ?? "";
     }
@@ -989,4 +981,22 @@ const template96 = _tmpl$54();
 function MyVideo() {
   return _tmpl$54();
 }
+const template97 = (() => {
+  var _el$136 = _tmpl$55();
+  _$spread(
+    _el$136,
+    _$mergeProps(
+      {
+        get value() {
+          return get();
+        }
+      },
+      {
+        style: "color:red"
+      }
+    ),
+    false
+  );
+  return _el$136;
+})();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -914,7 +914,7 @@ const template93 = (() => {
     ) => {
       _el$116.muted = e;
       _el$117.muted = t;
-      _el$118.defaultMuted = a;
+      a !== _p$.a && (_el$118.defaultMuted = a);
       _el$118.muted = o;
     }
   );

--- a/packages/dom-expressions/src/client.d.ts
+++ b/packages/dom-expressions/src/client.d.ts
@@ -1,5 +1,5 @@
 import { JSX } from "./jsx.js";
-export const DOMWithState: Record<string, Record<string, number>>;
+export const DOMWithState: Record<string, Record<string, 1 | 2>>;
 export const ChildProperties: Set<string>;
 export const DelegatedEvents: Set<string>;
 export const DOMElements: Set<string>;

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -491,8 +491,8 @@ function assignProp(node, prop, value, prev, skipRef, nodeName) {
   if (prop === "style") return (style(node, value, prev), value);
   if (prop === "class") return (className(node, value, prev), value);
   // dom with state may differs from reactive state
-  // reactive state is the source of truth
-  if (value === prev && !DOMWithState[nodeName]?.[prop]) return prev;
+  // dom value derives from reactive state
+  if (value === prev && DOMWithState[nodeName]?.[prop] !== 1) return prev;
   if (prop === "ref") {
     if (!skipRef && value) ref(() => value, node);
     return value;

--- a/packages/dom-expressions/src/constants.d.ts
+++ b/packages/dom-expressions/src/constants.d.ts
@@ -1,4 +1,10 @@
-export const DOMWithState: Record<string, Record<string, number>>;
+/**
+ * Flags
+ *
+ * - 1 - Stateful property - value derives from reactive state
+ * - 2 - Locked to property - value not specially treated
+ */
+export const DOMWithState: Record<string, Record<string, 1 | 2>>;
 
 export const ChildProperties: Set<string>;
 

--- a/packages/dom-expressions/src/constants.js
+++ b/packages/dom-expressions/src/constants.js
@@ -1,19 +1,17 @@
+/**
+ * Flags
+ *
+ * - 1 - Stateful property - value derives from reactive state
+ * - 2 - Locked to property - value not specially treated
+ */
 const DOMWithState = {
-  INPUT: { value: 1, defaultValue: 1, checked: 1, defaultChecked: 1 },
+  INPUT: { value: 1, defaultValue: 2, checked: 1, defaultChecked: 2 },
   SELECT: { value: 1 },
-  OPTION: { value: 1, selected: 1, defaultSelected: 1 },
-  TEXTAREA: { value: 1, defaultValue: 1 },
-  VIDEO: { muted: 1, defaultMuted: 1 },
-  AUDIO: { muted: 1, defaultMuted: 1 }
+  OPTION: { value: 1, selected: 1, defaultSelected: 2 },
+  TEXTAREA: { value: 1, defaultValue: 2 },
+  VIDEO: { muted: 1, defaultMuted: 2 },
+  AUDIO: { muted: 1, defaultMuted: 2 }
 };
-
-// this is for spreads, spreads will receive "prop:value" and "value"
-// either we do this here once or in spreads remove `prop:` from every key name
-for (const tagName in DOMWithState) {
-  for (const propName in DOMWithState[tagName]) {
-    DOMWithState[tagName]["prop:" + propName] = 1;
-  }
-}
 
 const ChildProperties = /*#__PURE__*/ new Set([
   "innerHTML",

--- a/packages/lit-dom-expressions/src/index.ts
+++ b/packages/lit-dom-expressions/src/index.ts
@@ -23,7 +23,7 @@ interface Runtime {
   dynamicProperty(props: any, key: string): any;
   setAttribute(node: Element, name: string, value: any): void;
   setAttributeNS(node: Element, namespace: string, name: string, value: any): void;
-  DOMWithState: Record<string, Record<string, number>>;
+  DOMWithState: Record<string, Record<string, 1 | 2>>;
   ChildProperties: Set<string>;
   DelegatedEvents: Set<string>;
   SVGElements: Set<string>;
@@ -176,13 +176,13 @@ export function createHTML(
       namespace = parts[0];
     }
     const isChildProp = r.ChildProperties.has(name);
-    const isStatefulDOMProperty = !!r.DOMWithState[node.name.toUpperCase()]?.[name];
+    const isLockedDOMProperty = !!r.DOMWithState[node.name.toUpperCase()]?.[name];
 
     if (name === "style") {
       options.exprs.push(`r.style(${tag},${expr},_$p)`);
     } else if (name === "class") {
       options.exprs.push(`r.className(${tag},${expr},_$p)`);
-    } else if (isChildProp || isStatefulDOMProperty || namespace === "prop") {
+    } else if (isChildProp || isLockedDOMProperty || namespace === "prop") {
       options.exprs.push(`${tag}.${name} = ${expr}`);
     } else {
       const ns = name.indexOf(":") > -1 && r.Namespaces[name.split(":")[0]];


### PR DESCRIPTION
Handles 2 things:

1. Compare defaultValue with previous value from effect, dom property is stateless, but still locked to properties

2. Handle merge props:

At compile time we were ok, at assign time in client we also were ok, but noticed that `mergeProps` had the problem of dom with state having the `prop:` prefix, it would not have merged

`mergeProps` getters need to drop `prop:` in stateful properties to be able to collapse the keys. It doesnt really matter that doesnt have the `prop:` prefix because in client assign time its locked to be a property (the replacement is only done to dom with state properties).

The following:

```js
const propsObj = { value: 1 }
const template97 = <input {...propsObj} value={get()} />
```

was compiling to something on the lines of 

```js
const template97 = (() => {
  var _el$136 = _tmpl$55();
  _$spread(
    _el$136,
    _$mergeProps(propsObj, 
      {
        get ["prop:value"]() {
          return get();
        }
      },
    ),
    false
  );
  return _el$136;
})();
```

it changed now to be the following so it can collapse `value` into 1 thing

```js
const template97 = (() => {
  var _el$136 = _tmpl$55();
  _$spread(
    _el$136,
    _$mergeProps(propsObj, 
      {
        get value() {
          return get();
        }
      },
    ),
    false
  );
  return _el$136;
})();
```