### PR TITLE
fix: identify slots by per-insert tokens so adjacent slots can exchange nodes

### DIFF
--- a/.changeset/slot-token-ownership.md
+++ b/.changeset/slot-token-ownership.md
@@ -1,0 +1,30 @@
+---
+"@dom-expressions/runtime": patch
+---
+
+Fix adjacent expression slots destroying each other's nodes when content
+migrates between them. Adjacent compiled slots can share a physical
+insertion marker (`null` at the tail, or the next static element), so
+marker-based `$$SLOT` ownership collapsed neighboring slots into one
+region: exchanges dropped nodes, single-node migrations vanished in both
+directions, and array exchanges could crash `reconcileArrays` mid-update —
+while the same JSX worked after hydration, where hydratable output emits a
+dedicated marker pair per slot.
+
+Ownership is now keyed on per-`insert()` slot identity. Single-slot
+parents keep using the physical marker as the ownership tag (their
+instruction stream is unchanged); parents hosting multiple expression
+slots switch to per-slot identity tokens registered on `parent._$slots`.
+Ownership checks accept token-or-marker so content inserted before a
+parent becomes multi-slot stays owned across the transition. When a slot's
+entire content migrates away in the same flush it receives fresh content,
+its position is recovered from the next live slot's region — which also
+fixes a pre-existing mis-order where a null-marker slot emptied via `[]`
+appended refilled content at the parent's end, after later slots' content.
+
+Scope: DOM renderer (`client.js`) only. `universal.js` is intentionally
+unchanged — universal hosts target older JS environments, expando writes
+on platform nodes can collide with proxy-based node wrappers, and the
+JSX-DOM migration patterns this fix addresses are not idiomatic on
+non-DOM platforms. If a real case surfaces on a universal renderer it can
+be revisited with a host-appropriate storage strategy.

--- a/packages/runtime/src/client.js
+++ b/packages/runtime/src/client.js
@@ -12,6 +12,7 @@ import {
   flatten
 } from "rxcore";
 import reconcileArrays from "./reconcile";
