### PR TITLE
[next] Wrap the effect compute argument

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/template.js
@@ -4,9 +4,9 @@ import {
   getConfig,
   getNumberedId,
   getRendererConfig,
-  inlineCallExpression,
   isStatefulDOMProperty,
-  registerImportMethod
+  registerImportMethod,
+  wrapForEffect
 } from "../shared/utils";
 import { setAttr } from "./element";
 
@@ -125,7 +125,7 @@ function wrapDynamics(path, dynamics) {
     const newValue = t.identifier("_v$");
     return t.expressionStatement(
       t.callExpression(effectWrapperId, [
-        inlineCallExpression(dynamics[0].value),
+        wrapForEffect(dynamics[0].value),
         t.arrowFunctionExpression(
           prevValue ? [newValue, prevValue] : [newValue],
           t.blockStatement([

--- a/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/shared/utils.js
@@ -402,6 +402,18 @@ export function inlineCallExpression(node) {
     : t.arrowFunctionExpression([], node);
 }
 
+// Like inlineCallExpression, but only unwraps IIFEs — never a bare identifier
+// call. Used for the first argument of a two-arg effect, where the reactive
+// system passes the previous value into the compute function and a bare
+// identifier callee would leak that prev into user-authored accessors.
+export function wrapForEffect(node) {
+  return t.isCallExpression(node) &&
+    !node.arguments.length &&
+    (t.isArrowFunctionExpression(node.callee) || t.isFunctionExpression(node.callee))
+    ? node.callee
+    : t.arrowFunctionExpression([], node);
+}
+
 const chars = "etaoinshrdlucwmfygpbTAOISWCBvkxjqzPHFMDRELNGUKVYJQZX_$";
 const base = chars.length;
 

--- a/packages/babel-plugin-jsx-dom-expressions/src/universal/template.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/universal/template.js
@@ -3,7 +3,7 @@ import {
   getConfig,
   getNumberedId,
   registerImportMethod,
-  inlineCallExpression
+  wrapForEffect
 } from "../shared/utils";
 import { setAttr } from "./element";
 
@@ -51,7 +51,7 @@ function wrapDynamics(path, dynamics) {
 
     return t.expressionStatement(
       t.callExpression(effectWrapperId, [
-        inlineCallExpression(dynamics[0].value),
+        wrapForEffect(dynamics[0].value),
         t.arrowFunctionExpression(
           [newValue, prevValue],
           t.blockStatement([

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_compatible_fixtures__/attributeExpressions/output.js
@@ -195,9 +195,12 @@ const template5 = _tmpl$5();
 const template6 = (() => {
   var _el$12 = _tmpl$4();
   _el$12.textContent = "Hi";
-  _$effect(someStyle, (_v$, _$p) => {
-    _$style(_el$12, _v$, _$p);
-  });
+  _$effect(
+    () => someStyle(),
+    (_v$, _$p) => {
+      _$style(_el$12, _v$, _$p);
+    }
+  );
   return _el$12;
 })();
 let undefVar;
@@ -525,9 +528,12 @@ const template38 = (() => {
 const template39 = _tmpl$22();
 const template40 = (() => {
   var _el$54 = _tmpl$4();
-  _$effect(a, _v$ => {
-    _$setStyleProperty(_el$54, "color", _v$);
-  });
+  _$effect(
+    () => a(),
+    _v$ => {
+      _$setStyleProperty(_el$54, "color", _v$);
+    }
+  );
   return _el$54;
 })();
 const template41 = (() => {
@@ -621,9 +627,12 @@ const template64 = _tmpl$40();
 const template65 = _tmpl$41();
 const template66 = (() => {
   var _el$82 = _tmpl$41();
-  _$effect(signal, _v$ => {
-    _$setStyleProperty(_el$82, "border", _v$);
-  });
+  _$effect(
+    () => signal(),
+    _v$ => {
+      _$setStyleProperty(_el$82, "border", _v$);
+    }
+  );
   return _el$82;
 })();
 const template67 = (() => {
@@ -672,9 +681,12 @@ const template78 = (() => {
   var _el$95 = _tmpl$4();
   _$setStyleProperty(_el$95, "width", props.width);
   _$setStyleProperty(_el$95, "height", props.height);
-  _$effect(color, _v$ => {
-    _$setAttribute(_el$95, "something", _v$);
-  });
+  _$effect(
+    () => color(),
+    _v$ => {
+      _$setAttribute(_el$95, "something", _v$);
+    }
+  );
   return _el$95;
 })();
 const template79 = (() => {
@@ -826,9 +838,12 @@ const template88 = (() => {
   _$style(_el$105, style);
   _$className(_el$105, style);
   _$insert(_el$105, count);
-  _$effect(count, _v$ => {
-    _$setAttribute(_el$105, "aria-label", _v$);
-  });
+  _$effect(
+    () => count(),
+    _v$ => {
+      _$setAttribute(_el$105, "aria-label", _v$);
+    }
+  );
   return _el$105;
 })();
 {

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/attributeExpressions/output.js
@@ -190,9 +190,12 @@ const template5 = _tmpl$5();
 const template6 = (() => {
   var _el$12 = _tmpl$4();
   _el$12.textContent = "Hi";
-  _$effect(someStyle, (_v$, _$p) => {
-    _$style(_el$12, _v$, _$p);
-  });
+  _$effect(
+    () => someStyle(),
+    (_v$, _$p) => {
+      _$style(_el$12, _v$, _$p);
+    }
+  );
   return _el$12;
 })();
 let undefVar;
@@ -520,9 +523,12 @@ const template38 = (() => {
 const template39 = _tmpl$22();
 const template40 = (() => {
   var _el$54 = _tmpl$4();
-  _$effect(a, _v$ => {
-    _$setStyleProperty(_el$54, "color", _v$);
-  });
+  _$effect(
+    () => a(),
+    _v$ => {
+      _$setStyleProperty(_el$54, "color", _v$);
+    }
+  );
   return _el$54;
 })();
 const template41 = (() => {
@@ -616,9 +622,12 @@ const template64 = _tmpl$40();
 const template65 = _tmpl$41();
 const template66 = (() => {
   var _el$82 = _tmpl$41();
-  _$effect(signal, _v$ => {
-    _$setStyleProperty(_el$82, "border", _v$);
-  });
+  _$effect(
+    () => signal(),
+    _v$ => {
+      _$setStyleProperty(_el$82, "border", _v$);
+    }
+  );
   return _el$82;
 })();
 const template67 = (() => {
@@ -670,9 +679,12 @@ const template78 = (() => {
   var _el$95 = _tmpl$4();
   _$setStyleProperty(_el$95, "width", props.width);
   _$setStyleProperty(_el$95, "height", props.height);
-  _$effect(color, _v$ => {
-    _$setAttribute(_el$95, "something", _v$);
-  });
+  _$effect(
+    () => color(),
+    _v$ => {
+      _$setAttribute(_el$95, "something", _v$);
+    }
+  );
   return _el$95;
 })();
 const template79 = (() => {
@@ -828,9 +840,12 @@ const template88 = (() => {
   _$style(_el$105, style);
   _$className(_el$105, style);
   _$insert(_el$105, count);
-  _$effect(count, _v$ => {
-    _$setAttribute(_el$105, "aria-label", _v$);
-  });
+  _$effect(
+    () => count(),
+    _v$ => {
+      _$setAttribute(_el$105, "aria-label", _v$);
+    }
+  );
   return _el$105;
 })();
 

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/multipleClassAttributes/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_fixtures__/multipleClassAttributes/output.js
@@ -13,9 +13,12 @@ const flag = true;
 const t1 = _tmpl$();
 const t2 = (() => {
   var _el$2 = _tmpl$2();
-  _$effect(dynamicClass, (_v$, _$p) => {
-    _$className(_el$2, _v$, _$p);
-  });
+  _$effect(
+    () => dynamicClass(),
+    (_v$, _$p) => {
+      _$className(_el$2, _v$, _$p);
+    }
+  );
   return _el$2;
 })();
 const t3 = _tmpl$3();

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_hydratable_fixtures__/attributeExpressions/output.js
@@ -188,9 +188,12 @@ const template5 = _$getNextElement(_tmpl$5);
 const template6 = (() => {
   var _el$12 = _$getNextElement(_tmpl$4);
   _$setProperty(_el$12, "textContent", "Hi");
-  _$effect(someStyle, (_v$, _$p) => {
-    _$style(_el$12, _v$, _$p);
-  });
+  _$effect(
+    () => someStyle(),
+    (_v$, _$p) => {
+      _$style(_el$12, _v$, _$p);
+    }
+  );
   return _el$12;
 })();
 let undefVar;
@@ -530,9 +533,12 @@ const template38 = (() => {
 const template39 = _$getNextElement(_tmpl$22);
 const template40 = (() => {
   var _el$58 = _$getNextElement(_tmpl$4);
-  _$effect(a, _v$ => {
-    _$setStyleProperty(_el$58, "color", _v$);
-  });
+  _$effect(
+    () => a(),
+    _v$ => {
+      _$setStyleProperty(_el$58, "color", _v$);
+    }
+  );
   return _el$58;
 })();
 const template41 = (() => {
@@ -626,9 +632,12 @@ const template64 = _$getNextElement(_tmpl$40);
 const template65 = _$getNextElement(_tmpl$41);
 const template66 = (() => {
   var _el$86 = _$getNextElement(_tmpl$41);
-  _$effect(signal, _v$ => {
-    _$setStyleProperty(_el$86, "border", _v$);
-  });
+  _$effect(
+    () => signal(),
+    _v$ => {
+      _$setStyleProperty(_el$86, "border", _v$);
+    }
+  );
   return _el$86;
 })();
 const template67 = (() => {
@@ -680,9 +689,12 @@ const template78 = (() => {
   var _el$99 = _$getNextElement(_tmpl$4);
   _$setStyleProperty(_el$99, "width", props.width);
   _$setStyleProperty(_el$99, "height", props.height);
-  _$effect(color, _v$ => {
-    _$setAttribute(_el$99, "something", _v$);
-  });
+  _$effect(
+    () => color(),
+    _v$ => {
+      _$setAttribute(_el$99, "something", _v$);
+    }
+  );
   return _el$99;
 })();
 const template79 = (() => {
@@ -843,9 +855,12 @@ const template88 = (() => {
   _$style(_el$109, style);
   _$className(_el$109, style);
   _$insert(_el$109, count);
-  _$effect(count, _v$ => {
-    _$setAttribute(_el$109, "aria-label", _v$);
-  });
+  _$effect(
+    () => count(),
+    _v$ => {
+      _$setAttribute(_el$109, "aria-label", _v$);
+    }
+  );
   return _el$109;
 })();
 const template89 = _$getNextElement(_tmpl$48);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dynamic_fixtures__/attributeExpressions/output.js
@@ -183,9 +183,12 @@ const template5 = _tmpl$5();
 const template6 = (() => {
   var _el$12 = _tmpl$4();
   _el$12.textContent = "Hi";
-  _$effect(someStyle, (_v$, _$p) => {
-    _$style(_el$12, _v$, _$p);
-  });
+  _$effect(
+    () => someStyle(),
+    (_v$, _$p) => {
+      _$style(_el$12, _v$, _$p);
+    }
+  );
   return _el$12;
 })();
 let undefVar;
@@ -513,9 +516,12 @@ const template38 = (() => {
 const template39 = _tmpl$22();
 const template40 = (() => {
   var _el$54 = _tmpl$4();
-  _$effect(a, _v$ => {
-    _$setStyleProperty(_el$54, "color", _v$);
-  });
+  _$effect(
+    () => a(),
+    _v$ => {
+      _$setStyleProperty(_el$54, "color", _v$);
+    }
+  );
   return _el$54;
 })();
 const template41 = (() => {
@@ -624,9 +630,12 @@ const template64 = _tmpl$38();
 const template65 = _tmpl$39();
 const template66 = (() => {
   var _el$87 = _tmpl$39();
-  _$effect(signal, _v$ => {
-    _$setStyleProperty(_el$87, "border", _v$);
-  });
+  _$effect(
+    () => signal(),
+    _v$ => {
+      _$setStyleProperty(_el$87, "border", _v$);
+    }
+  );
   return _el$87;
 })();
 const template67 = (() => {
@@ -678,9 +687,12 @@ const template78 = (() => {
   var _el$100 = _tmpl$4();
   _$setStyleProperty(_el$100, "width", props.width);
   _$setStyleProperty(_el$100, "height", props.height);
-  _$effect(color, _v$ => {
-    _$setAttribute(_el$100, "something", _v$);
-  });
+  _$effect(
+    () => color(),
+    _v$ => {
+      _$setAttribute(_el$100, "something", _v$);
+    }
+  );
   return _el$100;
 })();
 const template79 = (() => {
@@ -836,9 +848,12 @@ const template88 = (() => {
   _$style(_el$110, style);
   _$className(_el$110, style);
   _$insert(_el$110, count);
-  _$effect(count, _v$ => {
-    _$setAttribute(_el$110, "aria-label", _v$);
-  });
+  _$effect(
+    () => count(),
+    _v$ => {
+      _$setAttribute(_el$110, "aria-label", _v$);
+    }
+  );
   return _el$110;
 })();
 _$delegateEvents(["click", "input"]);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__universal_fixtures__/attributeExpressions/output.js
@@ -121,9 +121,12 @@ const template5 = (() => {
 const template6 = (() => {
   var _el$12 = _$createElement("div");
   _$setProp(_el$12, "textContent", "Hi");
-  _$effect(someStyle, (_v$, _$p) => {
-    _$setProp(_el$12, "style", _v$, _$p);
-  });
+  _$effect(
+    () => someStyle(),
+    (_v$, _$p) => {
+      _$setProp(_el$12, "style", _v$, _$p);
+    }
+  );
   return _el$12;
 })();
 const template7 = (() => {


### PR DESCRIPTION
fixes #510
 
Wrap the effect compute argument in an arrow when the JSX has a single dynamic attribute, so the source expression isn't called with the previous value as its first  argument