### PR TITLE
Add JSX DOM plugin link metadata

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/package.json
+++ b/packages/babel-plugin-jsx-dom-expressions/package.json
@@ -8,6 +8,10 @@
     "type": "git",
     "url": "https://github.com/ryansolid/dom-expressions/blob/main/packages/babel-plugin-jsx-dom-expressions"
   },
+  "homepage": "https://github.com/ryansolid/dom-expressions/tree/main/packages/babel-plugin-jsx-dom-expressions#readme",
+  "bugs": {
+    "url": "https://github.com/ryansolid/dom-expressions/issues"
+  },
   "readmeFilename": "README.md",
   "main": "index.js",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- add npm `homepage` metadata for the package README
- add npm `bugs.url` metadata for the public issue tracker

The published package currently exposes repository metadata, but does not expose homepage or bugs links in npm package metadata.

## Verification

- `node -e "const p=require('./packages/babel-plugin-jsx-dom-expressions/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,homepage:p.homepage,bugs:p.bugs},null,2)); if(p.name!=='babel-plugin-jsx-dom-expressions'||p.homepage!=='https://github.com/ryansolid/dom-expressions/tree/main/packages/babel-plugin-jsx-dom-expressions#readme'||p.bugs?.url!=='https://github.com/ryansolid/dom-expressions/issues') process.exit(1)"`
- `git diff --check`