### PR TITLE
fix document root reactivity

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@rollup/plugin-commonjs": "24.0.0",
     "@rollup/plugin-json": "6.0.0",
     "@rollup/plugin-node-resolve": "15.0.1",
-    "@solidjs/signals": "2.0.0-beta.8",
+    "@solidjs/signals": "2.0.0-beta.9",
     "@types/jest": "^29.2.5",
     "babel-jest": "^29.3.1",
     "babel-plugin-tester": "^10.1.0",

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-compatible.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-compatible.spec.js
@@ -1,21 +1,21 @@
-const path = require('path')
-const pluginTester = require('babel-plugin-tester').default;
-const plugin = require('../index');
+const path = require("path");
+const pluginTester = require("babel-plugin-tester").default;
+const plugin = require("../index");
 
 pluginTester({
   plugin,
   pluginOptions: {
-    moduleName: 'r-dom',
-    builtIns: ['For', 'Show'],
+    moduleName: "r-dom",
+    builtIns: ["For", "Show"],
     generate: "dom",
     wrapConditionals: true,
     contextToCustomElements: true,
     staticMarker: "@once",
     requireImportSource: false,
     omitLastClosingTag: false,
-    omitQuotes: false,
+    omitQuotes: false
   },
-  title: 'Convert JSX',
-  fixtures: path.join(__dirname, '__dom_compatible_fixtures__'),
+  title: "Convert JSX",
+  fixtures: path.join(__dirname, "__dom_compatible_fixtures__"),
   snapshot: true
 });

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-no-inline-styles.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-no-inline-styles.spec.js
@@ -1,20 +1,20 @@
-const path = require('path')
-const pluginTester = require('babel-plugin-tester').default;
-const plugin = require('../index');
+const path = require("path");
+const pluginTester = require("babel-plugin-tester").default;
+const plugin = require("../index");
 
 pluginTester({
   plugin,
   pluginOptions: {
-    moduleName: 'r-dom',
-    builtIns: ['For', 'Show'],
+    moduleName: "r-dom",
+    builtIns: ["For", "Show"],
     generate: "dom",
     wrapConditionals: true,
     contextToCustomElements: true,
     staticMarker: "@once",
     requireImportSource: false,
-    inlineStyles: false,
+    inlineStyles: false
   },
-  title: 'Convert JSX',
-  fixtures: path.join(__dirname, '__dom_no_inline_styles_fixtures__'),
+  title: "Convert JSX",
+  fixtures: path.join(__dirname, "__dom_no_inline_styles_fixtures__"),
   snapshot: true
 });

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-wrapperless.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-wrapperless.spec.js
@@ -1,19 +1,19 @@
-const path = require('path')
-const pluginTester = require('babel-plugin-tester').default;
-const plugin = require('../index');
+const path = require("path");
+const pluginTester = require("babel-plugin-tester").default;
+const plugin = require("../index");
 
 pluginTester({
   plugin,
   pluginOptions: {
-    moduleName: 'r-dom',
-    builtIns: ['For', 'Show'],
+    moduleName: "r-dom",
+    builtIns: ["For", "Show"],
     generate: "dom",
     wrapConditionals: false,
     delegateEvents: false,
     effectWrapper: false,
-    memoWrapper: false,
+    memoWrapper: false
   },
-  title: 'Convert JSX',
-  fixtures: path.join(__dirname, '__dom_wrapperless_fixtures__'),
+  title: "Convert JSX",
+  fixtures: path.join(__dirname, "__dom_wrapperless_fixtures__"),
   snapshot: true
 });

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom.spec.js
@@ -1,19 +1,19 @@
-const path = require('path')
-const pluginTester = require('babel-plugin-tester').default;
-const plugin = require('../index');
+const path = require("path");
+const pluginTester = require("babel-plugin-tester").default;
+const plugin = require("../index");
 
 pluginTester({
   plugin,
   pluginOptions: {
-    moduleName: 'r-dom',
-    builtIns: ['For', 'Show'],
+    moduleName: "r-dom",
+    builtIns: ["For", "Show"],
     generate: "dom",
     wrapConditionals: true,
     contextToCustomElements: true,
     staticMarker: "@once",
-    requireImportSource: false,
+    requireImportSource: false
   },
-  title: 'Convert JSX',
-  fixtures: path.join(__dirname, '__dom_fixtures__'),
+  title: "Convert JSX",
+  fixtures: path.join(__dirname, "__dom_fixtures__"),
   snapshot: true
 });

