### PR TITLE
Infer element type in applyRef function

### DIFF
--- a/.changeset/apply-ref-element-type.md
+++ b/.changeset/apply-ref-element-type.md
@@ -1,0 +1,5 @@
+---
+"@dom-expressions/runtime": patch
+---
+
+Make `applyRef` generic so callbacks typed for a concrete element (e.g. `HTMLInputElement`) type-check when forwarding `props.ref`.

--- a/packages/runtime/src/client.d.ts
+++ b/packages/runtime/src/client.d.ts
@@ -109,9 +109,9 @@ export function style(
 export function getOwner(): unknown;
 export function mergeProps(...sources: unknown[]): unknown;
 export function dynamicProperty(props: unknown, key: string): unknown;
-export function applyRef(
-  r: ((element: Element) => void) | ((element: Element) => void)[],
-  element: Element
+export function applyRef<T extends Element = Element>(
+  r: ((element: NoInfer<T>) => void) | ((element: NoInfer<T>) => void)[],
+  element: T
 ): void;
 export function ref(
   fn: () => ((element: Element) => void) | ((element: Element) => void)[],


### PR DESCRIPTION
This allows expressions like:

```ts
function Input(props: ComponentProps<"input">) {
  let input!: HTMLInputElement;
  
  return (
    <input ref={(el) => {
      input = el;
      if (typeof props.ref === "function") applyRef(props.ref, el);
    }} />
  );
}
```

without type errors.