### PR TITLE
fix(client): delegated events reach outer roots across nested render roots

### DIFF
--- a/.changeset/nested-root-delegation.md
+++ b/.changeset/nested-root-delegation.md
@@ -1,0 +1,24 @@
+---
+"@dom-expressions/runtime": patch
+---
+
+Fix delegated events never reaching outer roots when a render root is
+rendered inside another root's DOM (embedded widgets, microfrontends).
+The first (innermost) container listener marked the event consumed for
+every other root, so an outer root's delegated handlers were silently
+skipped even though the native event bubbled through its elements: a
+plain `addEventListener` on the same element fired while the delegated
+handler didn't.
+
+`$$EVENT_OWNER` now records the boundary of the most recent walk instead
+of a consumed flag: an ancestor container whose subtree contains that boundary
+resumes the handler walk from it up to its own boundary, so each root's
+handlers fire exactly once, innermost-out, matching native bubbling.
+`stopPropagation()` inside a nested root still suppresses outer roots (it
+stops the native event before their listeners run), and hydration event
+replay now relays queued events through all matching roots innermost-first
+so pre- and post-hydration clicks behave identically. Apps that relied on
+nested roots to isolate clicks from outer handlers should use
+`stopPropagation()`, which remains the documented mechanism. Non-nested
+apps are unaffected; the resume path is unreachable unless an inner root
+already handled the event.

