### PR TITLE
feat: add omitServerOnlyTemplates option so $ServerOnly survives HMR

### DIFF
--- a/packages/babel-plugin-jsx-dom-expressions/README.md
+++ b/packages/babel-plugin-jsx-dom-expressions/README.md
@@ -184,6 +184,28 @@ When `true` (the default), the template output drops the whitespace between a qu
 
 Set this to `false` to emit a single space between attributes (`<svg width="12" height="13">`) so the generated HTML is strictly valid. This may also be desirable together with `omitQuotes: false` / `omitLastClosingTag: false` when targeting stricter parsers.
 
+### omitServerOnlyTemplates
+
+- Type: `boolean`
+- Default: `true`
+
+Only applies when `hydratable` is `true`. When `true` (the default), an element marked `$ServerOnly` has no template registered, so its markup is never shipped to the client and the generated code calls `getNextElement()` with no argument. That element can then only be obtained by hydrating against server-rendered DOM.
+
+Because `getNextElement` falls back to `template()` whenever it is not hydrating, such an element throws `TypeError: template is not a function` if it is ever re-created on the client. Hot module replacement does exactly that: it disposes the old root and re-runs the component outside of hydration, so editing any file containing `$ServerOnly` breaks the page in development.
+
+Set this to `false` to keep registering the template. The hydration path is unchanged, since `getNextElement` prefers the hydration registry and only calls `template()` when there is nothing to hydrate. The only cost is the template markup being present in the output, which makes this suitable for development builds:
+
+```js
+{
+  plugins: [
+    ["jsx-dom-expressions", {
+      hydratable: true,
+      omitServerOnlyTemplates: process.env.NODE_ENV === "production"
+    }]
+  ]
+}
+```
+
 ### requireImportSource
 
 - Type: `string | false`

