### PR TITLE
fix(compiler): keep closing tag before trailing per-slot insertion markers

### DIFF
--- a/.changeset/fix-omit-closing-tag-per-slot-markers.md
+++ b/.changeset/fix-omit-closing-tag-per-slot-markers.md
@@ -1,0 +1,6 @@
+---
+"@dom-expressions/babel-plugin-jsx": patch
+"@dom-expressions/jsx-compiler": patch
+---
+
+Fix omitLastClosingTag corrupting templates when per-slot insertion markers follow the last static element. An element trailed by two or more dynamic slots now keeps its closing tag, so the trailing `<!>` placeholders parse as its siblings instead of being swallowed as children of the still-open element (which crashed the template walk with "Cannot read properties of null (reading 'nextSibling')").

--- a/packages/babel-plugin-jsx/src/dom/element.ts
+++ b/packages/babel-plugin-jsx/src/dom/element.ts
@@ -1173,9 +1173,35 @@ function transformAttributes(
   results.hasHydratableEvent = results.hasHydratableEvent || hasHydratableEvent;
 }
 
+// Children that compile to `insert()` calls and contribute no markup of their
+// own: dynamic expression containers, components, and spread children. Mirrors
+// the `!child.id && child.exprs.length` count in transformChildren.
+function countDynamicSlots(children: JSXChildPath[]): number {
+  let count = 0;
+  for (const child of children) {
+    const node = child.node;
+    if (
+      t.isJSXText(node) ||
+      (t.isJSXExpressionContainer(node) &&
+        getStaticExpression(child as BabelPath<babelTypes.JSXExpressionContainer>) !== false) ||
+      (t.isJSXElement(node) && !isComponent(getTagName(node)))
+    )
+      continue;
+    count++;
+  }
+  return count;
+}
+
 function findLastElement(children: JSXChildPath[], hydratable?: boolean): number {
   let lastElement = -1,
     tagName;
+  // Counterpart of transformChildren's per-slot markers: with two or more
+  // dynamic slots under this parent (CSR only), a trailing dynamic child
+  // appends a dedicated `<!>` placeholder to the template, so an earlier
+  // element may not omit its closing tag — the still-open element would
+  // swallow the placeholder as a child while the generated
+  // firstChild/nextSibling walk expects it as a sibling.
+  const perSlotMarkers = !hydratable && countDynamicSlots(children) > 1;
   for (let i = children.length - 1; i >= 0; i--) {
     const node = children[i].node;
     if (
@@ -1189,6 +1215,9 @@ function findLastElement(children: JSXChildPath[], hydratable?: boolean): number
       lastElement = i;
       break;
     }
+    // This trailing dynamic slot will emit a per-slot placeholder after any
+    // preceding element's markup: nothing here may omit its closing tag.
+    if (perSlotMarkers) break;
   }
   return lastElement;
 }

--- a/packages/babel-plugin-jsx/test/__dom_fixtures__/adjacentSlots/code.js
+++ b/packages/babel-plugin-jsx/test/__dom_fixtures__/adjacentSlots/code.js
@@ -1,0 +1,44 @@
+// Per-slot `<!>` insertion markers × omitLastClosingTag: an element followed
+// by multiple dynamic slots must keep its closing tag, or the trailing
+// placeholders parse as its children and corrupt the template walk.
+const trailingSlotsAfterElement = (
+  <div>
+    <span>static</span>
+    {a()}
+    {b()}
+  </div>
+);
+
+const trailingComponentAndSlot = (
+  <div>
+    <span>static</span>
+    <Comp />
+    {b()}
+  </div>
+);
+
+const nestedParent = (
+  <div>
+    <header>
+      <span>static</span>
+      {a()}
+      {b()}
+    </header>
+  </div>
+);
+
+// Safe omissions that must be preserved:
+const slotsBeforeElement = (
+  <div>
+    {a()}
+    {b()}
+    <span>static</span>
+  </div>
+);
+
+const singleTrailingSlot = (
+  <div>
+    <span>static</span>
+    {a()}
+  </div>
+);

