### PR TITLE
Add homepage and bugs.url package metadata

### DIFF
--- a/packages/lit-dom-expressions/package.json
+++ b/packages/lit-dom-expressions/package.json
@@ -8,6 +8,10 @@
     "type": "git",
     "url": "https://github.com/ryansolid/dom-expressions/blob/main/packages/lit-dom-expressions"
   },
+  "homepage": "https://github.com/ryansolid/dom-expressions/tree/main/packages/lit-dom-expressions#readme",
+  "bugs": {
+    "url": "https://github.com/ryansolid/dom-expressions/issues"
+  },
   "main": "lib/lit-dom-expressions.js",
   "module": "dist/lit-dom-expressions.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `lit-dom-expressions`
- updates only `packages/lit-dom-expressions/package.json`

## Metadata added
- `homepage`: `https://github.com/ryansolid/dom-expressions/tree/main/packages/lit-dom-expressions#readme`
- `bugs.url`: `https://github.com/ryansolid/dom-expressions/issues`

## Validation
- parsed `packages/lit-dom-expressions/package.json` as JSON after the change
- confirmed the manifest still has `name: lit-dom-expressions`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package expose the project support/discovery information once the package is next released.