+import { createSlot, registerSlot, slotBoundary } from "./slots";
 import { DOMWithState } from "./constants";
 export {
   DOMWithState,
@@ -313,6 +314,8 @@ export function ref(fn, element) {
 
 export function insert(parent, accessor, marker, initial, options) {
   const multi = marker !== undefined;
+  // Adjacent slots can share a physical marker; token identity separates them.
+  const slot = multi ? createSlot(initial) : undefined;
   const host = options && options.host;
   if (multi && !initial) initial = [];
   if (isHydrating(parent)) {
@@ -329,6 +332,12 @@ export function insert(parent, accessor, marker, initial, options) {
   if (typeof accessor !== "function") {
     accessor = normalize(accessor, initial, multi, true);
     if (typeof accessor !== "function") {
+      // One-shot callers may thread `current` across insert() calls. Register
+      // only for neighboring-slot boundary recovery; leave ownership untagged.
+      if (multi) {
+        slot.current = Array.isArray(accessor) ? accessor : [accessor];
+        registerSlot(parent, slot);
+      }
       insertExpression(parent, accessor, initial, marker);
       host && tagHost(accessor, host);
       return;
@@ -340,6 +349,10 @@ export function insert(parent, accessor, marker, initial, options) {
     initial = [placeholder];
   }
   let current = initial;
+  if (slot) {
+    registerSlot(parent, slot);
+    slot.current = current;
+  }
   effect(
     prev => {
       const value = normalize(accessor(), current, multi, true);
@@ -347,8 +360,9 @@ export function insert(parent, accessor, marker, initial, options) {
       effect(
         () => normalize(value, current, multi),
         inner => {
-          insertExpression(parent, inner, current, marker);
+          insertExpression(parent, inner, current, marker, slot);
           current = inner;
+          if (slot && slot.shared) slot.current = current;
           host && tagHost(current, host);
         },
         prev !== undefined && !(options && options.schedule)
@@ -359,8 +373,9 @@ export function insert(parent, accessor, marker, initial, options) {
     },
     value => {
       if (value === INNER_OWNED) return;
-      insertExpression(parent, value, current, marker);
+      insertExpression(parent, value, current, marker, slot);
       current = value;
+      if (slot && slot.shared) slot.current = current;
       host && tagHost(current, host);
     },
     options
@@ -767,9 +782,12 @@ function eventHandler(e, container, state) {
   retarget(oriTarget);
 }
 
-function insertExpression(parent, value, current, marker) {
+function insertExpression(parent, value, current, marker, slot) {
   if (isHydrating(parent)) return;
   if (value === current) return;
+  // Before a parent has multiple slots, marker-delimited inserts use marker
+  // ownership so adopted token-tagged nodes become removable by their new slot.
+  if (slot && !slot.shared) slot = marker || undefined;
   const t = typeof value,
     multi = marker !== undefined;
 
@@ -779,32 +797,40 @@ function insertExpression(parent, value, current, marker) {
       parent.firstChild.data = value;
     } else parent.textContent = value;
   } else if (value === undefined) {
-    cleanChildren(parent, current, marker);
+    cleanChildren(parent, current, marker, undefined, slot);
   } else if (value.nodeType) {
     if (Array.isArray(current)) {
-      cleanChildren(parent, current, multi ? marker : null, value);
+      cleanChildren(parent, current, multi ? marker : null, value, slot);
     } else if (current && current.nodeType) {
       // `current` is a node we previously inserted but it may have been
       // moved out by user code (e.g. ref-driven migration, JSX wrapping)
       // since the last render. If it's still here, replace it in place;
-      // otherwise append — never `replaceChild` a node that isn't ours.
+      // otherwise re-insert at the slot's region. Never `replaceChild` a
+      // node that isn't ours.
       current.parentNode === parent
         ? parent.replaceChild(value, current)
-        : parent.appendChild(value);
+        : parent.insertBefore(value, slot ? slotBoundary(parent, slot, marker) : null);
     } else if (current && parent.firstChild) {
       parent.replaceChild(value, parent.firstChild);
     } else {
       parent.appendChild(value);
     }
-    if (marker) value[$$SLOT] = marker;
+    if (slot && value[$$SLOT] !== slot) value[$$SLOT] = slot;
   } else if (Array.isArray(value)) {
     const currentArray = current && Array.isArray(current);
     if (value.length === 0) {
-      cleanChildren(parent, current, marker);
+      cleanChildren(parent, current, marker, undefined, slot);
     } else if (currentArray) {
       if (current.length === 0) {
-        appendNodes(parent, value, marker);
-      } else reconcileArrays(parent, current, value, marker);
+        // Empty slots have no local anchor; recover from a later slot boundary
+        // when available, otherwise fall back to the physical marker.
+        appendNodes(
+          parent,
+          value,
+          slot && !slot.nodeType ? slotBoundary(parent, slot, marker) : marker,
+          slot
+        );
+      } else reconcileArrays(parent, current, value, marker, slot);
     } else {
       current && cleanChildren(parent);
       appendNodes(parent, value);
@@ -847,15 +873,15 @@ function tagHost(value, host) {
   }
 }
 
-function appendNodes(parent, array, marker = null) {
+function appendNodes(parent, array, marker = null, slot) {
   for (let i = 0, len = array.length; i < len; i++) {
     const n = array[i];
     parent.insertBefore(n, marker);
-    if (marker) n[$$SLOT] = marker;
+    if (slot && n[$$SLOT] !== slot) n[$$SLOT] = slot;
   }
 }
 
-function cleanChildren(parent, current, marker, replacement) {
+function cleanChildren(parent, current, marker, replacement, slot) {
   if (marker === undefined) return (parent.textContent = "");
   if (current.length) {
     let inserted = false;
@@ -863,14 +889,17 @@ function cleanChildren(parent, current, marker, replacement) {
       const el = current[i];
       if (replacement !== el) {
         const tag = el[$$SLOT];
-        const owns = el.parentNode === parent && (!tag || tag === marker);
+        // Pre-share marker tags remain valid; adopted token-tagged nodes are retagged.
+        const owns = el.parentNode === parent && (!tag || tag === slot || tag === marker);
         if (replacement && !inserted && !i)
-          owns ? parent.replaceChild(replacement, el) : parent.insertBefore(replacement, marker);
+          owns
+            ? parent.replaceChild(replacement, el)
+            : parent.insertBefore(replacement, slot ? slotBoundary(parent, slot, marker) : marker);
         else if (owns) el.remove();
       } else inserted = true;
     }
   } else if (replacement) parent.insertBefore(replacement, marker);
-  if (replacement && marker) replacement[$$SLOT] = marker;
+  if (replacement && slot && replacement[$$SLOT] !== slot) replacement[$$SLOT] = slot;
 }
 
 function gatherHydratable(element, root) {

--- a/packages/runtime/src/constants.js
+++ b/packages/runtime/src/constants.js
@@ -20,10 +20,12 @@ const ChildProperties = /*#__PURE__*/ new Set([
   "children"
 ]);
 
-// Per-node tag identifying the owning slot's marker. Set on every runtime
-// insertion site so that subsequent reconcile / cleanup work can distinguish
-// "the node still belongs to my slot" from "the node has migrated to another
-// slot in the same parent" without consulting external bookkeeping.
+// Per-node ownership tag identifying the slot that inserted the node: the
+// slot's identity token when its parent hosts multiple slots, or the slot's
+// physical marker for single-slot marker-delimited inserts. Set on runtime
+// insertion sites so reconcile / cleanup can distinguish "the node still
+// belongs to my slot" from "the node has migrated to another slot" without
+// external bookkeeping.
 const $$SLOT = /*#__PURE__*/ Symbol("slot");
 
 // Guard companion to the `_$host` getter applied by `insert`'s `host` option:

--- a/packages/runtime/src/reconcile.js
+++ b/packages/runtime/src/reconcile.js
@@ -1,7 +1,8 @@
 // Slightly modified version of: https://github.com/WebReflection/udomdiff/blob/master/index.js
 import { $$SLOT } from "./constants";
+import { slotBoundary } from "./slots";
 
-export default function reconcileArrays(parentNode, a, b, marker) {
+export default function reconcileArrays(parentNode, a, b, marker, slot) {
   let bLength = b.length,
     aEnd = a.length,
     bEnd = bLength,
@@ -9,15 +10,15 @@ export default function reconcileArrays(parentNode, a, b, marker) {
     bStart = 0,
     tail = a[aEnd - 1],
     tailTag = tail[$$SLOT],
-    // Ownership tag: an unclaimed node (no `$$SLOT`) is fair game; a tagged
-    // node belongs only to the slot whose marker matches. If `a`'s tail has
-    // migrated to another slot — same parent or otherwise — `tail.nextSibling`
-    // points into a region we don't own, so fall back to `marker`. `marker ||
-    // null` keeps non-multi (root-mode) callers happy.
+    // If the tail is no longer owned by this slot, its nextSibling may point
+    // into another region. Recover from a later slot boundary when available,
+    // otherwise fall back to the physical marker/null anchor.
     after =
-      tail.parentNode === parentNode && (!tailTag || tailTag === marker)
+      tail.parentNode === parentNode && (!tailTag || tailTag === slot || tailTag === marker)
         ? tail.nextSibling
-        : marker || null,
+        : slot
+          ? slotBoundary(parentNode, slot, marker)
+          : marker || null,
     map = null,
     anchor,
     anchorTag;
@@ -42,7 +43,7 @@ export default function reconcileArrays(parentNode, a, b, marker) {
           const prev = b[bStart - 1];
           const prevTag = prev[$$SLOT];
           node =
-            prev.parentNode === parentNode && (!prevTag || prevTag === marker)
+            prev.parentNode === parentNode && (!prevTag || prevTag === slot || prevTag === marker)
               ? prev.nextSibling
               : after;
         } else node = b[bEnd - bStart];
@@ -50,8 +51,10 @@ export default function reconcileArrays(parentNode, a, b, marker) {
 
       while (bStart < bEnd) {
         const n = b[bStart++];
-        parentNode.insertBefore(n, node);
-        if (marker) n[$$SLOT] = marker;
+        // A migrated anchor may also be in `b`; skip the self-insert.
+        if (n === node) node = n.nextSibling;
+        else parentNode.insertBefore(n, node);
+        if (slot && n[$$SLOT] !== slot) n[$$SLOT] = slot;
       }
       // remove
     } else if (bEnd === bStart) {
@@ -59,7 +62,7 @@ export default function reconcileArrays(parentNode, a, b, marker) {
         const n = a[aStart++];
         if (!map || !map.has(n)) {
           const tag = n[$$SLOT];
-          if (n.parentNode === parentNode && (!tag || tag === marker)) n.remove();
+          if (n.parentNode === parentNode && (!tag || tag === slot || tag === marker)) n.remove();
         }
       }
       // swap backward — symmetric end-swap detected. Walk inward with a single
@@ -75,17 +78,17 @@ export default function reconcileArrays(parentNode, a, b, marker) {
       (anchor = a[aStart]) === b[bEnd - 1] &&
       b[bStart] === a[aEnd - 1] &&
       anchor.parentNode === parentNode &&
-      (!(anchorTag = anchor[$$SLOT]) || anchorTag === marker)
+      (!(anchorTag = anchor[$$SLOT]) || anchorTag === slot || anchorTag === marker)
     ) {
       // Tightest inner loop in the file; one `insertBefore` per iter plus an
-      // end-condition probe. Splitting on `marker` avoids a per-iter branch in
+      // end-condition probe. Splitting on `slot` avoids a per-iter branch in
       // the hot path — js-framework-benchmark `05_swap1k` regresses ~6.5% when
       // this is collapsed (validated 2026-05-16 on Chrome headless).
-      if (marker) {
+      if (slot) {
         do {
           const n = a[--aEnd];
           parentNode.insertBefore(n, anchor);
-          n[$$SLOT] = marker;
+          if (n[$$SLOT] !== slot) n[$$SLOT] = slot;
           bStart++;
           if (aStart >= aEnd - 1 || bStart >= bEnd) break;
         } while (a[aStart] === b[bEnd - 1] && b[bStart] === a[aEnd - 1]);
@@ -121,28 +124,33 @@ export default function reconcileArrays(parentNode, a, b, marker) {
             const head = a[aStart];
             const headTag = head[$$SLOT];
             const node =
-              head.parentNode === parentNode && (!headTag || headTag === marker) ? head : after;
+              head.parentNode === parentNode && (!headTag || headTag === slot || headTag === marker)
+                ? head
+                : after;
             while (bStart < index) {
               const n = b[bStart++];
               parentNode.insertBefore(n, node);
-              if (marker) n[$$SLOT] = marker;
+              if (slot && n[$$SLOT] !== slot) n[$$SLOT] = slot;
             }
           } else {
             const oldNode = a[aStart++];
             const newNode = b[bStart++];
             const oldTag = oldNode[$$SLOT];
-            if (oldNode.parentNode === parentNode && (!oldTag || oldTag === marker)) {
+            if (
+              oldNode.parentNode === parentNode &&
+              (!oldTag || oldTag === slot || oldTag === marker)
+            ) {
               parentNode.replaceChild(newNode, oldNode);
             } else {
               parentNode.insertBefore(newNode, after);
             }
-            if (marker) newNode[$$SLOT] = marker;
+            if (slot && newNode[$$SLOT] !== slot) newNode[$$SLOT] = slot;
           }
         } else aStart++;
       } else {
         const n = a[aStart++];
         const nTag = n[$$SLOT];
-        if (n.parentNode === parentNode && (!nTag || nTag === marker)) n.remove();
+        if (n.parentNode === parentNode && (!nTag || nTag === slot || nTag === marker)) n.remove();
       }
     }
   }

--- a/packages/runtime/src/slots.js
+++ b/packages/runtime/src/slots.js
@@ -1,0 +1,53 @@
+// Slot registry for multi-expression parents, in creation order (document
+// order for compiled output). Token ownership and positional recovery only
+// engage once a parent has more than one slot; single-slot parents keep using
+// their physical marker as the ownership tag when one exists.
+//
+// Entries are append-only for a parent's lifetime. Stale entries may retain
+// their last `current` arrays, but boundary scans only use nodes still in the
+// parent and not tagged to another token-owned slot.
+import { $$SLOT } from "./constants";
+
+export function createSlot(current) {
+  // Keep the shape stable for hot-path reads.
+  return { current, shared: false, index: 0 };
+}
+
+export function registerSlot(parent, slot) {
+  const existing = parent._$slots;
+  if (existing === undefined) {
+    parent._$slots = slot;
+  } else if (Array.isArray(existing)) {
+    slot.index = existing.length;
+    existing.push(slot);
+    slot.shared = true;
+  } else {
+    slot.index = 1;
+    parent._$slots = [existing, slot];
+    existing.shared = true;
+    slot.shared = true;
+  }
+}
+
+// First usable node in `parent` from a slot created after `slot`; falls back to
+// the shared physical marker (or null = append). Used when the current slot
+// cannot derive an insertion point from its own nodes.
+export function slotBoundary(parent, slot, marker) {
+  const slots = parent._$slots;
+  if (Array.isArray(slots)) {
+    for (let i = slot.index + 1; i < slots.length; i++) {
+      const s = slots[i];
+      const cur = s.current;
+      if (!cur) continue;
+      for (let j = 0; j < cur.length; j++) {
+        const n = cur[j];
+        if (n && n.nodeType && n.parentNode === parent) {
+          const t = n[$$SLOT];
+          if (t && !t.nodeType && t !== s) continue;
+          return n;
+        }
+      }
+    }
+  }
+  return marker || null;
+}

--- a/packages/runtime/test/dom/slot-ownership.spec.jsx
+++ b/packages/runtime/test/dom/slot-ownership.spec.jsx
@@ -1,0 +1,691 @@
+/**
+ * @jest-environment jsdom
+ */
+// Slot-ownership probes for nodes that migrate between expression slots.
+// Adjacent compiled slots can share a physical marker, so marker equality
+// alone cannot identify which slot owns a node.
+import { createRoot, createSignal, flush } from "@solidjs/signals";
+import { insert } from "../../src/client";
+
+describe("cross-slot node migration", () => {
+  test("exchange between adjacent slots (tail position, null markers)", () => {
+    const el1 = <span>1</span>;
+    const el2 = <b>2</b>;
+    const [swap, setSwap] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {swap() ? el2 : el1}
+          {swap() ? el1 : el2}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("12");
+    setSwap(true);
+    flush();
+    expect(div.textContent).toBe("21");
+    setSwap(false);
+    flush();
+    expect(div.textContent).toBe("12");
+    dispose();
+  });
+
+  test("exchange between adjacent slots (shared static-element marker)", () => {
+    const el1 = <span>1</span>;
+    const el2 = <b>2</b>;
+    const [swap, setSwap] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {swap() ? el2 : el1}
+          {swap() ? el1 : el2}
+          <u>end</u>
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("12end");
+    setSwap(true);
+    flush();
+    expect(div.textContent).toBe("21end");
+    setSwap(false);
+    flush();
+    expect(div.textContent).toBe("12end");
+    dispose();
+  });
+
+  test("single node migrating forward to the adjacent slot", () => {
+    const el = <b>X</b>;
+    const [right, setRight] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          <span>[</span>
+          {right() ? null : el}
+          {right() ? el : null}
+          <span>]</span>
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("[X]");
+    setRight(true);
+    flush();
+    expect(div.textContent).toBe("[X]");
+    expect(div.contains(el)).toBe(true);
+    setRight(false);
+    flush();
+    expect(div.textContent).toBe("[X]");
+    expect(div.contains(el)).toBe(true);
+    dispose();
+  });
+
+  test("arrays exchanging members across adjacent slots", () => {
+    const el1 = <span>1</span>;
+    const el2 = <span>2</span>;
+    const el3 = <b>3</b>;
+    const el4 = <b>4</b>;
+    const [swap, setSwap] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {swap() ? [el3, el4] : [el1, el2]}
+          {swap() ? [el1, el2] : [el3, el4]}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("1234");
+    setSwap(true);
+    flush();
+    expect(div.textContent).toBe("3412");
+    setSwap(false);
+    flush();
+    expect(div.textContent).toBe("1234");
+    dispose();
+  });
+
+  test("rotation across three adjacent slots", () => {
+    const els = [<span>a</span>, <span>b</span>, <span>c</span>];
+    const [offset, setOffset] = createSignal(0);
+    const at = i => els[(i + offset()) % 3];
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {at(0)}
+          {at(1)}
+          {at(2)}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("abc");
+    setOffset(1);
+    flush();
+    expect(div.textContent).toBe("bca");
+    setOffset(0);
+    flush();
+    expect(div.textContent).toBe("abc");
+    dispose();
+  });
+
+  test("single node migrating backward to the preceding adjacent slot", () => {
+    // Mirror the forward case: the receiving slot updates first.
+    const el = <b>X</b>;
+    const [left, setLeft] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          <span>[</span>
+          {left() ? el : null}
+          {left() ? null : el}
+          <span>]</span>
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("[X]");
+    setLeft(true);
+    flush();
+    expect(div.textContent).toBe("[X]");
+    expect(div.contains(el)).toBe(true);
+    dispose();
+  });
+
+  test("node handed to the next slot while its old slot becomes an array", () => {
+    const el = <b>X</b>;
+    const elA = <span>a</span>;
+    const elB = <span>b</span>;
+    const [swap, setSwap] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {swap() ? [elA, elB] : el}
+          {swap() ? el : null}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("X");
+    setSwap(true);
+    flush();
+    expect(div.textContent).toBe("abX");
+    dispose();
+  });
+
+  test("exchange across an interleaved text expression slot", () => {
+    // A text expression between two node slots still shares their marker.
+    const el1 = <span>1</span>;
+    const el2 = <b>2</b>;
+    const [swap, setSwap] = createSignal(false);
+    const [label, setLabel] = createSignal("-");
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {swap() ? el2 : el1}
+          {label()}
+          {swap() ? el1 : el2}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("1-2");
+    setSwap(true);
+    setLabel("+");
+    flush();
+    expect(div.textContent).toBe("2+1");
+    dispose();
+  });
+
+  // If a slot loses every node while receiving fresh content, its position can
+  // still be recovered from a later slot boundary.
+  test("fresh content lands in position when the slot's old content migrates away", () => {
+    const x = <span>x</span>;
+    const y = <span>y</span>;
+    const w = <b>w</b>;
+    const z = <i>z</i>;
+    const [steal, setSteal] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {steal() ? y : x}
+          {steal() ? w : y}
+          {z}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("xyz");
+    setSteal(true);
+    flush();
+    expect(div.textContent).toBe("ywz");
+    dispose();
+  });
+
+  // The first slot starts with marker ownership, then becomes token-owned
+  // when a second slot registers on the same parent.
+  test("exchange works when the second slot registers after the first updated", () => {
+    const el1 = <span>1</span>;
+    const el2 = <b>2</b>;
+    const [a, setA] = createSignal([]);
+    const [b, setB] = createSignal([el2]);
+    const parent = document.createElement("div");
+    let dispose;
+    createRoot(d => {
+      dispose = d;
+      insert(parent, () => a(), null);
+      flush();
+      setA([el1]);
+      flush();
+      insert(parent, () => b(), null);
+    });
+    flush();
+    expect(parent.textContent).toBe("12");
+
+    setA([el2]);
+    setB([el1]);
+    flush();
+    expect(parent.textContent).toBe("21");
+    expect(parent.contains(el1)).toBe(true);
+    expect(parent.contains(el2)).toBe(true);
+    dispose();
+  });
+
+  // Function-valued children use the nested insert effect.
+  test("exchange between adjacent slots holding function values", () => {
+    const el1 = <span>1</span>;
+    const el2 = <b>2</b>;
+    const [swap, setSwap] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {() => (swap() ? el2 : el1)}
+          {() => (swap() ? el1 : el2)}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("12");
+    setSwap(true);
+    flush();
+    expect(div.textContent).toBe("21");
+    setSwap(false);
+    flush();
+    expect(div.textContent).toBe("12");
+    dispose();
+  });
+
+  test("node migrating through three parents in sequence", () => {
+    const el = <b>X</b>;
+    const [at, setAt] = createSignal(0);
+    let p1, p2, p3, dispose;
+    createRoot(d => {
+      dispose = d;
+      p1 = (
+        <div>
+          {at() === 1 ? [el] : []}
+          {[]}
+        </div>
+      );
+      p2 = (
+        <div>
+          {at() === 2 ? [el] : []}
+          <u />
+        </div>
+      );
+      p3 = (
+        <div>
+          {at() === 3 ? [el] : []}
+          {[]}
+        </div>
+      );
+    });
+    flush();
+    setAt(1);
+    flush();
+    expect(p1.contains(el)).toBe(true);
+    setAt(2);
+    flush();
+    expect(p1.contains(el)).toBe(false);
+    expect(p2.contains(el)).toBe(true);
+    setAt(3);
+    flush();
+    expect(p2.contains(el)).toBe(false);
+    expect(p3.contains(el)).toBe(true);
+    setAt(0);
+    flush();
+    expect(p3.contains(el)).toBe(false);
+    dispose();
+  });
+
+  // Move a middle array member while both arrays keep stable edges.
+  test("middle array member migrating between adjacent slots", () => {
+    const a1 = <span>a</span>;
+    const m = <b>M</b>;
+    const a2 = <span>b</span>;
+    const b1 = <i>c</i>;
+    const b2 = <i>d</i>;
+    const [moved, setMoved] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {moved() ? [a1, a2] : [a1, m, a2]}
+          {moved() ? [b1, m, b2] : [b1, b2]}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("aMbcd");
+    setMoved(true);
+    flush();
+    expect(div.textContent).toBe("abcMd");
+    setMoved(false);
+    flush();
+    expect(div.textContent).toBe("aMbcd");
+    dispose();
+  });
+
+  // Same-node reuse is user error, but it should not crash or destroy the node.
+  test("same node referenced by two slots at once: last insert wins, no crash", () => {
+    const el = <b>X</b>;
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          <span>[</span>
+          {[el]}
+          {[el]}
+          <span>]</span>
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("[X]");
+    expect(div.contains(el)).toBe(true);
+    dispose();
+  });
+
+  // Empty arrays remove the local anchor; refill should use slot order.
+  test("slot emptied by [] regains its position when refilled", () => {
+    const x1 = <span>x</span>;
+    const x2 = <b>X</b>;
+    const y = <i>y</i>;
+    const [state, setState] = createSignal(0);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {state() === 0 ? [x1] : state() === 2 ? [x2] : []}
+          {[y]}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("xy");
+    setState(1);
+    flush();
+    expect(div.textContent).toBe("y");
+    setState(2);
+    flush();
+    expect(div.textContent).toBe("Xy");
+    dispose();
+  });
+
+  // One-shot slots keep stale `current`; boundary scans must ignore nodes
+  // later adopted by another token-owned slot.
+  test("positional recovery skips stale one-shot entries for stolen nodes", () => {
+    const el = <b>X</b>;
+    const y = <span>y</span>;
+    const w = <span>w</span>;
+    const c = <i>c</i>;
+    const [state, setState] = createSignal(0);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {state() >= 2 ? [el, y] : state() >= 1 ? [el] : []}
+          {state() >= 2 ? [w] : [y]}
+          {[el]}
+          {[c]}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("yXc");
+
+    setState(1);
+    flush();
+    expect(div.textContent).toBe("Xyc");
+
+    setState(2);
+    flush();
+    expect(div.textContent).toBe("Xywc");
+    dispose();
+  });
+
+  // Normalize creates text nodes per slot; the element should survive a round
+  // trip through a neighbor.
+  test("slot cycling node -> text -> node while the neighbor borrows the node", () => {
+    const el = <b>X</b>;
+    const [state, setState] = createSignal(0);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {state() === 1 ? "hello" : el}
+          {state() === 1 ? el : null}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("X");
+    setState(1);
+    flush();
+    expect(div.textContent).toBe("helloX");
+    expect(div.contains(el)).toBe(true);
+    setState(0);
+    flush();
+    expect(div.textContent).toBe("X");
+    expect(div.contains(el)).toBe(true);
+    dispose();
+  });
+
+  // Manual multi-slot insert() calls against one surviving parent grow the
+  // append-only registry. Correctness must survive stale entries.
+  test("registry grows under repeated root creation on one parent, stays correct", () => {
+    const parent = document.createElement("div");
+    const CYCLES = 100;
+    for (let i = 0; i < CYCLES; i++) {
+      let dispose;
+      const el = document.createElement("span");
+      el.textContent = "r" + i;
+      const [v, setV] = createSignal([el]);
+      createRoot(d => {
+        dispose = d;
+        insert(parent, () => v(), null);
+      });
+      flush();
+      setV([]);
+      flush();
+      dispose();
+    }
+    expect(parent._$slots.length).toBe(CYCLES);
+    expect(parent.textContent).toBe("");
+
+    const el1 = document.createElement("span");
+    el1.textContent = "1";
+    const el2 = document.createElement("b");
+    el2.textContent = "2";
+    const [a, setA] = createSignal([el1]);
+    const [b, setB] = createSignal([el2]);
+    let dispose;
+    createRoot(d => {
+      dispose = d;
+      insert(parent, () => a(), null);
+      insert(parent, () => b(), null);
+    });
+    flush();
+    expect(parent.textContent).toBe("12");
+    setA([el2]);
+    setB([el1]);
+    flush();
+    expect(parent.textContent).toBe("21");
+    dispose();
+  });
+
+  // Disposing one root does not remove manual insert() content; a live sibling
+  // slot on the same parent must keep rendering and recovering boundaries.
+  test("a live slot keeps working after a sibling root's slot is released", () => {
+    const parent = document.createElement("div");
+    const a1 = document.createElement("span");
+    a1.textContent = "a";
+    const b1 = document.createElement("b");
+    b1.textContent = "b";
+    const b2 = document.createElement("i");
+    b2.textContent = "B";
+
+    let disposeA;
+    createRoot(d => {
+      disposeA = d;
+      const [va] = createSignal([a1]);
+      insert(parent, () => va(), null);
+    });
+    let disposeB, setB;
+    createRoot(d => {
+      disposeB = d;
+      const [vb, set] = createSignal([b1]);
+      setB = set;
+      insert(parent, () => vb(), null);
+    });
+    flush();
+    expect(parent.textContent).toBe("ab");
+
+    disposeA();
+    // Disposal alone does not remove manual insert() content; here we only
+    // care that B stays functional with an earlier stale registry entry.
+    setB([b2]);
+    flush();
+    expect(parent.contains(b2)).toBe(true);
+    expect(parent.contains(b1)).toBe(false);
+    setB([]);
+    flush();
+    setB([b1]);
+    flush();
+    // Refill positioning still works with a stale entry in front of it.
+    expect(parent.contains(b1)).toBe(true);
+    disposeB();
+  });
+
+  // Mirror case: an EARLIER live slot must still anchor on a stale LATER slot
+  // whose DOM remains in the parent.
+  test("a live slot still anchors on a disposed-but-present later slot", () => {
+    const parent = document.createElement("div");
+    const a1 = document.createElement("span");
+    a1.textContent = "a";
+    const b1 = document.createElement("b");
+    b1.textContent = "b";
+
+    let disposeA, setA;
+    createRoot(d => {
+      disposeA = d;
+      const [va, set] = createSignal([a1]);
+      setA = set;
+      insert(parent, () => va(), null);
+    });
+    let disposeB;
+    createRoot(d => {
+      disposeB = d;
+      const [vb] = createSignal([b1]);
+      insert(parent, () => vb(), null);
+    });
+    flush();
+    expect(parent.textContent).toBe("ab");
+
+    disposeB(); // b1 remains rendered under parent
+    expect(parent.textContent).toBe("ab");
+
+    setA([]);
+    flush();
+    expect(parent.textContent).toBe("b");
+    setA([a1]);
+    flush();
+    // A refills BEFORE the disposed-but-present b1, not after it
+    expect(parent.textContent).toBe("ab");
+    disposeA();
+  });
+
+  test("control: exchange works when a static element separates the slots", () => {
+    const el1 = <span>1</span>;
+    const el2 = <b>2</b>;
+    const [swap, setSwap] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          {swap() ? el2 : el1}
+          <hr />
+          {swap() ? el1 : el2}
+        </div>
+      );
+    });
+    flush();
+    expect(div.textContent).toBe("12");
+    setSwap(true);
+    flush();
+    expect(div.textContent).toBe("21");
+    setSwap(false);
+    flush();
+    expect(div.textContent).toBe("12");
+    dispose();
+  });
+
+  // Unshared parents retag adopted nodes with marker ownership.
+  test("token-tagged node is owned by its new single-slot parent", () => {
+    const el = <b>X</b>;
+    const [state, setState] = createSignal(5);
+    let src, dst, dispose;
+    createRoot(d => {
+      dispose = d;
+      src = (
+        <div>
+          {state() === 0 ? [el] : []}
+          {state() === 99 ? [el] : []}
+        </div>
+      );
+      dst = (
+        <div>
+          {state() === 1 ? [el] : []}
+          <u>end</u>
+        </div>
+      );
+    });
+    flush();
+    setState(0);
+    flush();
+    expect(src.textContent).toBe("X");
+    expect(dst.textContent).toBe("end");
+
+    setState(1);
+    flush();
+    expect(dst.textContent).toBe("Xend");
+
+    setState(2);
+    flush();
+    expect(dst.textContent).toBe("end");
+    expect(dst.contains(el)).toBe(false);
+    dispose();
+  });
+
+  test("control: single node migrating between slots in different parents", () => {
+    const el = <b>X</b>;
+    const [right, setRight] = createSignal(false);
+    let div, dispose;
+    createRoot(d => {
+      dispose = d;
+      div = (
+        <div>
+          <div id="a">{right() ? null : el}</div>
+          <div id="b">{right() ? el : null}</div>
+        </div>
+      );
+    });
+    flush();
+    expect(div.querySelector("#a").textContent).toBe("X");
+    setRight(true);
+    flush();
+    expect(div.querySelector("#b").textContent).toBe("X");
+    expect(div.querySelector("#a").textContent).toBe("");
+    setRight(false);
+    flush();
+    expect(div.querySelector("#a").textContent).toBe("X");
+    dispose();
+  });
+});

--- a/packages/runtime/test/ssr/hydrate-slot-ownership.spec.js
+++ b/packages/runtime/test/ssr/hydrate-slot-ownership.spec.js
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment jsdom
+ */
+// Post-hydration slot migration starts from claimed DOM nodes, which have not
+// passed through the client insertion paths that apply $$SLOT ownership tags.
+import * as r from "../../src/client";
+import * as r2 from "../../src/server";
+import { createSignal, flush } from "@solidjs/signals";
+
+globalThis._$HY = { events: [], completed: new WeakSet() };
+
+describe("post-hydration cross-slot migration (adjacent marker-delimited slots)", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  beforeEach(() => {
+    globalThis._$HY = { events: [], completed: new WeakSet() };
+    container.innerHTML = "";
+  });
+
+  it("single claimed node migrates forward to the adjacent slot", () => {
+    // Server HTML matching the client evaluation order:
+    // <div _hk=1><!--$--><b _hk=0>X</b><!--/--><!--$--><!--/--></div>
+    const rendered = r2.renderToString(() => {
+      const inner = r2.ssr(["<b", ">X</b>"], r2.ssrHydrationKey());
+      return r2.ssr(
+        ["<div", "><!--$-->", "<!--/--><!--$-->", "<!--/--></div>"],
+        r2.ssrHydrationKey(),
+        inner,
+        ""
+      );
+    });
+    container.innerHTML = rendered;
+    const serverB = container.querySelector("b");
+
+    const _tmplB = r.template(`<b>X</b>`);
+    const _tmplDiv = r.template(`<div><!$><!/><!$><!/></div>`);
+
+    let setter, el;
+    r.hydrate(() => {
+      const [right, setRight] = createSignal(false);
+      setter = setRight;
+      el = r.getNextElement(_tmplB);
+      const _el$ = r.getNextElement(_tmplDiv),
+        _el$2 = _el$.firstChild,
+        [_el$3, _co$] = r.getNextMarker(_el$2.nextSibling),
+        _el$4 = _el$3.nextSibling,
+        [_el$5, _co$2] = r.getNextMarker(_el$4.nextSibling);
+      r.insert(
+        _el$,
+        r.memo(() => (right() ? null : el)),
+        _el$3,
+        _co$
+      );
+      r.insert(
+        _el$,
+        r.memo(() => (right() ? el : null)),
+        _el$5,
+        _co$2
+      );
+      r.insert(container, _el$, undefined, [...container.childNodes]);
+      r.runHydrationEvents();
+    }, container);
+
+    expect(el).toBe(serverB);
+    expect(container.textContent).toBe("X");
+
+    setter(true);
+    flush();
+    expect(container.textContent).toBe("X");
+    expect(container.contains(el)).toBe(true);
+
+    setter(false);
+    flush();
+    expect(container.textContent).toBe("X");
+    expect(container.contains(el)).toBe(true);
+  });
+
+  it("two claimed nodes exchange between adjacent slots", () => {
+    // Server HTML matching the client evaluation order:
+    // <div _hk=2><!--$--><span _hk=0>1</span><!--/--><!--$--><b _hk=1>2</b><!--/--></div>
+    const rendered = r2.renderToString(() => {
+      const innerSpan = r2.ssr(["<span", ">1</span>"], r2.ssrHydrationKey());
+      const innerBold = r2.ssr(["<b", ">2</b>"], r2.ssrHydrationKey());
+      return r2.ssr(
+        ["<div", "><!--$-->", "<!--/--><!--$-->", "<!--/--></div>"],
+        r2.ssrHydrationKey(),
+        innerSpan,
+        innerBold
+      );
+    });
+    container.innerHTML = rendered;
+    const serverSpan = container.querySelector("span");
+    const serverBold = container.querySelector("b");
+
+    const _tmplSpan = r.template(`<span>1</span>`);
+    const _tmplBold = r.template(`<b>2</b>`);
+    const _tmplDiv = r.template(`<div><!$><!/><!$><!/></div>`);
+
+    let setter, el1, el2, div;
+    r.hydrate(() => {
+      const [swap, setSwap] = createSignal(false);
+      setter = setSwap;
+      el1 = r.getNextElement(_tmplSpan);
+      el2 = r.getNextElement(_tmplBold);
+      const _el$ = r.getNextElement(_tmplDiv),
+        _el$2 = _el$.firstChild,
+        [_el$3, _co$] = r.getNextMarker(_el$2.nextSibling),
+        _el$4 = _el$3.nextSibling,
+        [_el$5, _co$2] = r.getNextMarker(_el$4.nextSibling);
+      div = _el$;
+      r.insert(
+        _el$,
+        r.memo(() => (swap() ? el2 : el1)),
+        _el$3,
+        _co$
+      );
+      r.insert(
+        _el$,
+        r.memo(() => (swap() ? el1 : el2)),
+        _el$5,
+        _co$2
+      );
+      r.insert(container, _el$, undefined, [...container.childNodes]);
+      r.runHydrationEvents();
+    }, container);
+
+    expect(el1).toBe(serverSpan);
+    expect(el2).toBe(serverBold);
+    expect(div.textContent).toBe("12");
+
+    setter(true);
+    flush();
+    expect(div.textContent).toBe("21");
+
+    setter(false);
+    flush();
+    expect(div.textContent).toBe("12");
+  });
+});


### PR DESCRIPTION
Fixes solidjs/solid#2830 — nodes migrating between **adjacent** JSX expression slots are destroyed by the slot they left. This closes the remaining gap in the slot-ownership model this repo shipped for solidjs/solid#2030 ("Support moving DOM Element references inside JSX"): migration works across parents and across separated slots, but adjacent slots silently eat nodes. The everyday shape is two `<Show>`s trading kept-alive panels on a layout flip — each toggle destroys one panel. The full failure class, each pinned by a test:

- exchange between adjacent slots drops a node per swap (`"12"` → `"1"`), in both the tail-position and shared-static-marker geometries
- a single node migrating to the adjacent slot **vanishes entirely**, in both directions
- arrays exchanging members across adjacent slots throw `NotFoundError` mid-reconcile
- a rotation across three slots destroys two of the three elements
- an interleaved text expression does not separate the slots
- related, present even without migration: a null-marker slot emptied via `[]` loses its anchor, so refilled content appends after later slots' content
- **post-hydration the same JSX works** (hydratable output emits a marker pair per slot), so this is also a CSR/SSR behavioral divergence

Scope note: every move here happens through JSX expression values — this is the "Solid controls both sides" case #2030 shipped, not the externally-moved-nodes class declined in solidjs/solid#2515. External-mutation behavior is unchanged.

## Root cause

The compiler gives adjacent expression slots the **same insertion marker** (`null` at the tail, or the next static element — verified for raw expressions and components alike), and the ownership predicate uses the marker as identity:

```js
const owns = el.parentNode === parent && (!tag || tag === marker);
```

Tail slots never tag at all (`if (marker)`), so both slots consider every node fair game; marker-sharing slots tag with the same node, so `tag === marker` is true across slots. Either way two logical slots collapse into one ownership region, and one slot's cleanup removes the node its neighbor just claimed.

## Fix

Ownership is keyed on a per-`insert()` slot identity token; the marker keeps its positioning role. Gated so the hot path is untouched:

- **Single-slot parents (the For-list shape) run the exact previous instruction stream** — tokens engage only when a parent registers a second slot (`parent._$slots`, append-only, creation order).
- Ownership checks accept **token-or-marker**, so content inserted before a parent becomes multi-slot stays owned across the transition; adoption always retags, which is what keeps the permissive untagged case safe.
- A slot whose entire content migrated away in the same flush it receives fresh content recovers its position from the next live slot's region — this also fixes the pre-existing `[]`-refill mis-order.
- Reconcile's `after` anchor gains a guard for the migration case where `tail.nextSibling` is itself an incoming node.
- One-shot inserts stay token-less (direct callers legitimately thread `current` across separate calls) but register for positional queries.

Registry entries live as long as their parent element and hold small slot records plus each slot's last value array; eager release on disposal is deliberately **not** in this PR — it only benefits manual `insert()` reuse against long-lived parents, and is staged separately with its own tests if wanted. DOM renderer only; `universal.js` intentionally unchanged (older host environments, expando/proxy interactions, and these migration patterns aren't idiomatic there).

## Tests

- 27 new tests (25 in `test/dom/slot-ownership.spec.jsx`, 2 hydration in `test/ssr/hydrate-slot-ownership.spec.js`): the failure shapes above, both directions, function-valued slots (the nested-effect path components compile to), dynamic late slot registration, three-parent migration chains, mixed node→text→node cycles, same-node-in-two-slots (last insert wins, no crash), a registry-growth stress documenting the append-only tradeoff at 100 stale entries, and controls pinning the working boundary (separated slots, cross-parent, post-hydration).
- Full runtime suite: 497/497 across browser/server/universal projects.
- Validated end-to-end in the solid repo with this runtime patched into the installed package: the solidjs/solid#2830 repro (6 tests) flips grepasses with zero regressions.

## Performance

Benchmarked old-vs-new through built dists in isolated headless-Chrome processes, 9 loads per variant, medians with distribution overlap comput

| tier | result |
|---|---|
| js-framework-benchmark keyed ops (9 ops) | 9/9 overlapping distributions, max median delta +3.0% |
| realistic app (tabbed dashboard, 200-row list, kept-alive panel swap) | mount identical (0.567ms both); interactions overlap |
| targeted runtime workloads (reverse/swap/replace/create ×2/shared updates) | 6/6 overlapping |

Across all 20 measured operations, the **only statistically disjoint row is the kept-alive tab switch — where the old runtime destroys a panel  absence of work. Residual cost is ~0.02µs/update confined to multi-slot parents. The swap1k-guarded branch split in `reconcileArrays` ispreserved.

Alternative considered: compiler-emitted per-slot markers (hydratable output already produces them, which is why hydrated pages don't have thiswith zero runtime bookkeeping but permanent extra template/DOM nodes at every adjacent-expression site and compiler/runtime lockstep. The runtime token approach keeps DOM shape and works with existing compiled output; happy to pivot if you prefer the marker route.

Full disclosure: I wrote this with the help of an AI assistant (Claude Fable 5) and reviewed every line before pushing. All new tests were written first and confirmed failing on the unfixed code