--- a/packages/runtime/src/client.js
+++ b/packages/runtime/src/client.js
@@ -597,14 +597,34 @@ export function runHydrationEvents() {
         const [el, e] = events[0];
         if (!completed.has(el)) return;
         events.shift();
-        let match;
+        let matchContainer, matchState, matchDistance, matches;
         for (const [container, state] of delegatedContainers) {
           if (!state.handlers.has(e.type)) continue;
           const entry = findOwner(e.target, state);
-          if (entry && (!match || entry.distance < match.distance))
-            match = { container, state, distance: entry.distance };
+          if (!entry) continue;
+          if (matchContainer) {
+            if (!matches)
+              matches = [
+                {
+                  container: matchContainer,
+                  state: matchState,
+                  distance: matchDistance
+                }
+              ];
+            matches.push({ container, state, distance: entry.distance });
+          } else {
+            matchContainer = container;
+            matchState = state;
+            matchDistance = entry.distance;
+          }
         }
-        if (match) eventHandler(e, match.container, match.state);
+        if (matches) {
+          // Replay innermost-first so queued hydration events follow the same
+          // root-boundary handoff as live native bubbling.
+          matches.sort((a, b) => a.distance - b.distance);
+          for (let i = 0; i < matches.length; i++)
+            eventHandler(e, matches[i].container, matches[i].state);
+        } else if (matchContainer) eventHandler(e, matchContainer, matchState);
       }
       if (sharedConfig.done) {
         sharedConfig.events = _$HY.events = null;
@@ -696,7 +716,15 @@ function eventHandler(e, container, state) {
   if (sharedConfig.registry && sharedConfig.events) {
     if (sharedConfig.events.find(([el, ev]) => ev === e)) return;
   }
-  if (e[$$EVENT_OWNER]) return;
+  const prev = e[$$EVENT_OWNER];
+  let resumeNode;
+  if (prev) {
+    // An inner root already walked its segment. Ancestor roots resume from
+    // that boundary; unrelated/shared containers must not see the event as
+    // theirs. Native stopPropagation still prevents this listener from running.
+    if (prev === true || prev === container || !container.contains(prev)) return;
+    resumeNode = prev;
+  }
   const owner =
     state &&
     (state.owners.size === 1 && state.owners.has(container)
@@ -705,7 +733,7 @@ function eventHandler(e, container, state) {
   if (state && !owner) return;
   e[$$EVENT_OWNER] = owner || true;
 
-  let node = e.target;
+  let node = resumeNode || e.target;
   const key = `$$${e.type}`;
   const oriTarget = e.target;
   const boundary = owner || container || e.currentTarget;
@@ -742,7 +770,13 @@ function eventHandler(e, container, state) {
       return node || boundary || document;
     }
   });
-  if (e.composedPath) {
+  if (resumeNode) {
+    // If the boundary was the target, the inner walk already fired it.
+    // Resume above it so boundary handlers do not run twice.
+    if (resumeNode === e.target)
+      node = resumeNode._$host || resumeNode.parentNode || resumeNode.host;
+    if (node && node !== boundary) walkUpTree();
+  } else if (e.composedPath) {
     const path = e.composedPath();
     if (path.length) {
       retarget(path[0]);

--- a/packages/runtime/test/dom/nested-roots.spec.jsx
+++ b/packages/runtime/test/dom/nested-roots.spec.jsx
@@ -1,0 +1,273 @@
+/**
+ * @jest-environment jsdom
+ */
+// Delegated events across nested render roots: a root rendered inside another
+// root's DOM. The native event bubbles through the outer root's elements, so
+// the outer root's delegated handlers must fire unless stopPropagation ran:
+// each registered root walks its own segment of the propagation path.
+import * as r from "../../src/client";
+import { sharedConfig } from "../core";
+
+function mount(el, code) {
+  return r.render(code, el);
+}
+
+describe("delegated events across nested render roots", () => {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+
+  afterEach(() => {
+    host.innerHTML = "";
+  });
+
+  test("outer root's delegated handler fires for clicks inside a nested root", () => {
+    let outer = 0;
+    let native = 0;
+    let inner = 0;
+    let slot;
+    const d1 = mount(host, () => (
+      <div onClick={() => outer++} ref={el => el.addEventListener("click", () => native++)}>
+        <div ref={el => (slot = el)} />
+      </div>
+    ));
+    const d2 = mount(slot, () => <button onClick={() => inner++}>go</button>);
+
+    slot.querySelector("button").click();
+    expect(inner).toBe(1);
+    expect(native).toBe(1);
+    expect(outer).toBe(1);
+
+    d2();
+    d1();
+  });
+
+  test("three levels of nesting fire inner-to-outer, once each", () => {
+    const order = [];
+    let slot1, slot2;
+    const d1 = mount(host, () => (
+      <div onClick={() => order.push("outer")}>
+        <div ref={el => (slot1 = el)} />
+      </div>
+    ));
+    const d2 = mount(slot1, () => (
+      <div onClick={() => order.push("middle")}>
+        <div ref={el => (slot2 = el)} />
+      </div>
+    ));
+    const d3 = mount(slot2, () => <button onClick={() => order.push("inner")}>go</button>);
+
+    slot2.querySelector("button").click();
+    expect(order).toEqual(["inner", "middle", "outer"]);
+
+    d3();
+    d2();
+    d1();
+  });
+
+  test("two sibling nested roots stay isolated, outer fires for both", () => {
+    let outer = 0;
+    let innerA = 0;
+    let innerB = 0;
+    let slotA, slotB;
+    const d1 = mount(host, () => (
+      <div onClick={() => outer++}>
+        <div ref={el => (slotA = el)} />
+        <div ref={el => (slotB = el)} />
+      </div>
+    ));
+    const d2 = mount(slotA, () => <button onClick={() => innerA++}>a</button>);
+    const d3 = mount(slotB, () => <button onClick={() => innerB++}>b</button>);
+
+    slotA.querySelector("button").click();
+    expect([innerA, innerB, outer]).toEqual([1, 0, 1]);
+    slotB.querySelector("button").click();
+    expect([innerA, innerB, outer]).toEqual([1, 1, 2]);
+
+    d3();
+    d2();
+    d1();
+  });
+
+  test("stopPropagation inside the nested root suppresses outer roots", () => {
+    let outer = 0;
+    let slot;
+    const d1 = mount(host, () => (
+      <div onClick={() => outer++}>
+        <div ref={el => (slot = el)} />
+      </div>
+    ));
+    const d2 = mount(slot, () => <button onClick={e => e.stopPropagation()}>go</button>);
+
+    slot.querySelector("button").click();
+    expect(outer).toBe(0);
+
+    d2();
+    d1();
+  });
+
+  test("handlers between the roots fire once, with correct currentTarget", () => {
+    let slot;
+    let wrapperFires = 0;
+    let wrapperCurrentTargetOk = false;
+    let wrapperEl;
+    const d1 = mount(host, () => (
+      <div>
+        <section
+          ref={el => (wrapperEl = el)}
+          onClick={e => {
+            wrapperFires++;
+            wrapperCurrentTargetOk = e.currentTarget === wrapperEl;
+          }}
+        >
+          <div ref={el => (slot = el)} />
+        </section>
+      </div>
+    ));
+    const d2 = mount(slot, () => <button onClick={() => {}}>go</button>);
+
+    slot.querySelector("button").click();
+    expect(wrapperFires).toBe(1);
+    expect(wrapperCurrentTargetOk).toBe(true);
+
+    d2();
+    d1();
+  });
+
+  test("bound handler data is delivered on the resumed outer walk", () => {
+    let received;
+    let slot;
+    const d1 = mount(host, () => (
+      <div onClick={[d => (received = d), { menu: 42 }]}>
+        <div ref={el => (slot = el)} />
+      </div>
+    ));
+    const d2 = mount(slot, () => <button onClick={() => {}}>go</button>);
+
+    slot.querySelector("button").click();
+    expect(received).toEqual({ menu: 42 });
+
+    d2();
+    d1();
+  });
+
+  test("hydration replay handles all nested roots innermost-first", async () => {
+    const order = [];
+    let slot, btn;
+    const d1 = mount(host, () => (
+      <div onClick={() => order.push("outer")}>
+        <div ref={el => (slot = el)} />
+      </div>
+    ));
+    const d2 = mount(slot, () => (
+      <button ref={el => (btn = el)} onClick={() => order.push("inner")}>
+        go
+      </button>
+    ));
+
+    const event = new MouseEvent("click", { bubbles: true });
+    sharedConfig.registry = new Map();
+    sharedConfig.events = [[btn, event]];
+    sharedConfig.completed = new WeakSet([btn]);
+    btn.dispatchEvent(event); // absorbed by the queued-event short-circuit
+    expect(order).toEqual([]);
+
+    sharedConfig.done = false;
+    r.runHydrationEvents();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(order).toEqual(["inner", "outer"]);
+    sharedConfig.registry = undefined;
+    sharedConfig.events = undefined;
+    sharedConfig.completed = undefined;
+    d2();
+    d1();
+  });
+
+  test("nested root inside an outer-owned external portal reaches outer handlers", () => {
+    const calls = [];
+    const portalMount = document.createElement("div");
+    document.body.appendChild(portalMount);
+    let logicalParent;
+    const d1 = mount(host, () => (
+      <section ref={el => (logicalParent = el)} onClick={() => calls.push("logical")} />
+    ));
+
+    const content = document.createElement("div");
+    content.$$click = () => calls.push("content");
+    portalMount.appendChild(content);
+    content._$host = logicalParent;
+    r.registerDelegatedContainer(portalMount, host);
+
+    const slot = document.createElement("div");
+    content.appendChild(slot);
+    const d2 = mount(slot, () => <button onClick={() => calls.push("inner")}>go</button>);
+
+    slot.querySelector("button").click();
+    expect(calls).toEqual(["inner", "content", "logical"]);
+
+    r.unregisterDelegatedContainer(portalMount, host);
+    portalMount.remove();
+    d2();
+    d1();
+  });
+
+  test("clicking directly on the nested root's container fires its handler once", () => {
+    let slotClicks = 0;
+    let outerClicks = 0;
+    let slot;
+    const d1 = mount(host, () => (
+      <div onClick={() => outerClicks++}>
+        <section>
+          <div onClick={() => slotClicks++} ref={el => (slot = el)} />
+        </section>
+      </div>
+    ));
+    const d2 = mount(slot, () => <button onClick={() => {}}>go</button>);
+
+    slot.click();
+    expect(slotClicks).toBe(1);
+    expect(outerClicks).toBe(1);
+
+    d2();
+    d1();
+  });
+
+  test("clicking a nested-root container below an outer handler", () => {
+    let slotClicks = 0;
+    let rootClicks = 0;
+    let slot;
+    const d1 = mount(host, () => (
+      <div onClick={() => rootClicks++}>
+        <div onClick={() => slotClicks++} ref={el => (slot = el)} />
+      </div>
+    ));
+    const d2 = mount(slot, () => <button onClick={() => {}}>go</button>);
+
+    slot.click();
+    expect(slotClicks).toBe(1);
+    expect(rootClicks).toBe(1);
+
+    d2();
+    d1();
+  });
+
+  test("the nested root's container element handlers fire once", () => {
+    // the slot element belongs to the outer root's JSX and may carry its own
+    // delegated handler; the inner walk stops below its boundary, so the
+    // outer walk must pick it up exactly once
+    let slotClicks = 0;
+    let slot;
+    const d1 = mount(host, () => (
+      <div>
+        <div onClick={() => slotClicks++} ref={el => (slot = el)} />
+      </div>
+    ));
+    const d2 = mount(slot, () => <button onClick={() => {}}>go</button>);
+
+    slot.querySelector("button").click();
+    expect(slotClicks).toBe(1);
+
+    d2();
+    d1();
+  });
+});


### PR DESCRIPTION
Fixes solidjs/solid#2832 — when a render root is mounted inside another root's DOM (an embedded widget or microfrontend calling `render()` into a slot of the host app), the outer root's **delegated** handlers never fire for events from the inner root, even though the native event bubbles through the outer root's elements: a plain `addEventListener` on the same wrapper fires while the delegated `onClick` on it doesn't. The everyday casualty is any delegated handler above an embedded root — click-outside-to-dismiss, analytics capture, modal scrims — silently dead inside the embedded region, with native listeners still working, which makes it maddening to debug. This contradicts the natural reading of the root-owned delegation docs (*"`event.stopPropagation()` inside a nested Solid root can prevent outer roots … from observing the native event"* — implying un-stopped events are observed), and it's a regression from 1.x, where document-level delegation walked the composed path across roots.

The same root-scoping affects **hydration replay**: `runHydrationEvents` picked only the nearest registered root, so a click queued during hydration would handle just the innermost segment even once live dispatch is fixed.

## Root cause

Every registered container receives the bubbling native event, innermost first. The first listener marks it consumed for all others:

```js
if (e[$$EVENT_OWNER]) return;   // ← outer root's listener bails out here
...
e[$$EVENT_OWNER] = owner || true;
```

…and its walk (correctly) stops at its own root boundary. So the inner root never invokes outer handlers, and the marker then prevents the outer root's listener from walking its own segment.

## Fix

`$$EVENT_OWNER` becomes "the boundary of the most recent walk" instead of a consumed flag. An ancestor container whose subtree contains the recorded boundary resumes the walk *from that boundary element* up to its own boundary; unrelated containers still bail:

```js
if (prev === true || prev === container || !container.contains(prev)) return;
resumeNode = prev;
```

Resuming *at* the boundary is load-bearing: walks fire a boundary's own handlers only when it is the event target, so in the normal case the inner root's container element (outer-owned JSX that may carry its own handlers) hasn't fired yet. In the one case where it has — the click landed directly on the container — the resume steps to the next node up instead, and skips entirely if that lands on the outer root's own boundary. Each root's handlers run exactly once, innermost-out, matching native bubbling order. `stopPropagation()` composes for free: it stops the native event before outer containers' listeners run. `runHydrationEvents` now relays queued events through all matching roots innermost-first, so pre- and post-hydration clicks behave identically.

Behavior change to be aware of: code using nested roots to *sandbox* clicks from outer handlers — i.e. relying on this bug — will see outer handlers fire again; `stopPropagation()` remains the documented isolation mechanism. Known limitation, unchanged from before: portal content mounted outside all roots and owned by a *nested* root still can't reach outer roots (the native event never touches their containers). Non-nested apps are unaffected by construction — the resume path is unreachable unless an inner root already recorded a boundary, so there is no cost on the common path.

## Tests

- 11 new tests in `test/dom/nested-roots.spec.jsx`: the basic case with a native-listener control, three-level nesting firing innermost-out once each, sibling nested roots staying isolated, `stopPropagation` suppression across roots, between-root handlers with correct `currentTarget`, the nested root's container element firing exactly once — including when the click lands directly on the container, and when that container is a direct child of the outer root's boundary — bound-handler data (`onClick={[fn, data]}`) on the resumed walk, hydration replay across nested roots, and a nested root inside an outer-owned external portal (wired the way `Portal` actually registers: `_$host` + `registerDelegatedContainer`).
- Full runtime suite: 483/483 across browser/server/universal — all existing events, shadow-DOM, portal, and replay tests unaffected.
- Validated end-to-end in the solid repo with this runtime patched into the installed package: the solidjs/solid#2832 repro flips green, and both solid-web's client suite (309 passing) and its separately-configured hydration suite (byte-identical failure set to pristine baseline) show zero regressions attributable to this change.