--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -55,7 +55,11 @@ export function render(code, element, init, options = {}) {
     dispose => {
       disposer = dispose;
       if (element === document) {
-        flatten(code);
+        const tree = code();
+        effect(
+          () => flatten(tree),
+          () => {}
+        );
       } else {
         const tree = code();
         insert(

--- a/packages/dom-expressions/test/core.js
+++ b/packages/dom-expressions/test/core.js
@@ -40,12 +40,16 @@ export {
   flatten
 } from "@solidjs/signals";
 
-export const effect = (fn, effectFn, initial) =>
-  createRenderEffect(fn, effectFn, initial, { transparent: true });
+export const effect = (fn, effectFn, options) =>
+  createRenderEffect(
+    fn,
+    effectFn,
+    options ? { transparent: true, ...options } : { transparent: true }
+  );
 
 export const memo = (fn, transparent) =>
   transparent
     ? fn.$r
       ? fn
-      : createMemo(() => fn(), undefined, { transparent: true })
+      : createMemo(() => fn(), { transparent: true })
     : createMemo(() => fn());

--- a/packages/dom-expressions/test/dom/render.spec.jsx
+++ b/packages/dom-expressions/test/dom/render.spec.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import * as r from "../../src/client";
-import { createSignal, createRoot } from "@solidjs/signals";
+import { createSignal, createRoot, createMemo, flush } from "@solidjs/signals";
 
 describe("render", () => {
   // Rendering into `document` itself short-circuits insert and runs the
@@ -21,6 +21,34 @@ describe("render", () => {
     dispose();
     expect(document.body.innerHTML).toBe(savedBody);
     expect(document.documentElement.childNodes.length).toBe(savedBodyChildCount);
+  });
+
+  it("keeps lazy memo-owned content reactive when the root element is document", () => {
+    const savedBody = document.body.innerHTML;
+    let setShow, rendered;
+
+    document.body.innerHTML = "";
+    const dispose = r.render(() => {
+      const [show, set] = createSignal(false);
+      setShow = set;
+
+      return createMemo(
+        () => {
+          rendered = show() ? "show branch" : "fallback branch";
+          return <main>{rendered}</main>;
+        },
+        { lazy: true }
+      );
+    }, document);
+
+    expect(rendered).toBe("fallback branch");
+
+    setShow(true);
+    flush();
+
+    expect(rendered).toBe("show branch");
+    dispose();
+    document.body.innerHTML = savedBody;
   });
 
   it("should render JSX", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 15.0.1
         version: 15.0.1(rollup@3.29.5)
       '@solidjs/signals':
-        specifier: 2.0.0-beta.8
-        version: 2.0.0-beta.8
+        specifier: 2.0.0-beta.9
+        version: 2.0.0-beta.9
       '@types/jest':
         specifier: ^29.2.5
         version: 29.2.5
@@ -1112,60 +1112,70 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1280,8 +1290,8 @@ packages:
   '@sinonjs/fake-timers@9.1.2':
     resolution: {integrity: sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==}
 
-  '@solidjs/signals@2.0.0-beta.8':
-    resolution: {integrity: sha512-4voN4js6a8miqWcOgo1wIWdGzHFqLraYaURJqHXGL4zHqTNDRRs1A3cYqhVanm3CoOCGXwyrR6Uw9zG6tzhobA==}
+  '@solidjs/signals@2.0.0-beta.9':
+    resolution: {integrity: sha512-NAluX7aSi33X4T5lNK/for05fdUKAVkxdt+Iv/qf7QA6vu3Nlry1MI1u9XiXI63CKKK4i33mzhG9hZRqkLx6sg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2459,24 +2469,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4841,7 +4855,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 1.8.6
 
-  '@solidjs/signals@2.0.0-beta.8': {}
+  '@solidjs/signals@2.0.0-beta.9': {}
 
   '@standard-schema/spec@1.1.0': {}
 


### PR DESCRIPTION
## Summary
Fixes document-root rendering/hydration so lazy memo-owned content remains reactive after `render(..., document)` / `hydrate(..., document)`.
## Problem
The `element === document` render path only called `flatten(code)`. With `@solidjs/signals@2.0.0-beta.9`, lazy memos can auto-dispose when read without an active subscriber. That means a top-level lazy memo tree can hydrate initially, then stop responding to later signal updates.
This showed up in Tanstack Solid Start-style full-document hydration, where navigation state updated but nested rendered content could stay stale.
## Fix
For document-root rendering, evaluate the app tree once and keep its flattened output observed in a render effect:
```js
const tree = code()
effect(() => flatten(tree), () => {})
```
This preserves the existing document-root behavior of not inserting into document, while ensuring the root JSX tree remains subscribed and reactive.
Tests
- Upgraded the test dependency to @solidjs/signals@2.0.0-beta.9 to reproduce the auto-dispose behavior.
- Updated the test adapter for beta9 createMemo / createRenderEffect signatures.
- Added a regression test covering lazy memo-owned content rendered with document as the root.
Verified with:
pnpm --filter dom-expressions test -- --selectProjects browser test/dom/render.spec.jsx --runInBand