### PR TITLE
fix(runtime): escape non-string SSR attribute values after coercion

### DIFF
--- a/.changeset/fix-non-string-attribute-escaping.md
+++ b/.changeset/fix-non-string-attribute-escaping.md
@@ -1,0 +1,5 @@
+---
+"@dom-expressions/runtime": patch
+---
+
+Escape SSR attribute values after coercing arrays, objects, numbers, and other non-string values to strings. This prevents quotes produced during coercion from breaking out of native attributes while preserving nullish and boolean attribute handling.

--- a/packages/runtime/src/server.js
+++ b/packages/runtime/src/server.js
@@ -980,15 +980,16 @@ export function ssrHydrationKey() {
 export function escape(s, attr) {
   const t = typeof s;
   if (t !== "string") {
-    if (!attr && Array.isArray(s)) {
+    if (attr) {
+      if (s == null || t === "boolean") return s;
+      s = String(s);
+    } else if (Array.isArray(s)) {
       const joined = tryJoinPlainSSRArray(s);
       if (joined !== undefined) return joined;
       s = s.slice(); // avoids double escaping - https://github.com/ryansolid/dom-expressions/issues/393
       for (let i = 0; i < s.length; i++) s[i] = escape(s[i]);
       return s;
-    }
-    if (attr && t === "boolean") return s;
-    return s;
+    } else return s;
   }
   // Fast path: single forward pass over the string. Most values (color
   // names, ids, prop strings, plain text) contain none of `&`, `<`, or

--- a/packages/runtime/test/ssr/jsx.spec.jsx
+++ b/packages/runtime/test/ssr/jsx.spec.jsx
@@ -273,6 +273,44 @@ describe("SSR attribute escaping (JSX)", () => {
     expect(res).not.toContain('onmouseover="alert');
   });
 
+  it("escapes non-string dynamic attribute values after coercion", () => {
+    const state = { title: ['"><script>alert(1)</script>', "b"] };
+    const res = r.renderToString(() => <div title={state.title} />);
+    expect(res).toBe('<div title="&quot;><script>alert(1)</script>,b"></div>');
+    const template = document.createElement("template");
+    template.innerHTML = res;
+    expect(template.content.querySelector("script")).toBeNull();
+    expect(template.content.firstElementChild.title).toBe(String(state.title));
+  });
+
+  it("escapes coercible attribute values passed via spread", () => {
+    const props = {
+      title: { toString: () => '"><script>alert(1)</script>' }
+    };
+    const res = r.renderToString(() => <div {...props} />);
+    expect(res).toBe('<div title="&quot;><script>alert(1)</script>"></div>');
+  });
+
+  it("escapes array attribute values passed via spread", () => {
+    const props = { title: ['"><script>alert(1)</script>', "b"] };
+    const res = r.renderToString(() => <div {...props} />);
+    expect(res).toBe('<div title="&quot;><script>alert(1)</script>,b"></div>');
+  });
+
+  it("renders number attribute values as their string form", () => {
+    const state = { count: 0 };
+    const res = r.renderToString(() => <div data-count={state.count} />);
+    expect(res).toBe('<div data-count="0"></div>');
+    const spread = r.renderToString(() => <div {...{ tabindex: 5 }} />);
+    expect(spread).toBe('<div tabindex="5"></div>');
+  });
+
+  it("escapes a non-string style object value after coercion", () => {
+    const evil = { toString: () => '"><script>alert(1)</script>' };
+    const res = r.renderToString(() => <div style={{ background: evil }} />);
+    expect(res).toBe('<div style="background:&quot;><script>alert(1)</script>"></div>');
+  });
+
   it('escapes `"` in a static style string literal', () => {
     const res = r.renderToString(() => <div style='color:red;"x' />);
     expect(res).toContain('style="color:red;&quot;x"');


### PR DESCRIPTION
In SSR, a **non-string** attribute value (an array, or any object whose `toString()` contains a quote) is spliced into the double-quoted attribute without escaping. The coerced string can terminate the attribute and inject live markup:

```tsx
const evil = ['"><script>alert(1)</script>', "b"];
<div title={evil as any} />
// → <div _hk=0 title=""><script>alert(1)</script>,b"></div>
```

Attacker-controlled *strings* are escaped correctly; the gap is only the non-string path, reachable through spread props, untyped CMS/API data, or plain JS. The client is unaffected (`setAttribute` never parses the value as markup), so this is a server-only hardening gap.

## Root cause

In `escape(s, attr)` (`packages/runtime/src/server.js`), attribute mode handles booleans but returns every other non-string value unchanged:

```js
if (attr && t === "boolean") return s;
return s;   // ← array / object falls through unescaped
```

`ssrElement` then splices it via `` `${escape(prop)}="${escape(value, true)}"` ``, so the template literal stringifies it *after* the escaping boundary. The invariant is broader than arrays: any object with a quote-producing `toString()` takes the same bypass, so fixing arrays alone would leave an equivalent hole.

## Fix

In attribute mode, coerce any non-nullish, non-boolean value with `String(s)` and fall through into the existing fast/slow escaping path — coerce first, then escape. No recursion, no extra branch on the string hot path.

- Nullish and boolean pass-through is preserved: compiler-emitted `_$ssrAttribute(key, _$escape(v, true))` relies on `null`/`false`/`true` to omit or render boolean attributes.
- `String(s)` is exactly the coercion the template literal already performed implicitly (and what client `setAttribute` does — an array comma-joins on both sides), just moved before the escaping boundary.
- Text context is untouched and needs no equivalent fix: `resolveSSRNode` only appends strings/numbers and skips unrecognized objects, so there is no `toString` coercion to exploit there.
- Cost on the common non-string value (numbers, e.g. `tabindex={0}`) is a `String()` call plus a fast-path scan over digits that bails without allocating.

## Tests

- 5 new tests in `test/ssr/jsx.spec.jsx`: a direct array-valued attribute (asserting the quote is entity-escaped, no `<script>` survives parsing, and the parsed `title` property matches what client-side `setAttribute` would produce), a quote-breakout `toString()` object passed via spread through `ssrElement`, the array payload via spread, a quote-breakout `toString()` object as a style object value (`ssrStyle` funnels values through the same `escape(v, true)` and had the same pre-fix breakout inside `style="…"`), and number controls (direct and spread) locking `data-count={0}` → `data-count="0"`.
- All four escaping tests fail against the pre-fix `escape` (verified by swapping in the previous `server.js`); the number control passes both before and after, confirming no behavior change on the common numeric path.
- Full runtime suite: 543/543 passing across all projects; existing string, boolean (`forms.spec.jsx` covers dynamic `true`/`false`), and nullish attribute tests unaffected.
- Changeset included (`patch`).