--- a/packages/babel-plugin-jsx-dom-expressions/src/config.ts
+++ b/packages/babel-plugin-jsx-dom-expressions/src/config.ts
@@ -12,6 +12,7 @@ export default {
   omitQuotes: true,
   omitAttributeSpacing: true,
   contextToCustomElements: false,
+  omitServerOnlyTemplates: true,
   staticMarker: "@once",
   effectWrapper: "effect",
   memoWrapper: "memo",

--- a/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
+++ b/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js
@@ -994,7 +994,7 @@ function transformAttributes(path, results) {
         }
       } else {
         if (config.hydratable && key === "$ServerOnly") {
-          results.skipTemplate = true;
+          if (config.omitServerOnlyTemplates) results.skipTemplate = true;
           return;
         }
         if (t.isJSXExpressionContainer(value)) value = value.expression;

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_server_only_templates_fixtures__/flags/code.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_server_only_templates_fixtures__/flags/code.js
@@ -1,0 +1,27 @@
+const template = (
+  <div $ServerOnly>
+    <h1>Hello</h1>
+    <Component />
+    {state.interpolation}
+    <span>More Text</span>
+  </div>
+);
+
+const template2 = (
+  <Component>
+    <div $ServerOnly />
+  </Component>
+);
+
+const template3 = (
+  <Component>
+    <div $ServerOnly />
+    <span $ServerOnly />
+  </Component>
+);
+
+const template4 = (
+  <>
+    <div $ServerOnly />
+  </>
+);

--- a/packages/babel-plugin-jsx-dom-expressions/test/__dom_server_only_templates_fixtures__/flags/output.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/__dom_server_only_templates_fixtures__/flags/output.js
@@ -1,0 +1,31 @@
+import { template as _$template } from "r-dom";
+import { getNextElement as _$getNextElement } from "r-dom";
+import { getNextMarker as _$getNextMarker } from "r-dom";
+import { insert as _$insert } from "r-dom";
+import { createComponent as _$createComponent } from "r-dom";
+var _tmpl$ = /*#__PURE__*/ _$template(`<div><h1>Hello</h1><!$><!/><!$><!/><span>More Text`),
+  _tmpl$2 = /*#__PURE__*/ _$template(`<div>`),
+  _tmpl$3 = /*#__PURE__*/ _$template(`<span>`);
+const template = (() => {
+  var _el$ = _$getNextElement(_tmpl$),
+    _el$2 = _el$.firstChild,
+    _el$4 = _el$2.nextSibling,
+    [_el$5, _co$] = _$getNextMarker(_el$4.nextSibling),
+    _el$6 = _el$5.nextSibling,
+    [_el$7, _co$2] = _$getNextMarker(_el$6.nextSibling),
+    _el$3 = _el$7.nextSibling;
+  _$insert(_el$, _$createComponent(Component, {}), _el$5, _co$);
+  _$insert(_el$, () => state.interpolation, _el$7, _co$2);
+  return _el$;
+})();
+const template2 = _$createComponent(Component, {
+  get children() {
+    return _$getNextElement(_tmpl$2);
+  }
+});
+const template3 = _$createComponent(Component, {
+  get children() {
+    return [_$getNextElement(_tmpl$2), _$getNextElement(_tmpl$3)];
+  }
+});
+const template4 = _$getNextElement(_tmpl$2);

--- a/packages/babel-plugin-jsx-dom-expressions/test/dom-server-only-templates.spec.js
+++ b/packages/babel-plugin-jsx-dom-expressions/test/dom-server-only-templates.spec.js
@@ -1,0 +1,19 @@
+const path = require('path')
+const pluginTester = require('babel-plugin-tester').default;
+const plugin = require('../index');
+
+pluginTester({
+  plugin,
+  pluginOptions: {
+    moduleName: 'r-dom',
+    builtIns: ['For', 'Show'],
+    generate: "dom",
+    hydratable: true,
+    contextToCustomElements: true,
+    staticMarker: "@once",
+    omitServerOnlyTemplates: false
+  },
+  title: 'Convert JSX omitServerOnlyTemplates: false',
+  fixtures: path.join(__dirname, '__dom_server_only_templates_fixtures__'),
+  snapshot: true
+});


### PR DESCRIPTION
- Closing https://github.com/solidjs/solid-start/issues/1930

## Problem

Under `hydratable`, an element marked `$ServerOnly` sets `results.skipTemplate`, so `registerTemplate` emits `getNextElement()` with no argument:

```js
hydratable
  ? t.callExpression(registerImportMethod(path, "getNextElement", ...),
      templateId ? [templateId] : [])   // empty when skipTemplate
  : t.callExpression(templateId, [])
```

But `getNextElement` falls back to `template()` whenever it is *not* hydrating:

```js
function getNextElement(template) {
  let node, key, hydrating = isHydrating();
  if (!hydrating || !(node = sharedConfig.registry.get(key = getHydrationKey()))) {
    if (hydrating) { ... }
    return template();   // undefined() when the template was skipped
  }
```

So any client-side re-creation of a `$ServerOnly` element throws `TypeError: template is not a function`.

Hot module replacement does exactly that. solid-refresh disposes the old root and re-runs the component outside of hydration, so **editing any file containing `$ServerOnly` breaks the page in development.** Initial load is fine because that is a hydrating render and `template` is never called.

This is solidjs/solid-start#1930, open since July 2025. It is reproducible today on `@solidjs/start@2.0.0-rc.3` with the `notes` example, which uses `$ServerOnly` in `src/app.tsx` and `src/components/SearchField.tsx`:

```
=== after editing app.tsx ===
[console.error] TypeError: template is not a function
div.main count: 0
```

## Change

Add an `omitServerOnlyTemplates` option, defaulting to `true` so existing output is byte-identical. Setting it to `false` keeps the template registered, so the element can be re-created on the client.

This is safe because `$ServerOnly`'s only effect in the DOM generator is `skipTemplate` (the SSR generator just strips the attribute at `src/ssr/element.js:406`). It carries no runtime semantics, so it is purely a payload optimization, and disabling it is a size tradeoff rather than a behavior change.

It also does not weaken hydration coverage in development, because `getNextElement` prefers the hydration registry and only reaches `template()` when there is nothing to hydrate. The dev and prod hydration paths stay identical; the only difference is the template markup being present in the output.

Intended usage is to disable it for development builds only:

```js
["jsx-dom-expressions", {
  hydratable: true,
  omitServerOnlyTemplates: process.env.NODE_ENV === "production"
}]
```

## Verification

`pnpm test` in `packages/babel-plugin-jsx-dom-expressions`: 16 suites, 108 tests, all passing. The existing `__dom_hydratable_fixtures__/flags` snapshot is unchanged, confirming the default path is untouched.

New spec `dom-server-only-templates.spec.js` reuses the existing `flags` fixture with the option off. Every `getNextElement()` now receives a template, and templates dedupe as usual:

```js
var _tmpl$ = /*#__PURE__*/ _$template(`<div><h1>Hello</h1><!$><!/><!$><!/><span>More Text`),
  _tmpl$2 = /*#__PURE__*/ _$template(`<div>`),
  _tmpl$3 = /*#__PURE__*/ _$template(`<span>`);
...
const template3 = _$createComponent(Component, {
  get children() {
    return [_$getNextElement(_tmpl$2), _$getNextElement(_tmpl$3)];
  }
});
const template4 = _$getNextElement(_tmpl$2);
```

I also verified this end-to-end against the real solid-start `notes` app with a headless Chromium driving actual HMR. No changes were needed in `babel-preset-solid` (it does `Object.assign(defaults, options)`) or `vite-plugin-solid` (it spreads `options.solid`), so the option threads through today:

```ts
solidStart({ solid: { solid: { omitServerOnlyTemplates: false } } })
```

Result, editing `src/app.tsx` twice while the page stays live:

```
=== initial load (SSR + hydrate) ===
errors: none
div.main count: 1
text: SOLID NOTES Search for a note by title NEW ...

=== HMR edit: "Solid Notes" -> "Solid Notes X" ===
errors: none
div.main count: 1
text: SOLID NOTES X Search for a note by title NEW ...

=== HMR edit: "Solid Notes X" -> "Solid Notes" ===
errors: none
div.main count: 1
text: SOLID NOTES Search for a note by title NEW ...
```

## Notes / out of scope

- `src/dom/element.js:143` sets `skipTemplate` for `html`/`head`/`body` under `hydratable`, which is the same crash vector. Those normally only appear in server entry code and are not client-HMR'd, so I left them alone. Happy to extend the flag to cover them if you'd prefer.
- Separately, `getNextElement` throwing a named error instead of a bare `TypeError` when `template` is missing would make this class of problem far easier to diagnose. That belongs in `dom-expressions` runtime rather than here, so I left it out. Glad to follow up.
- Naming follows the existing `omit*` family (`omitNestedClosingTags`, `omitLastClosingTag`, `omitQuotes`, `omitAttributeSpacing`). Happy to rename.
