### PR TITLE
rawtext fix

### DIFF
--- a/packages/sld-dom-expressions/src/tokenize.ts
+++ b/packages/sld-dom-expressions/src/tokenize.ts
@@ -143,7 +143,7 @@ export const tokenize = (
             // ">"
             if (
               rawTextElements.has(lastTagName) &&
-              tokens[tokens.length - 1]?.type !== SLASH_TOKEN
+              tokens[tokens.length - 2]?.type !== SLASH_TOKEN
             ) {
               state = STATE_RAW_TEXT;
             } else {

--- a/packages/sld-dom-expressions/tests/tokenize.test.ts
+++ b/packages/sld-dom-expressions/tests/tokenize.test.ts
@@ -753,6 +753,28 @@ describe("handling of raw text elements", () => {
     ]);
   });
 
+  it("should handle nested raw text elements ", () => {
+    const tokens = tokenizeTemplate`<div><style>.class > span { color: red; }</style></div>`;
+
+    expect(tokens).toEqual([
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "div" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: OPEN_TAG_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "style" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: TEXT_TOKEN, value: ".class > span { color: red; }" },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "style" },
+      { type: CLOSE_TAG_TOKEN },
+      { type: OPEN_TAG_TOKEN },
+      { type: SLASH_TOKEN },
+      { type: IDENTIFIER_TOKEN, value: "div" },
+      { type: CLOSE_TAG_TOKEN },
+    ]);
+  });
+
   it("should tokenize content inside <textarea> as text", () => {
     const tokens = tokenizeTemplate`<textarea>This is <span>not parsed</span>.</textarea>`;
 


### PR DESCRIPTION
There was a bug in the tokenizer with raw text elements causing tokens after a raw text element to be incorrect. Fixed and added test.