--- a/packages/babel-plugin-jsx/test/__dom_fixtures__/adjacentSlots/output.js
+++ b/packages/babel-plugin-jsx/test/__dom_fixtures__/adjacentSlots/output.js
@@ -1,0 +1,44 @@
+import { template as _$template } from "r-dom";
+import { createComponent as _$createComponent } from "r-dom";
+import { insert as _$insert } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(`<div><span>static</span><!><!>`),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div><header><span>static</span><!><!>`),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<div><!><span>static`),
+  _tmpl$4 = /*#__PURE__*/ _$template(`<div><span>static`);
+var _el$ = _tmpl$(),
+  _el$2 = _el$.firstChild,
+  _el$3 = _el$2.nextSibling,
+  _el$4 = _el$3.nextSibling;
+_$insert(_el$, a, _el$3);
+_$insert(_el$, b, _el$4);
+// Per-slot `<!>` insertion markers × omitLastClosingTag: an element followed
+// by multiple dynamic slots must keep its closing tag, or the trailing
+// placeholders parse as its children and corrupt the template walk.
+const trailingSlotsAfterElement = _el$;
+var _el$5 = _tmpl$(),
+  _el$6 = _el$5.firstChild,
+  _el$7 = _el$6.nextSibling,
+  _el$8 = _el$7.nextSibling;
+_$insert(_el$5, _$createComponent(Comp, {}), _el$7);
+_$insert(_el$5, b, _el$8);
+const trailingComponentAndSlot = _el$5;
+var _el$9 = _tmpl$2(),
+  _el$0 = _el$9.firstChild,
+  _el$1 = _el$0.firstChild,
+  _el$10 = _el$1.nextSibling,
+  _el$11 = _el$10.nextSibling;
+_$insert(_el$0, a, _el$10);
+_$insert(_el$0, b, _el$11);
+const nestedParent = _el$9;
+
+// Safe omissions that must be preserved:
+var _el$12 = _tmpl$3(),
+  _el$14 = _el$12.firstChild,
+  _el$13 = _el$14.nextSibling;
+_$insert(_el$12, a, _el$14);
+_$insert(_el$12, b, _el$13);
+const slotsBeforeElement = _el$12;
+var _el$15 = _tmpl$4(),
+  _el$16 = _el$15.firstChild;
+_$insert(_el$15, a, null);
+const singleTrailingSlot = _el$15;

