### PR TITLE
fix(compiler): scope-wrap dynamic children holes in the ssr spread path

### DIFF
--- a/.changeset/fix-ssr-spread-child-scope-wrap.md
+++ b/.changeset/fix-ssr-spread-child-scope-wrap.md
@@ -1,0 +1,5 @@
+---
+"@dom-expressions/babel-plugin-jsx": patch
+---
+
+Fix hydration id drift for spread elements with dynamic children. The ssr generate's spread-element path (`ssrElement`) never applied the hole id `scope()` wrap that `transformChildren` applies on the template path — while the dom generate scope-wraps the matching insert accessor regardless of spread. For a shape like `<a {...props}>{children()}</a>`, the client reserved one hydration id for the hole and the server did not, so every hydration key allocated after the hole drifted and the following siblings were left unclaimed (duplicated DOM, "unclaimed server-rendered node" warnings). `createElement` now wraps dynamic, id-allocating children holes in `scope()` exactly like the template path.

--- a/.changeset/fix-ssr-spread-mergeprops-id-order.md
+++ b/.changeset/fix-ssr-spread-mergeprops-id-order.md
@@ -1,0 +1,6 @@
+---
+"@dom-expressions/babel-plugin-jsx": patch
+"@dom-expressions/runtime": patch
+---
+
+Fix a spread element with dynamic props being left unclaimed on hydration. `mergeProps` with a function source creates a memo, which consumes a hydration child id. The ssr generate evaluated `mergeProps(...)` in `ssrElement`'s argument position — before the element's own hydration key was allocated — while the client claims the element (`getNextElement`) before applying the spread. The element's id shifted by one on the server and the client re-created it instead of claiming (later siblings re-synced, hiding the drift; a `<title>` rendered this way duplicated on every hydration). The ssr generate now defers the merge behind a thunk when hydratable and `ssrElement` allocates the hydration key before resolving function props, matching the client's allocation order.

--- a/packages/babel-plugin-jsx/src/ssr/element.ts
+++ b/packages/babel-plugin-jsx/src/ssr/element.ts
@@ -857,12 +857,25 @@ function createElement(
             `Fragments can only be used top level in JSX. Not used under a <${tagName}>.`
           );
         }
+        const allocatesIds = hydratable && canChildSlotAllocateIds(path);
         const child = transformNode(path);
         if (!child) return memo;
         if (markers && child.exprs.length && !child.spreadElement)
           memo.push(t.stringLiteral("<!--$-->"));
         if (child.exprs.length && !doNotEscape && !child.spreadElement)
           child.exprs[0] = escapeExpression(path, child.exprs[0] as babelTypes.Expression)!;
+        // Deferred holes that can allocate hydration ids evaluate under their
+        // own owner scope, exactly like `transformChildren` does for the
+        // template path. Spread elements render through `ssrElement` instead
+        // of a template, but their children holes still need the wrap — the
+        // dom generate scope()s the matching insert accessor regardless of
+        // spread, so skipping it here desyncs every hydration id that follows
+        // the hole.
+        if (child.exprs.length && allocatesIds && child.dynamic) {
+          child.exprs[0] = t.callExpression(registerImportMethod(path, "scope"), [
+            child.exprs[0] as babelTypes.Expression
+          ]);
+        }
         memo.push(
           getCreateTemplate(config, path, child)(path, child, false) as babelTypes.Expression
         );

--- a/packages/babel-plugin-jsx/src/ssr/element.ts
+++ b/packages/babel-plugin-jsx/src/ssr/element.ts
@@ -944,7 +944,19 @@ function createElement(
     if (runningObject.length || !props.length) props.push(t.objectExpression(runningObject));
 
     if (props.length > 1 || dynamicSpread) {
-      props = [t.callExpression(registerImportMethod(path, "mergeProps"), props)];
+      let merged: babelTypes.Expression = t.callExpression(
+        registerImportMethod(path, "mergeProps"),
+        props
+      );
+      // Defer the merge behind a thunk when hydratable: `mergeProps` with a
+      // function source creates a memo, which consumes a hydration child id.
+      // Evaluated in argument position it would run before `ssrElement`
+      // allocates the element's own id, while the client claims the element
+      // (getNextElement) before applying the spread — shifting the element's
+      // id by one and leaving it unclaimed. `ssrElement` resolves function
+      // props after allocating the hydration key, matching the client order.
+      if (hydratable) merged = t.arrowFunctionExpression([], merged);
+      props = [merged];
     }
   }
 

