### PR TITLE
fix(client): style() diffs against a runtime-owned record instead of the user's previous value

### DIFF
--- a/.changeset/fix-style-object-diff.md
+++ b/.changeset/fix-style-object-diff.md
@@ -1,0 +1,5 @@
+---
+"@dom-expressions/runtime": patch
+---
+
+Fix style object updates so shared or constant style objects are not mutated while diffing, and nullish property values correctly remove the applied style.

--- a/packages/runtime/src/client.js
+++ b/packages/runtime/src/client.js
@@ -246,20 +246,45 @@ export function addEvent(node, name, handler, delegate) {
 
 export function style(node, value, prev) {
   if (!value) {
-    if (prev) setAttribute(node, "style");
+    if (prev || node._$styles) {
+      setAttribute(node, "style");
+      node._$styles = undefined;
+    }
     return;
   }
   const nodeStyle = node.style;
-  if (typeof value === "string") return (nodeStyle.cssText = value);
-  typeof prev === "string" && (nodeStyle.cssText = prev = undefined);
-  prev || (prev = {});
+  if (typeof value === "string") {
+    node._$styles = undefined;
+    return (nodeStyle.cssText = value);
+  }
+  if (typeof prev === "string") {
+    nodeStyle.cssText = "";
+    prev = undefined;
+  }
+  // Track declarations applied by style() itself. value/prev are user-owned
+  // and may be the same object on shared-effect reruns.
+  let applied = node._$styles;
+  if (!applied) {
+    // seed from prev so direct callers that track their own previous value
+    // still get removals on their first call here
+    applied = node._$styles = prev ? { ...prev } : {};
+  }
   let v, s;
+  for (s in applied) {
+    if (value[s] == null) {
+      nodeStyle.removeProperty(s);
+      delete applied[s];
+    }
+  }
+  // Diff against applied state so in-place mutations are detected without
+  // rewriting unchanged DOM styles.
   for (s in value) {
     v = value[s];
-    if (v !== prev[s]) nodeStyle.setProperty(s, v);
-    delete prev[s];
+    if (v != null && v !== applied[s]) {
+      nodeStyle.setProperty(s, v);
+      applied[s] = v;
+    }
   }
-  for (s in prev) value[s] == null && nodeStyle.removeProperty(s);
 }
 
 export function setStyleProperty(node, name, value) {

--- a/packages/runtime/test/dom/style.spec.jsx
+++ b/packages/runtime/test/dom/style.spec.jsx
@@ -71,6 +71,68 @@ describe("Test style binding", () => {
     dispose();
   });
 
+  test("removes a property set to explicit undefined", () => {
+    const [on, setOn] = createSignal(true);
+    const st = () => ({ color: on() ? "red" : undefined });
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = <div style={st()} />;
+    });
+    expect(div.style.color).toBe("red");
+
+    setOn(false);
+    flush();
+    expect(div.style.color).toBe("");
+    dispose();
+  });
+
+  test("does not mutate user style objects when toggling between constants", () => {
+    const A = { color: "red", "background-color": "yellow" };
+    const B = { color: "green" };
+    const [flip, setFlip] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = <div style={flip() ? B : A} />;
+    });
+    expect(div.style.color).toBe("red");
+    expect(div.style.backgroundColor).toBe("yellow");
+
+    setFlip(true);
+    flush();
+    expect(div.style.color).toBe("green");
+    expect(div.style.backgroundColor).toBe("");
+    expect(A).toEqual({ color: "red", "background-color": "yellow" });
+
+    setFlip(false);
+    flush();
+    expect(div.style.color).toBe("red");
+    expect(div.style.backgroundColor).toBe("yellow");
+    expect(B).toEqual({ color: "green" });
+    dispose();
+  });
+
+  test("keeps a constant style object intact when a sibling binding updates", () => {
+    const C = { color: "red", "background-color": "yellow" };
+    const [n, setN] = createSignal(0);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = <div title={`count ${n()}`} style={C} />;
+    });
+    expect(div.style.color).toBe("red");
+    expect(div.style.backgroundColor).toBe("yellow");
+
+    setN(1);
+    flush();
+    expect(div.getAttribute("title")).toBe("count 1");
+    expect(C).toEqual({ color: "red", "background-color": "yellow" });
+    expect(div.style.color).toBe("red");
+    expect(div.style.backgroundColor).toBe("yellow");
+    dispose();
+  });
+
   // An initial string style should be replaced cleanly when the value
   // flips to an object — covers the `typeof prev === "string"` branch.
   test("replaces string style with object form", () => {
@@ -106,5 +168,75 @@ describe("r.style direct usage", () => {
     // Only 2 args → prev defaults.
     r.style(node, { color: "red" });
     expect(node.style.color).toBe("red");
+  });
+
+  test("clears applied styles on nullish value without prev", () => {
+    const node = document.createElement("div");
+    r.style(node, { color: "red" });
+    expect(node.style.color).toBe("red");
+
+    r.style(node, null);
+    expect(node.hasAttribute("style")).toBe(false);
+
+    // and stays a no-op on nodes style() never touched
+    const untouched = document.createElement("div");
+    r.style(untouched, null);
+    expect(untouched.hasAttribute("style")).toBe(false);
+  });
+
+  test("value === prev leaves the object and applied styles intact", () => {
+    const node = document.createElement("div");
+    const styles = { color: "red" };
+    r.style(node, styles);
+    expect(node.style.color).toBe("red");
+
+    r.style(node, styles, styles);
+    expect(styles).toEqual({ color: "red" });
+    expect(node.style.color).toBe("red");
+  });
+
+  test("re-applies current values when the same object is mutated in place", () => {
+    const node = document.createElement("div");
+    const styles = { color: "red" };
+    r.style(node, styles);
+    expect(node.style.color).toBe("red");
+
+    styles.color = "blue";
+    r.style(node, styles, styles);
+    expect(node.style.color).toBe("blue");
+    expect(styles).toEqual({ color: "blue" });
+  });
+
+  test("removes a property deleted in place from the same object", () => {
+    const node = document.createElement("div");
+    // longhand: jsdom's removeProperty() cannot remove shorthands
+    const styles = { color: "red", "background-color": "yellow" };
+    r.style(node, styles);
+    expect(node.style.color).toBe("red");
+    expect(node.style.backgroundColor).toBe("yellow");
+
+    delete styles["background-color"];
+    r.style(node, styles, styles);
+    expect(node.style.backgroundColor).toBe("");
+    expect(node.style.color).toBe("red");
+
+    styles.color = undefined;
+    r.style(node, styles, styles);
+    expect(node.style.color).toBe("");
+  });
+
+  test("does not clobber a manual style edit when the bound value is unchanged", () => {
+    const node = document.createElement("div");
+    const styles = { color: "red" };
+    r.style(node, styles);
+    expect(node.style.color).toBe("red");
+
+    node.style.setProperty("color", "blue"); // manual edit, e.g. from a ref
+    r.style(node, styles, styles); // sibling-triggered re-run, object unchanged
+    expect(node.style.color).toBe("blue");
+
+    styles.color = "green"; // ...but a real change still wins
+    r.style(node, styles, styles);
+    expect(node.style.color).toBe("green");
   });
 });