--- a/packages/jsx-compiler/__tests__/babel-fixtures.test.js
+++ b/packages/jsx-compiler/__tests__/babel-fixtures.test.js
@@ -13,6 +13,7 @@ const parityLevel = {
 const fixtureParity = {
   SVG: parityLevel.subset,
   SVGComponentPartial: parityLevel.subset,
+  adjacentSlots: parityLevel.subset,
   attributeExpressions: parityLevel.subset,
   components: parityLevel.subset,
   conditionalExpressions: parityLevel.subset,
@@ -114,6 +115,8 @@ describe("AST-native Babel DOM fixture reuse", () => {
 function supportedSubset(fixture) {
   const source = readFixture(fixture);
   switch (fixture) {
+    case "adjacentSlots":
+      return source;
     case "simpleElements":
       return source;
     case "textInterpolation":

--- a/packages/jsx-compiler/__tests__/fixtures/dom/adjacentSlots/output.js
+++ b/packages/jsx-compiler/__tests__/fixtures/dom/adjacentSlots/output.js
@@ -1,0 +1,48 @@
+import { template as _$template } from "r-dom";
+import { insert as _$insert } from "r-dom";
+import { createComponent as _$createComponent } from "r-dom";
+var _tmpl$ = /* @__PURE__ */ _$template(`<div><span>static</span><!><!>`);
+var _tmpl$2 = /* @__PURE__ */ _$template(`<div><header><span>static</span><!><!>`);
+var _tmpl$3 = /* @__PURE__ */ _$template(`<div><!><span>static`);
+var _tmpl$4 = /* @__PURE__ */ _$template(`<div><span>static`);
+// Per-slot `<!>` insertion markers × omitLastClosingTag: an element followed
+// by multiple dynamic slots must keep its closing tag, or the trailing
+// placeholders parse as its children and corrupt the template walk.
+const trailingSlotsAfterElement = (() => {
+	var _el$ = _tmpl$();
+	var _el$2 = _el$.firstChild.nextSibling;
+	_$insert(_el$, a, _el$2);
+	var _el$3 = _el$.firstChild.nextSibling.nextSibling;
+	_$insert(_el$, b, _el$3);
+	return _el$;
+})();
+const trailingComponentAndSlot = (() => {
+	var _el$4 = _tmpl$();
+	var _el$5 = _el$4.firstChild.nextSibling;
+	_$insert(_el$4, _$createComponent(Comp, {}), _el$5);
+	var _el$6 = _el$4.firstChild.nextSibling.nextSibling;
+	_$insert(_el$4, b, _el$6);
+	return _el$4;
+})();
+const nestedParent = (() => {
+	var _el$7 = _tmpl$2();
+	var _el$8 = _el$7.firstChild;
+	var _el$9 = _el$8.firstChild.nextSibling;
+	_$insert(_el$8, a, _el$9);
+	var _el$10 = _el$8.firstChild.nextSibling.nextSibling;
+	_$insert(_el$8, b, _el$10);
+	return _el$7;
+})();
+// Safe omissions that must be preserved:
+const slotsBeforeElement = (() => {
+	var _el$11 = _tmpl$3();
+	var _el$12 = _el$11.firstChild;
+	_$insert(_el$11, a, _el$12);
+	_$insert(_el$11, b, _el$11.firstChild.nextSibling);
+	return _el$11;
+})();
+const singleTrailingSlot = (() => {
+	var _el$13 = _tmpl$4();
+	_$insert(_el$13, a, null);
+	return _el$13;
+})();

--- a/packages/jsx-compiler/src/dom/children.rs
+++ b/packages/jsx-compiler/src/dom/children.rs
@@ -31,6 +31,12 @@ impl<'a> AstDomTransform<'a, '_> {
         // neighbor (solidjs/solid#2830). Slots ride an immediately following
         // static sibling when one exists, otherwise get a dedicated `<!>`.
         let per_slot = !self.hydratable && self.dynamic_slot_count(&element.children) > 1;
+        // Per-slot placeholders land after the last static element's markup
+        // when dynamic slots trail it; a still-open element would swallow the
+        // `<!>` placeholders as children while the generated node walk expects
+        // them as siblings — so that element keeps its closing tag.
+        let last_static_child = last_static_child
+            .filter(|&i| !(per_slot && self.dynamic_slot_count(&element.children[i + 1..]) > 0));
         let mut index = 0;
         let mut child_node_index = 0;
 

--- a/packages/runtime/test/dom/adjacent-slots.spec.jsx
+++ b/packages/runtime/test/dom/adjacent-slots.spec.jsx
@@ -249,4 +249,44 @@ describe("adjacent expression slots (#2830)", () => {
     expect(left.textContent).toBe("X");
     expect(rightDiv.textContent).toBe("");
   });
+
+  test("slots after a static element land beside it, not inside it", () => {
+    // Regression: per-slot `<!>` placeholders are appended after the element's
+    // markup, so omitLastClosingTag may not drop its closing tag — the open
+    // element would swallow the placeholders as children and the template
+    // walk would crash ("Cannot read properties of null").
+    const [a, setA] = createSignal("A");
+    const [b] = createSignal("B");
+    const div = createRoot(() => (
+      <div>
+        <span>static</span>
+        {a()}
+        {b()}
+      </div>
+    ));
+    expect(div.textContent).toBe("staticAB");
+    expect(div.querySelector("span").textContent).toBe("static");
+
+    setA("A2");
+    flush();
+    expect(div.textContent).toBe("staticA2B");
+    expect(div.querySelector("span").textContent).toBe("static");
+  });
+
+  test("slots after a static element inside a nested parent", () => {
+    const [a] = createSignal("A");
+    const [b] = createSignal("B");
+    const div = createRoot(() => (
+      <div>
+        <section>
+          <span>static</span>
+          {a()}
+          {b()}
+        </section>
+      </div>
+    ));
+    const section = div.firstChild;
+    expect(section.textContent).toBe("staticAB");
+    expect(section.firstChild.textContent).toBe("static");
+  });
 });


### PR DESCRIPTION
## The bug

Since 0.50.0-next.16, the per-slot `<!>` insertion markers introduced in bb7470ea (solidjs/solid#2830) append content to the template after a parent's dynamic slots. The `omitLastClosingTag` walk (`findLastElement`) still assumes dynamic children contribute nothing to the template, so an element followed by two or more dynamic slots loses its closing tag:

```jsx
const view = (
  <div>
    <span>static</span>
    {a()}
    {b()}
  </div>
);
```

compiles to:

```js
var _tmpl$ = /*#__PURE__*/ _$template(`<div><span>static<!><!>`);
var _el$ = _tmpl$(),
  _el$2 = _el$.firstChild,        // <span>
  _el$3 = _el$2.nextSibling,      // expects first <!> as span's SIBLING → null
  _el$4 = _el$3.nextSibling;      // 💥 TypeError: Cannot read properties of null (reading 'nextSibling')
```

Per HTML parsing rules the still-open `<span>` swallows the two comments as *children*, while the generated walk expects them as *siblings* — template instantiation crashes. Trigger: **two or more dynamic slots (expressions, components, or spreads) following a static element under the same parent, non-hydratable mode**. Hit in practice upgrading TanStack Router to Solid 2.0.0-beta.16; workaround until now was `omitLastClosingTag: false`.

The Rust jsx-compiler port has the same flaw for the expression-only shape (`has_following_static_content` doesn't count trailing dynamic slots); the component-then-slot shape was accidentally safe there.

## The fix

Teach both generates that trailing dynamic slots emit placeholders in per-slot mode (≥2 dynamic slots, CSR):

- **babel-plugin-jsx**: `findLastElement` stops its backward walk at a trailing dynamic slot instead of skipping past it, via a new `countDynamicSlots` helper mirroring the slot count in `transformChildren`.
- **jsx-compiler**: `lower_dom_children` clears `last_static_child` when per-slot placeholders will trail it.

Safe omissions are unchanged: slots *before* the last element, a single trailing slot (still `insert(el, expr, null)`), text-boxed slots, and parent/tail closing tags. No pre-existing fixture output changes.

## Tests

- New `__dom_fixtures__/adjacentSlots` fixture (broken shapes + safe-omission controls), also exercised by the jsx-compiler Babel-parity suite with a generated output fixture.
- Two runtime regression tests in `runtime/test/dom/adjacent-slots.spec.jsx` that render the shape end-to-end; verified they fail with the exact reported TypeError when the fix is reverted.
- Suites: babel-plugin-jsx 121/121, runtime 506/506, jsx-compiler 155/155, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)