--- a/packages/babel-plugin-jsx/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
+++ b/packages/babel-plugin-jsx/test/__ssr_hydratable_fixtures__/attributeExpressions/output.js
@@ -78,51 +78,53 @@ let id = "my-h1";
 let link;
 const template = _$ssrElement(
   "div",
-  _$mergeProps(
-    {
-      id: "main"
-    },
-    results,
-    {
-      class: {
-        selected: unknown
+  () =>
+    _$mergeProps(
+      {
+        id: "main"
       },
-      style: {
-        color
+      results,
+      {
+        class: {
+          selected: unknown
+        },
+        style: {
+          color
+        }
       }
-    }
-  ),
+    ),
   () =>
     _$ssrElement(
       "h1",
-      _$mergeProps(
-        {
-          id: "my-h1"
-        },
-        results,
-        {
-          foo: true,
-          disabled: true,
-          get title() {
-            return welcoming();
+      () =>
+        _$mergeProps(
+          {
+            id: "my-h1"
           },
-          get style() {
-            return {
-              "background-color": color(),
-              "margin-right": "40px"
-            };
-          },
-          get ["class"]() {
-            return [
-              "base",
-              {
-                dynamic: dynamic(),
-                selected
-              }
-            ];
+          results,
+          {
+            foo: true,
+            disabled: true,
+            get title() {
+              return welcoming();
+            },
+            get style() {
+              return {
+                "background-color": color(),
+                "margin-right": "40px"
+              };
+            },
+            get ["class"]() {
+              return [
+                "base",
+                {
+                  dynamic: dynamic(),
+                  selected
+                }
+              ];
+            }
           }
-        }
-      ),
+        ),
       () => ((_ref$ = link), _$ssr(_tmpl$, "ccc ddd")),
       false
     ),
@@ -267,9 +269,10 @@ var _v$32 = _$ssrHydrationKey(),
 const template23 = _$ssr(_tmpl$18, _v$32, _v$33, _v$34);
 const template24 = _$ssrElement(
   "a",
-  _$mergeProps(props, {
-    something: true
-  }),
+  () =>
+    _$mergeProps(props, {
+      something: true
+    }),
   undefined,
   true
 );
@@ -277,37 +280,40 @@ var _v$35 = _$ssrHydrationKey(),
   _v$36 = _$scope(() => _$escape(props.children)),
   _v$37 = _$ssrElement(
     "a",
-    _$mergeProps(props, {
-      something: true
-    }),
+    () =>
+      _$mergeProps(props, {
+        something: true
+      }),
     undefined,
     false
   );
 const template25 = _$ssr(_tmpl$19, _v$35, _v$36, _v$37);
 const template26 = _$ssrElement(
   "div",
-  _$mergeProps(
-    {
-      start: "Hi",
-      middle: middle
-    },
-    spread
-  ),
+  () =>
+    _$mergeProps(
+      {
+        start: "Hi",
+        middle: middle
+      },
+      spread
+    ),
   () => "Hi",
   true
 );
 const template27 = _$ssrElement(
   "div",
-  _$mergeProps(
-    {
-      start: "Hi"
-    },
-    first,
-    {
-      middle: middle
-    },
-    second
-  ),
+  () =>
+    _$mergeProps(
+      {
+        start: "Hi"
+      },
+      first,
+      {
+        middle: middle
+      },
+      second
+    ),
   () => "Hi",
   true
 );
@@ -530,34 +536,37 @@ const template80 = _$ssrElement("div", propsSpread, undefined, true);
 const template81 = _$ssrElement("div", propsSpread, undefined, true);
 const template82 = _$ssrElement(
   "div",
-  _$mergeProps(propsSpread, {
-    get ["data-dynamic"]() {
-      return color();
-    },
-    "data-static": color()
-  }),
+  () =>
+    _$mergeProps(propsSpread, {
+      get ["data-dynamic"]() {
+        return color();
+      },
+      "data-static": color()
+    }),
   undefined,
   true
 );
 const template83 = _$ssrElement(
   "div",
-  _$mergeProps(propsSpread, {
-    get ["data-dynamic"]() {
-      return color();
-    },
-    "data-static": color()
-  }),
+  () =>
+    _$mergeProps(propsSpread, {
+      get ["data-dynamic"]() {
+        return color();
+      },
+      "data-static": color()
+    }),
   undefined,
   true
 );
 const template84 = _$ssrElement(
   "div",
-  _$mergeProps(propsSpread1, propsSpread2, propsSpread3, {
-    get ["data-dynamic"]() {
-      return color();
-    },
-    "data-static": color()
-  }),
+  () =>
+    _$mergeProps(propsSpread1, propsSpread2, propsSpread3, {
+      get ["data-dynamic"]() {
+        return color();
+      },
+      "data-static": color()
+    }),
   undefined,
   true
 );

--- a/packages/babel-plugin-jsx/test/__ssr_hydratable_fixtures__/components/output.js
+++ b/packages/babel-plugin-jsx/test/__ssr_hydratable_fixtures__/components/output.js
@@ -358,5 +358,5 @@ const template25 = Component({
 function MyComponent(props) {
   let el;
   const others = omit(props, "children");
-  return _$ssrElement("div", others, () => () => _$escape(props.children), true);
+  return _$ssrElement("div", others, () => _$scope(() => _$escape(props.children)), true);
 }

--- a/packages/babel-plugin-jsx/test/__ssr_hydratable_fixtures__/insertChildren/output.js
+++ b/packages/babel-plugin-jsx/test/__ssr_hydratable_fixtures__/insertChildren/output.js
@@ -43,7 +43,12 @@ const template6 = Module({
 });
 const template7 = _$ssrElement("module", dynamic, undefined, true);
 const template8 = _$ssrElement("module", dynamic, () => "Hello", true);
-const template9 = _$ssrElement("module", dynamic, () => () => _$escape(dynamic.children), true);
+const template9 = _$ssrElement(
+  "module",
+  dynamic,
+  () => _$scope(() => _$escape(dynamic.children)),
+  true
+);
 const template10 = Module(
   _$mergeProps(dynamic, {
     children: "Hello"
@@ -96,7 +101,7 @@ const template23 = Module({
 const template24 = _$ssrElement(
   "module",
   dynamic,
-  () => ["Hi", "<!--$-->", () => _$escape(dynamic.children), "<!--/-->"],
+  () => ["Hi", "<!--$-->", _$scope(() => _$escape(dynamic.children)), "<!--/-->"],
   true
 );
 const tiles = [];

--- a/packages/runtime/src/server.js
+++ b/packages/runtime/src/server.js
@@ -870,11 +870,17 @@ export function ssrStyleProperty(name, value) {
 
 // review with new ssr
 export function ssrElement(tag, props, children, needsId) {
+  // The hydration key must be allocated before the props thunk runs: dynamic
+  // props (`mergeProps(() => ...)`) create a memo, which consumes a child id.
+  // The client claims the element (getNextElement) before applying the spread,
+  // so the server must allocate in the same order or the element's own id
+  // shifts by one and it is left unclaimed on hydration.
+  const hk = needsId ? ssrHydrationKey() : "";
   if (props == null) props = {};
   else if (typeof props === "function") props = props();
   const skipChildren = VOID_ELEMENTS.test(tag);
   const keys = Object.keys(props);
-  let result = `<${tag}${needsId ? ssrHydrationKey() : ""} `;
+  let result = `<${tag}${hk} `;
   for (let i = 0; i < keys.length; i++) {
     const prop = keys[i];
     if (ChildProperties.has(prop)) {

--- a/packages/runtime/test/ssr/hydrate-spread-mergeprops.spec.js
+++ b/packages/runtime/test/ssr/hydrate-spread-mergeprops.spec.js
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as r from "../../src/client";
+import * as r2 from "../../src/server";
+
+globalThis._$HY = { events: [], completed: new WeakSet() };
+
+// Regression for dynamic spread props shifting the element's own hydration id.
+// `mergeProps` with a function source creates a memo, which consumes a
+// hydration child id. The client claims the element (getNextElement) before
+// applying the spread, so the memo's id comes after the element's. The ssr
+// generate used to evaluate `mergeProps(...)` in ssrElement's argument
+// position — before the element's id was allocated — so the element's own id
+// shifted by one and it was left unclaimed (later siblings re-synced, hiding
+// the drift). Compiled shape (both generates) for:
+//
+//   <title ref={fn} {...props.attrs}>{c()}</title> followed by <span>tail</span>
+//
+// The ssr generate now defers the merge behind a thunk and ssrElement
+// allocates the hydration key before resolving it.
+describe("hydrating a spread element with dynamic (merged) props", () => {
+  function run(serverProps, clientProps) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const _tmpl$ = r.template(`<title>`);
+    const _tmpl$2 = r.template(`<span>tail`);
+    const child = () => "hi";
+
+    const rendered = r2.renderToString(() => [
+      r2.ssrElement("title", serverProps, () => r2.scope(() => r2.escape(child())), true),
+      r2.ssr(["<span", ">tail</span>"], r2.ssrHydrationKey())
+    ]);
+    container.innerHTML = rendered;
+    const serverTitle = container.firstChild;
+    const serverSpan = serverTitle.nextSibling;
+
+    let el;
+    let clientTitle, clientSpan;
+    r.hydrate(() => {
+      const fragment = [
+        (() => {
+          const _el$ = r.getNextElement(_tmpl$);
+          r.ref(() => e => (el = e), _el$);
+          r.spread(_el$, clientProps(), true);
+          r.insert(
+            _el$,
+            r.scope(() => child())
+          );
+          return (clientTitle = _el$);
+        })(),
+        (() => (clientSpan = r.getNextElement(_tmpl$2)))()
+      ];
+      r.insert(container, fragment, undefined, [...container.childNodes]);
+      r.runHydrationEvents();
+    }, container);
+
+    const result = {
+      titleClaimed: clientTitle === serverTitle,
+      spanClaimed: clientSpan === serverSpan,
+      refAssigned: el === clientTitle
+    };
+    container.remove();
+    return result;
+  }
+
+  it("claims the element when merged props are deferred behind a thunk", () => {
+    const attrs = { class: "x" };
+    expect(
+      run(
+        // server: `() => _$mergeProps(() => props.attrs)` (hydratable output)
+        () => r2.mergeProps(() => attrs),
+        // client: `_$spread(_el$, _$mergeProps(() => props.attrs), true)`
+        () => r.mergeProps(() => attrs)
+      )
+    ).toEqual({ titleClaimed: true, spanClaimed: true, refAssigned: true });
+  });
+
+  it("claims the element with plain object props", () => {
+    const attrs = { class: "x" };
+    expect(run(attrs, () => attrs)).toEqual({
+      titleClaimed: true,
+      spanClaimed: true,
+      refAssigned: true
+    });
+  });
+});

--- a/packages/runtime/test/ssr/hydrate-spread-scope.spec.js
+++ b/packages/runtime/test/ssr/hydrate-spread-scope.spec.js
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as r from "../../src/client";
+import * as r2 from "../../src/server";
+
+globalThis._$HY = { events: [], completed: new WeakSet() };
+
+// Regression for the ssrElement (spread-element) children path missing the
+// hole id scope wrap. The compiled shapes below mirror the two generates for:
+//
+//   function Wrapper(props) {
+//     return <div {...props.attrs}>{props.children}</div>;
+//   }
+//   <><Wrapper attrs={{ class: "box" }}>hi</Wrapper><span>tail</span></>
+//
+// The dom generate scope()s the insert accessor for the dynamic child hole,
+// reserving one hydration id. If the ssr generate does not evaluate the
+// matching ssrElement children thunk under a scope, the server allocates ids
+// without the reservation and every id after the hole drifts — the sibling
+// <span> (and everything following it) is left unclaimed on hydration.
+describe("hydrating a spread element with a dynamic child hole", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  const _tmpl$ = r.template(`<div>`),
+    _tmpl$2 = r.template(`<span>tail`);
+
+  it("keeps sibling hydration ids in sync", () => {
+    const attrs = { class: "box" };
+    const child = () => "hi";
+
+    // server (generate: "ssr", hydratable) — children thunk evaluates the
+    // dynamic hole under a scope, mirroring transformChildren's template path
+    const rendered = r2.renderToString(() => [
+      r2.ssrElement("div", attrs, () => r2.scope(() => r2.escape(child())), true),
+      r2.ssr(["<span", ">tail</span>"], r2.ssrHydrationKey())
+    ]);
+    container.innerHTML = rendered;
+    const serverDiv = container.firstChild;
+    const serverSpan = serverDiv.nextSibling;
+    expect(serverSpan.tagName).toBe("SPAN");
+
+    // client (generate: "dom", hydratable)
+    let clientDiv, clientSpan;
+    r.hydrate(() => {
+      const fragment = [
+        (() => {
+          const _el$ = r.getNextElement(_tmpl$);
+          r.spread(_el$, attrs, true);
+          r.insert(
+            _el$,
+            r.scope(() => child())
+          );
+          return (clientDiv = _el$);
+        })(),
+        (() => {
+          return (clientSpan = r.getNextElement(_tmpl$2));
+        })()
+      ];
+      r.insert(container, fragment, undefined, [...container.childNodes]);
+      r.runHydrationEvents();
+    }, container);
+
+    // both server nodes are claimed — the same DOM nodes, not re-created
+    expect(clientDiv).toBe(serverDiv);
+    expect(clientSpan).toBe(serverSpan);
+    expect(container.querySelectorAll("span").length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

The hole-owner-id-scopes change added the ssr generate's `scope()` wrap in `transformChildren` (the template path) but never in `createElement`, the spread-element path that renders through `ssrElement`. The dom generate scope-wraps the matching insert accessor regardless of spread, so a shape like `<a {...props}>{children()}</a>` reserved a hydration id slot on the client but not on the server — every hydration key allocated after the hole drifted and following siblings went unclaimed (duplicated DOM, "unclaimed server-rendered node" warnings).

Hit in practice upgrading TanStack Router to Solid 2.0.0-beta.16, where every `<Link>` desynced the ids of all its following siblings.

## Fix

`createElement` now applies the same wrap as `transformChildren`: dynamic children holes that can allocate hydration ids evaluate under their own owner scope.

## Testing

Regression-tested end-to-end in the runtime hydration suite; the new test (`packages/runtime/test/ssr/hydrate-spread-scope.spec.js`) fails with the exact sibling-unclaimed symptom when the wrap is removed.