### PR DESCRIPTION
Fixes the beta.15 style-object corruption (solidjs/solid#2828) and the long-standing re-apply clobbering from solidjs/solid#1938. Three user-visible symptoms, all from the same two lines:

1. `style={boxStyle()}` with `{ color: cond ? "red" : undefined }` never removes `color` — `setProperty(name, undefined)` is a CSSOM no-op. (Inline literals are unaffected: the compiler decomposes them into `setStyleProperty`, which handles removal.)
2. Toggling between two constant style objects permanently deletes keys from them (`delete prev[s]` writes to the user's object), so styles are silently lost on flip-back.
3. When any sibling binding shares the compiled template effect, the differ re-runs with `value === prev` and the delete loop empties the user's constant in one pass while iterating it — every style is lost on the next real update.

## Root cause

The loops are unchanged from 1.x — what changed is the contract behind `prev`. In 1.x, `style()` returned its internal accumulator of applied declarations and the compiled effect threaded that **return value** back (`_p$.e = _$style(el, v, _p$.e)`), so `delete prev[s]` / `prev[s] = v` always hit a runtime-owned object. The current codegen threads the previous **user value** instead (and `assignProp` returns `value` into `prevProps` on the spread path), so the same writes now destroy user data.

## Fix

`style()` keeps its applied declarations on `node._$styles` (expando, matching `_$host`/`$$SLOT`) and uses that record both ways:

- **Removal ledger**: keys in the record whose new value is nullish are removed — dropped keys and explicit `undefined` share one predicate (`value[s] == null`, literally 1.x's).
- **Write baseline**: values are applied when they differ from the record, never compared against the user's object. In-place mutations *and* in-place key deletions of a kept object still apply on re-run (1.x parity), since the record remembers what was actually applied even when `value === prev`.

User objects are never read as the diff baseline nor written to. The nullish-value clear branch also consults the record, so direct `style(node, null)` calls clear applied styles even without `prev`.

One deliberate behavior change vs 1.x: values unchanged since last applied are **not rewritten**, so unrelated re-runs no longer clobber manual `el.style` edits — the #1938 complaint. This aligns the object path with `className()` and the compiler-decomposed literal path, which already behave this way (as do React/Vue, which diff against their own snapshots). If declare-and-reassert semantics are preferred, it's the one `v !== applied[s]` guard to drop.

## Tests

- 8 new tests in `test/dom/style.spec.jsx`: the three symptoms above, the spread `value === prev` no-op, in-place mutation, in-place deletion, manual-edit survival (#1938), and the no-`prev` clear. All fail on current `next` except where they pin new-vs-1.x semantics; all pass with the fix.
- Full runtime suite: 480/480 across browser/server/universal projects.
- Real-browser check (headless Chrome): 14/14 behavior assertions, including shorthand `removeProperty` (jsdom's cssstyle can't remove shorthands, so those tests use longhands — noted inline).
- Validated end-to-end in the solid repo with this file patched into the installed runtime: the solidjs/solid#2828 repro (6 tests) flips to green, and solid-web's full client suite passes 307/307 (the only failures are unrelated known-bug repros that fail identically without this patch).

Full disclosure: I wrote this with the help of an AI assistant (Claude Fable 5) and reviewed every line before pushing. All new tests were written first and confirmed failing on the unfixed code