### PR TITLE
fix(compiler): prefer last children attribute

### DIFF
--- a/.changeset/fix-duplicate-children-attributes.md
+++ b/.changeset/fix-duplicate-children-attributes.md
@@ -1,0 +1,5 @@
+---
+"@dom-expressions/compiler": patch
+---
+
+Match Babel when native elements have duplicate dynamic `children` attributes by compiling the last value instead of the first.

--- a/packages/compiler/__tests__/parity-probes.test.js
+++ b/packages/compiler/__tests__/parity-probes.test.js
@@ -579,6 +579,9 @@ const a = <div innerHTML={"<b>bold</b>"} />;
   "duplicate attributes": `
 const a = <div class="one" class="two" title={t1()} title={t2()}>{x()}</div>;
 `,
+  "duplicate children attributes": `
+const a = <div children={a()} children={b()} />;
+`,
   "duplicate refs": `
 const a = <div ref={r1} ref={r2}>{x()}</div>;
 `,

--- a/packages/compiler/src/dom/element.rs
+++ b/packages/compiler/src/dom/element.rs
@@ -547,9 +547,9 @@ fn xmlns_attribute_value(element: &JSXElement<'_>) -> Option<String> {
     })
 }
 
-/// Matches the Babel plugin's `children`-attribute capture: a `children`
-/// attribute with a non-literal expression container value is treated as
-/// element children (insert), not as an attribute or property.
+/// Matches the Babel plugin's `children`-attribute capture: the last
+/// `children` attribute with a non-literal expression container value is
+/// treated as element children (insert), not as an attribute or property.
 pub(crate) fn children_attribute_container<'e, 'a>(
     element: &'e JSXElement<'a>,
 ) -> Option<&'e oxc_ast::ast::JSXExpressionContainer<'a>> {
@@ -557,6 +557,7 @@ pub(crate) fn children_attribute_container<'e, 'a>(
         .opening_element
         .attributes
         .iter()
+        .rev()
         .find_map(|attr| children_attribute_container_from_item(attr))
 }
 


### PR DESCRIPTION
When a native element has duplicate dynamic `children` attributes, the Oxc compiler uses the first value while Babel uses the last:

```tsx
<div children={a()} children={b()} />
```

Babel emits an insertion for `b`, but Oxc previously emitted one for `a`.

## Root cause

The Rust compiler located the first eligible `children` attribute with a forward `find_map`. Babel processes attributes from left to right and overwrites its captured `children` value, so the last eligible attribute wins.

## Fix

Search the JSX attributes in reverse when selecting the dynamic `children` container. This preserves the existing eligibility rules while matching Babel’s duplicate-attribute precedence.

## Tests

- Added a Babel/Oxc parity probe for duplicate dynamic `children` attributes.
- Confirmed the probe failed before the fix in every DOM-backed mode.
- All 2,490 parity probes pass.
- Full compiler suite passes: 26 suites, 3,657 tests.
- Rust unit tests and Clippy pass.
- Added a patch changeset for `@dom-expressions/compiler`.