### PR TITLE
feat: add omit attribute spacing option

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/README.md
+++ b/packages/babel-plugin-jsx-dom-expressions/README.md
@@ -175,6 +175,15 @@ Removes tags from the template output if they have no closing parents and are th
 
 Removes quotes for html attributes when possible from the template output. This may not work in all browser-like environments the same. The solution has been tested again Chrome/Edge/Firefox/Safari.
 
+### omitAttributeSpacing
+
+- Type: `boolean`
+- Default: `true`
+
+When `true` (the default), the template output drops the whitespace between a quoted attribute and the next attribute (`<svg width="12"height="13">`). This mirrors the prior behavior and relies on the browser's HTML parser to tolerate the missing space. Some strict parsers (notably XML/SVG-only or game-engine browser-likes such as Coherent Gameface) reject the resulting markup.
+
+Set this to `false` to emit a single space between attributes (`<svg width="12" height="13">`) so the generated HTML is strictly valid. This may also be desirable together with `omitQuotes: false` / `omitLastClosingTag: false` when targeting stricter parsers.
+
 ### requireImportSource
 
 - Type: `string | false`

--- a/packages/babel-plugin-jsx-dom-expressions/src/config.ts
+++ b/packages/babel-plugin-jsx-dom-expressions/src/config.ts
@@ -10,6 +10,7 @@ export default {
   omitNestedClosingTags: false,
   omitLastClosingTag: true,
   omitQuotes: true,
+  omitAttributeSpacing: true,
   contextToCustomElements: false,
   staticMarker: "@once",
   effectWrapper: "effect",

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -615,7 +615,7 @@ function transformAttributes(path, results) {
     }
 
     if (needsQuoting) {
-      needsSpacing = false;
+      needsSpacing = !config.omitAttributeSpacing;
       results.template += `="${escapeHTML(text, true)}"`;
     } else {
       needsSpacing = true;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_omit_attribute_spacing_no_omit_fixtures__/SVG/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_omit_attribute_spacing_no_omit_fixtures__/SVG/code.js
@@ -1,0 +1,5 @@
+const template = (
+  <svg width="300" height="130" xmlns="http://www.w3.org/2000/svg">
+    <rect width="200" height="100" x="10" y="10" rx="20" ry="20" fill="blue" />
+  </svg>
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_omit_attribute_spacing_no_omit_fixtures__/SVG/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_omit_attribute_spacing_no_omit_fixtures__/SVG/output.js
@@ -1,0 +1,5 @@
+import { template as _$template } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(
+  `<svg width="300" height="130" xmlns="http://www.w3.org/2000/svg"><rect width="200" height="100" x="10" y="10" rx="20" ry="20" fill="blue"></rect></svg>`
+);
+const template = _tmpl$();

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-omit-attribute-spacing.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-omit-attribute-spacing.spec.js
@@ -1,0 +1,22 @@
+const path = require('path')
+const pluginTester = require('babel-plugin-tester').default;
+const plugin = require('../index');
+
+pluginTester({
+  plugin,
+  pluginOptions: {
+    moduleName: 'r-dom',
+    builtIns: ['For', 'Show'],
+    generate: "dom",
+    wrapConditionals: true,
+    contextToCustomElements: true,
+    staticMarker: "@once",
+    requireImportSource: false,
+    omitLastClosingTag: false,
+    omitQuotes: false,
+    omitAttributeSpacing: false,
+  },
+  title: 'Convert JSX omitAttributeSpacing: false',
+  fixtures: path.join(__dirname, '__dom_omit_attribute_spacing_no_omit_fixtures__'),
+  snapshot: true
+});


### PR DESCRIPTION
Hello, we faced with the same issues with SVG as it was in #405

Gameface parser spams with warns when template omit spaces between attributes in elements.

I've added option `omitAttributeSpacing` that allow to configure it and with `true` value by default to save current behavior.
I've created PR for solidjs vite plugin to add possibility to pass the configure flag: https://github.com/solidjs/vite-plugin-solid/pull/258
It would be great to see it soon in release :)

PS I used AI to find out how to add and update the files. I've reviewed result and tested that it fixes our issue.