### PR TITLE
// and /* comments in tags

### DIFF
--- a/.changeset/kind-numbers-attend.md
+++ b/.changeset/kind-numbers-attend.md
@@ -1,0 +1,5 @@
+---
+"sld-dom-expressions": patch
+---
+
+// and /* comments in tags

--- a/packages/sld-dom-expressions/src/tokenize.ts
+++ b/packages/sld-dom-expressions/src/tokenize.ts
@@ -227,9 +227,9 @@ export const tokenize = (
         case STATE_LINE_COMMENT:
         case STATE_BLOCK_COMMENT:
           {
-            const commentEnd = STATE_LINE_COMMENT ? "\n" : STATE_BLOCK_COMMENT ? "*/" : "-->"
+            const commentEnd = state ===STATE_LINE_COMMENT ? "\n" : state === STATE_BLOCK_COMMENT ? "*/" : "-->"
             // LOOK FOR END OF COMMENT: - - >
-            const commentEndIndex = str.indexOf("-->", cursor);
+            const commentEndIndex = str.indexOf(commentEnd, cursor);
 
             if (commentEndIndex === -1) {
               // If we don't find the closer in this string chunk,
@@ -237,7 +237,7 @@ export const tokenize = (
               cursor = len;
             } else {
               // Found it! Return to normal text parsing
-              state = STATE_COMMENT ? STATE_TEXT : STATE_TAG;
+              state = state === STATE_COMMENT ? STATE_TEXT : STATE_TAG;
               cursor = commentEndIndex + commentEnd.length;
             }
             break;

--- a/packages/sld-dom-expressions/src/tokenize.ts
+++ b/packages/sld-dom-expressions/src/tokenize.ts
@@ -93,6 +93,8 @@ const STATE_TEXT = 0;
 const STATE_TAG = 1;
 const STATE_RAW_TEXT = 2;
 const STATE_COMMENT = 3;
+const STATE_LINE_COMMENT = 4
+const STATE_BLOCK_COMMENT = 5
 
 export const tokenize = (
   strings: TemplateStringsArray | string[],
@@ -157,10 +159,17 @@ export const tokenize = (
             // "="
             tokens.push({ type: EQUALS_TOKEN });
             cursor++;
-          } else if (code === 47) {
+          } else if (code === 47) {            
             // "/"
-            tokens.push({ type: SLASH_TOKEN });
-            cursor++;
+            const next = str.charCodeAt(cursor +1)
+            if (next===47 && tokens[tokens.length-1].type !== OPEN_TAG_TOKEN){
+              state = STATE_LINE_COMMENT
+            }else if(next===42){
+              state = STATE_BLOCK_COMMENT
+            }else{
+              tokens.push({ type: SLASH_TOKEN });
+              cursor++;
+            }
           } else if (code === 34 || code === 39) {
             const char = str[cursor] as "'" | '"';
             const endQuoteIndex = str.indexOf(char, cursor + 1);
@@ -229,11 +238,41 @@ export const tokenize = (
           }
           break;
         }
+        case STATE_LINE_COMMENT: {
+          // LOOK FOR END OF COMMENT: - - >
+          const endComment = str.indexOf("\n", cursor);
+
+          if (endComment === -1) {
+            // If we don't find the closer in this string chunk,
+            // we consume the rest of the string and stay in STATE_COMMENT
+            cursor = len;
+          } else {
+            // Found it! Return to normal text parsing
+            state = STATE_TAG;
+            cursor = endComment + 1;
+          }
+          break;
+        }
+        case STATE_BLOCK_COMMENT: {
+          // LOOK FOR END OF COMMENT: - - >
+          const endComment = str.indexOf("*/", cursor);
+
+          if (endComment === -1) {
+            // If we don't find the closer in this string chunk,
+            // we consume the rest of the string and stay in STATE_COMMENT
+            cursor = len;
+          } else {
+            // Found it! Return to normal text parsing
+            state = STATE_TAG;
+            cursor = endComment + 2;
+          }
+          break;
+        }
       }
     }
 
     if (i < strings.length - 1) {
-      if (state !== STATE_COMMENT) {
+      if (state === STATE_TEXT || state === STATE_TAG || state === STATE_RAW_TEXT) {
         tokens.push({ type: EXPRESSION_TOKEN, value: i });
       }
     }

--- a/packages/sld-dom-expressions/src/tokenize.ts
+++ b/packages/sld-dom-expressions/src/tokenize.ts
@@ -159,14 +159,14 @@ export const tokenize = (
             // "="
             tokens.push({ type: EQUALS_TOKEN });
             cursor++;
-          } else if (code === 47) {            
+          } else if (code === 47) {
             // "/"
-            const next = str.charCodeAt(cursor +1)
-            if (next===47 && tokens[tokens.length-1].type !== OPEN_TAG_TOKEN){
+            const next = str.charCodeAt(cursor + 1)
+            if (next === 47 && tokens[tokens.length - 1].type !== OPEN_TAG_TOKEN) {
               state = STATE_LINE_COMMENT
-            }else if(next===42){
+            } else if (next === 42) {
               state = STATE_BLOCK_COMMENT
-            }else{
+            } else {
               tokens.push({ type: SLASH_TOKEN });
               cursor++;
             }
@@ -223,51 +223,25 @@ export const tokenize = (
           }
           break;
         }
-        case STATE_COMMENT: {
-          // LOOK FOR END OF COMMENT: - - >
-          const endComment = str.indexOf("-->", cursor);
+        case STATE_COMMENT:
+        case STATE_LINE_COMMENT:
+        case STATE_BLOCK_COMMENT:
+          {
+            const commentEnd = STATE_LINE_COMMENT ? "\n" : STATE_BLOCK_COMMENT ? "*/" : "-->"
+            // LOOK FOR END OF COMMENT: - - >
+            const commentEndIndex = str.indexOf("-->", cursor);
 
-          if (endComment === -1) {
-            // If we don't find the closer in this string chunk,
-            // we consume the rest of the string and stay in STATE_COMMENT
-            cursor = len;
-          } else {
-            // Found it! Return to normal text parsing
-            state = STATE_TEXT;
-            cursor = endComment + 3;
+            if (commentEndIndex === -1) {
+              // If we don't find the closer in this string chunk,
+              // we consume the rest of the string and stay in STATE_COMMENT
+              cursor = len;
+            } else {
+              // Found it! Return to normal text parsing
+              state = STATE_COMMENT ? STATE_TEXT : STATE_TAG;
+              cursor = commentEndIndex + commentEnd.length;
+            }
+            break;
           }
-          break;
-        }
-        case STATE_LINE_COMMENT: {
-          // LOOK FOR END OF COMMENT: - - >
-          const endComment = str.indexOf("\n", cursor);
-
-          if (endComment === -1) {
-            // If we don't find the closer in this string chunk,
-            // we consume the rest of the string and stay in STATE_COMMENT
-            cursor = len;
-          } else {
-            // Found it! Return to normal text parsing
-            state = STATE_TAG;
-            cursor = endComment + 1;
-          }
-          break;
-        }
-        case STATE_BLOCK_COMMENT: {
-          // LOOK FOR END OF COMMENT: - - >
-          const endComment = str.indexOf("*/", cursor);
-
-          if (endComment === -1) {
-            // If we don't find the closer in this string chunk,
-            // we consume the rest of the string and stay in STATE_COMMENT
-            cursor = len;
-          } else {
-            // Found it! Return to normal text parsing
-            state = STATE_TAG;
-            cursor = endComment + 2;
-          }
-          break;
-        }
       }
     }
 

--- a/packages/sld-dom-expressions/tests/tokenize.test.ts
+++ b/packages/sld-dom-expressions/tests/tokenize.test.ts
@@ -957,6 +957,7 @@ describe("comments handling", () => {
       //handle with expression=${1}
       class="btn"
     />`;
+    console.log(tokens)
     expect(tokens).toBeDefined();
     expect(tokens.length).toBe(8);
     expect(tokens[2].value).toBe("disabled")

--- a/packages/sld-dom-expressions/tests/tokenize.test.ts
+++ b/packages/sld-dom-expressions/tests/tokenize.test.ts
@@ -949,4 +949,35 @@ describe("comments handling", () => {
     const tokens = tokenizeTemplate`<!-- Comment with ${value} inside -->`;
     expect(tokens).toEqual([]);
   });
+
+
+  it("should handle line // comments", () => {
+    const tokens = tokenizeTemplate`<button
+      disabled//comment
+      //handle with expression=${1}
+      class="btn"
+    />`;
+    expect(tokens).toBeDefined();
+    expect(tokens.length).toBe(8);
+    expect(tokens[2].value).toBe("disabled")
+    expect(tokens[3].value).toBe("class")
+  });
+
+  it("Should not handle <//> shorthand closing", () => {
+    const tokens = tokenizeTemplate`<${0}>Text<//>`
+    expect(tokens.length).toEqual(8);
+  });
+
+  it("should handle block comments", () => {
+    const tokens = tokenizeTemplate`<button
+      disabled /*comment
+      //handle with expression=${1}
+      */class="btn"
+    />`;
+    console.log(tokens)
+    expect(tokens).toBeDefined();
+    expect(tokens.length).toBe(8);
+    expect(tokens[2].value).toBe("disabled")
+    expect(tokens[3].value).toBe("class")
+  });
 });


### PR DESCRIPTION
Added support for line and block comments. Tokenizer will skip over them leaving the same resulting tokens.

Consideration:
JSX seems to allow line comments before the tag name eg.
```tsx
<  //Comment
 button>
Click Me
</button>
```
To match this, we would need to change the syntax of the shorthand closing <//> to just </> or another alternative


<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/danielrkling/dom-expressions/tree/danielrkling/patch-62443"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/danielrkling/dom-expressions/tree/danielrkling/patch-62443)._