### PR TITLE
fix class reconciliation bug

### DIFF
--- a/packages/dom-expressions/src/client.js
+++ b/packages/dom-expressions/src/client.js
@@ -149,8 +149,8 @@ export function className(node, value, prev) {
   if (typeof prev === "string") {
     prev = {};
     node.removeAttribute("class");
-  } else prev = classListToObject(prev || {});
-  value = classListToObject(value);
+  } else prev = reconcileClassObject(classListToObject(prev || {}));
+  value = reconcileClassObject(classListToObject(value));
   const classKeys = Object.keys(value || {});
   const prevKeys = Object.keys(prev);
   let i, len;
@@ -546,9 +546,25 @@ function getChildRoot(node) {
 }
 
 function toggleClassKey(node, key, value) {
-  const classNames = key.trim().split(/\s+/);
-  for (let i = 0, nameLen = classNames.length; i < nameLen; i++)
-    node.classList.toggle(classNames[i], value);
+  node.classList.toggle(key, value);
+}
+
+function reconcileClassObject(classObject) {
+  if (typeof classObject !== "object") return classObject;
+  const result = {};
+  const keys = Object.keys(classObject);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i],
+      value = classObject[key];
+    if (!classObject[key]) continue;
+
+    const classNames = key.trim().split(/\s+/);
+    for (let j = 0; j < classNames.length; j++) {
+      const className = classNames[j];
+      if (className && !(className in result)) result[className] = true;
+    }
+  }
+  return result;
 }
 
 function classListToObject(classList) {

--- a/packages/dom-expressions/test/dom/class.spec.jsx
+++ b/packages/dom-expressions/test/dom/class.spec.jsx
@@ -234,4 +234,28 @@ describe("Test class binding", () => {
     // in prev but not in the (empty) new keys.
     expect(node.classList.contains("stale")).toBe(false);
   });
+
+  test("shared class tokens remain when switching composite class keys", () => {
+    const node = document.createElement("span");
+
+    const first = {
+      "bg-zinc-400 text-white": true,
+      "bg-sky-400 text-white": true
+    };
+
+    const second = {
+      "bg-zinc-400 text-white": false,
+      "bg-sky-400 text-white": true
+    };
+
+    r.className(node, first);
+    expect(node.classList.contains("text-white")).toBe(true);
+    expect(node.classList.contains("bg-zinc-400")).toBe(true);
+    expect(node.classList.contains("bg-sky-400")).toBe(true);
+
+    r.className(node, second, first);
+    expect(node.classList.contains("text-white")).toBe(true);
+    expect(node.classList.contains("bg-zinc-400")).toBe(false);
+    expect(node.classList.contains("bg-sky-400")).toBe(true);
+  });
 });


### PR DESCRIPTION
Example of the bug [here](https://stackblitz.com/edit/github-gj63q1tt-y8io2gkm?file=src%2Fapp.css,vite.config.ts,src%2FApp.tsx) (turn on both of the colors and then switch off one of them, the text will be dark instead of white).

This is a proposed solution, might use some refactoring. 