### PR TITLE
fix(client): don't let transient detached values clobber tracked nodes during hydration

### DIFF
--- a/packages/runtime/src/client.js
+++ b/packages/runtime/src/client.js
@@ -348,7 +348,7 @@ export function insert(parent, accessor, marker, initial, options) {
         () => normalize(value, current, multi),
         inner => {
           insertExpression(parent, inner, current, marker);
-          current = inner;
+          if (!isHydrating(parent) || tracksDOM(inner)) current = inner;
           host && tagHost(current, host);
         },
         prev !== undefined && !(options && options.schedule)
@@ -360,11 +360,29 @@ export function insert(parent, accessor, marker, initial, options) {
     value => {
       if (value === INNER_OWNED) return;
       insertExpression(parent, value, current, marker);
-      current = value;
+      if (!isHydrating(parent) || tracksDOM(value)) current = value;
       host && tagHost(current, host);
     },
     options
   );
+}
+
+// During hydration `insertExpression` leaves the server-rendered DOM
+// untouched, so a value holding DOM nodes only becomes the tracked `current`
+// if those nodes re-identify nodes already in the document (claimed elements
+// / adopted text). Transient values holding detached nodes — e.g. a
+// <Loading> fallback rendered while the boundary waits to resume — must not
+// clobber the tracked DOM nodes; otherwise the resume pass can't adopt the
+// existing text node via `normalize` and later updates leave it behind as a
+// ghost. Non-node values (strings, undefined) pass through unchanged.
+function tracksDOM(value) {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (!tracksDOM(value[i])) return false;
+    }
+    return true;
+  }
+  return !(value && value.nodeType) || value.isConnected;
 }
 
 export function assign(node, props, skipChildren, prevProps = {}, skipRef = false) {

--- a/packages/runtime/test/ssr/hydrate.spec.js
+++ b/packages/runtime/test/ssr/hydrate.spec.js
@@ -1147,3 +1147,54 @@ describe("loadModuleAssets shortcut branches", () => {
     expect(globalThis._$HY.loading[moduleUrl]).toBe(loadingPromise);
   });
 });
+
+describe("transient detached value during hydration (solidjs/solid#2801)", () => {
+  it("keeps tracking the adopted text node across a fallback pass", () => {
+    // created here, not at describe time — earlier suites reset document.body
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    globalThis._$HY = { events: [], completed: new WeakSet(), r: {} };
+    const _tmpl$ = r.template(`<button>Refresh</button>`);
+
+    const rendered = r2.renderToString(() => [
+      r2.ssr(["<button", ">Refresh</button>"], r2.ssrHydrationKey()),
+      r2.escape("value-1")
+    ]);
+    expect(rendered).toBe(`<button _hk=0>Refresh</button>value-1`);
+
+    container.innerHTML = rendered;
+    const btnNode = container.firstChild;
+    const textNode = container.lastChild;
+
+    // A boundary (e.g. <Loading>) renders its fallback — a detached node —
+    // while waiting to resume, then swaps to the claimed children before
+    // hydration completes. The fallback pass must not clobber the tracked
+    // server nodes or the text node can never be adopted.
+    const fallback = document.createElement("div");
+    fallback.textContent = "loading";
+
+    let claimed, setter;
+    r.hydrate(() => {
+      const [view, setView] = createSignal(fallback);
+      setter = setView;
+      r.insert(container, () => view(), undefined, [...container.childNodes]);
+      claimed = r.getNextElement(_tmpl$);
+      setView([claimed, "value-1"]);
+      flush();
+      r.runHydrationEvents();
+    }, container);
+
+    expect(container.innerHTML).toBe(`<button _hk="0">Refresh</button>value-1`);
+    expect(container.firstChild).toBe(btnNode);
+    expect(container.lastChild).toBe(textNode);
+
+    // Post-hydration swap must replace the adopted text, not ghost it.
+    setter([claimed, "value-2"]);
+    flush();
+    expect(container.innerHTML).toBe(`<button _hk="0">Refresh</button>value-2`);
+
+    setter([claimed, "value-3"]);
+    flush();
+    expect(container.innerHTML).toBe(`<button _hk="0">Refresh</button>value-3`);
+  });
+});


### PR DESCRIPTION
Fixes bug 1 of solidjs/solid#2801 — a bare async value directly inside `<Loading>` next to element siblings (`<Loading fallback={...}><button>Refresh</button>{data()}</Loading>`) hydrates fine, but the first `refresh()` leaves the old value behind as a ghost (`Refreshvalue-1value-2`). Wrapping the value in a `<div>` avoids it, which pointed at positional text adoption rather than element claiming.

## Root cause

During hydration a boundary briefly renders its fallback — a freshly created, **detached** node — before resuming with the claimed children. In `insert()`, `insertExpression` correctly leaves the server-rendered DOM untouched while hydrating, but `current = value` still ran unconditionally, so the tracked server nodes (`[button, #text "value-1"]`) were replaced by the never-inserted fallback. On the resume pass, `normalize()` then looked at `current[1]` to adopt the existing text node, found the fallback div instead, and created a *detached* replacement text node. The first post-hydration update reconciled against that detached node — removal was a no-op (`parentNode === null`) — and the real server text node stayed in the DOM untracked.

## Fix

A value may only become the tracked `current` during hydration if all its DOM nodes are connected, i.e. it re-identifies claimed/adopted server nodes. Transient values holding detached nodes (the fallback pass) no longer clobber tracking, so the resume pass adopts the real text node and post-hydration updates reconcile against the DOM that's actually there.

Non-node values (strings, `undefined`) pass through unchanged: rejecting `undefined` too would regress the spread + `innerHTML` case (solidjs/solid#2737), where `props.children` is legitimately `undefined` while the content belongs to `innerHTML` — keeping stale node tracking there makes the next update wipe the content via `cleanChildren`.

## Tests

- New regression test in `test/ssr/hydrate.spec.js` modeling the exact sequence with runtime primitives (insert with server child nodes → detached value while hydrating → claimed element + adopted text → post-hydration swaps). Fails on current `next` with `value-1value-2`; passes with the fix.
- Full runtime suite: 473/473. hyperscript 69/69, tagged-jsx 179/179. (`babel-plugin-jsx` has 2 pre-existing `dynamic.spec.js` failures on pristine `next` tip, unrelated; `jsx-compiler`'s Cargo.lock doesn't parse with my local Rust toolchain so it wasn't run.)
- Also validated end-to-end in the solid repo (with this file patched into the installed runtime): the solidjs/solid#2801 bug-1 repro flips to passing, its div-wrapped control stays green, and solid's server (115), client (299), and hydration suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)