### PR TITLE
feat: export more isomorphic APIs from server.js

### DIFF
--- a/.changeset/soft-chairs-cry.md
+++ b/.changeset/soft-chairs-cry.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"dom-expressions": patch
 ---
 
 feat: export more isomorphic APIs from server.js

--- a/.changeset/soft-chairs-cry.md
+++ b/.changeset/soft-chairs-cry.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+feat: export more isomorphic APIs from server.js

--- a/packages/dom-expressions/src/server.d.ts
+++ b/packages/dom-expressions/src/server.d.ts
@@ -175,3 +175,13 @@ export function getNextElement(template?: HTMLTemplateElement): Element;
 export function getNextMatch(start: Node, elementName: string): Element;
 /** @deprecated not supported on the server side */
 export function getNextMarker(start: Node): [Node, Array<Node>];
+/** @deprecated not supported on the server side */
+export function runHydrationEvents(): void;
+/** @deprecated not supported on the server side */
+export function use<Arg, Ret>(fn: (node: Element, arg: Arg) => Ret, node: Element, arg?: Arg): Ret;
+/** @deprecated not supported on the server side */
+export function setBoolAttribute(node: Element, name: string, value: any): void;
+/** @deprecated not supported on the server side */
+export function setStyleProperty(node: Element, name: string, value: any): void;
+/** @deprecated not supported on the server side */
+export function clearDelegatedEvents(d?: Document): void;

--- a/packages/dom-expressions/src/server.js
+++ b/packages/dom-expressions/src/server.js
@@ -730,7 +730,11 @@ export {
   notSup as getNextElement,
   notSup as getNextMatch,
   notSup as getNextMarker,
-  notSup as runHydrationEvents
+  notSup as runHydrationEvents,
+  notSup as use,
+  notSup as setBoolAttribute,
+  notSup as setStyleProperty,
+  notSup as clearDelegatedEvents
 };
 
 function notSup() {


### PR DESCRIPTION
fix: #519 
follows: #345 

This only fix the warning of no exports, but still throws error from `notSup`