### PR TITLE
fix(runtime): await in-flight writes before releasing the pipeTo writer

### DIFF
--- a/.changeset/pipeto-await-inflight-writes.md
+++ b/.changeset/pipeto-await-inflight-writes.md
@@ -1,0 +1,5 @@
+---
+"@dom-expressions/runtime": patch
+---
+
+`renderToStream(...).pipeTo(w)` now awaits in-flight writes before releasing the writer and closing. `buffer.write` issued `writer.write()` without awaiting the returned promise, and `writable.end()` then called `writer.releaseLock()` synchronously, so whether a chunk still in flight survived was left to the host's stream implementation — Node queues it anyway, workerd drops it. The chunk at risk is always the last one written, which for a streamed `<Loading>` boundary is its `<id>_fr` resolution script. Losing that leaves the client's boundary waiting on a promise that never resolves: it renders its fallback into detached DOM, the server's streamed content is never claimed, and every binding inside the boundary is dead after hydration — including plain signals with no async involvement, and with no error anywhere.

--- a/packages/runtime/src/server.js
+++ b/packages/runtime/src/server.js
@@ -829,16 +829,28 @@ export function renderToStream(code, options = {}) {
             if (!shellCompleted) return flush();
             const encoder = new TextEncoder();
             const writer = w.getWriter();
+            // Writes are chained and awaited before the lock is released.
+            // `writer.write()` returns a promise, and releasing the lock (or
+            // closing) with one still in flight leaves that chunk's fate up to
+            // the host's stream implementation — Node queues it anyway, workerd
+            // drops it. The chunk at risk is the last one written, which for a
+            // streamed boundary is its `_fr` resolution; losing that leaves the
+            // client's boundary waiting on a promise that never resolves.
+            let pendingWrites = Promise.resolve();
             writable = {
               end() {
-                writer.releaseLock();
-                w.close().catch(() => {});
-                resolve();
+                pendingWrites.then(() => {
+                  writer.releaseLock();
+                  w.close().catch(() => {});
+                  resolve();
+                });
               }
             };
             buffer = {
               write(payload) {
-                writer.write(encoder.encode(payload)).catch(() => {});
+                pendingWrites = pendingWrites
+                  .then(() => writer.write(encoder.encode(payload)))
+                  .catch(() => {});
               }
             };
             buffer.write(tmp);

--- a/packages/runtime/test/ssr/stream-final-chunk.spec.js
+++ b/packages/runtime/test/ssr/stream-final-chunk.spec.js
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ *
+ * `pipeTo` must not release the writer's lock (or close the stream) while a
+ * write it issued is still in flight.
+ *
+ * `buffer.write` calls `writer.write()` without awaiting the returned promise,
+ * and `writable.end()` then calls `writer.releaseLock()` synchronously. Whether
+ * the in-flight chunk survives that is up to the host's stream implementation:
+ * Node's queues it anyway, but workerd drops it. The chunk at risk is always
+ * the last one, which for a streamed boundary is its `<id>_fr` resolution
+ * script — and losing that leaves the client's boundary waiting on a promise
+ * that never resolves. It renders its fallback into detached DOM, the streamed
+ * server content is never claimed, and every binding inside the boundary is
+ * dead after hydration (plain signals included).
+ *
+ * Observed with `@tanstack/solid-router` on Cloudflare Workers: the `$df(...)`
+ * reveal arrived but `$R[n]($R[m],!0)` never did.
+ *
+ * The existing `pipeToWritable` spec passes a writer whose `write()` returns an
+ * already-resolved promise, so nothing is ever in flight and this never shows
+ * up. Asserting the invariant directly keeps the guard platform-independent.
+ */
+import * as r from "../../src/server";
+import { sharedConfig } from "rxcore";
+
+function asyncError() {
+  let resolve;
+  const promise = new Promise(r => (resolve = r));
+  const err = new Error("async");
+  err._promise = promise;
+  return { err, resolve };
+}
+
+// Models a sink that doesn't settle writes synchronously — i.e. any real
+// stream applying backpressure — and records how many writes were still in
+// flight when the lock was released.
+function createBackpressuredSink() {
+  const chunks = [];
+  const decoder = new TextDecoder();
+  let inFlight = 0;
+  const state = { inFlightAtRelease: null };
+  const writable = {
+    getWriter() {
+      return {
+        write(v) {
+          inFlight++;
+          return new Promise(resolve =>
+            setTimeout(() => {
+              inFlight--;
+              chunks.push(typeof v === "string" ? v : decoder.decode(v));
+              resolve();
+            }, 0)
+          );
+        },
+        releaseLock() {
+          state.inFlightAtRelease = inFlight;
+        }
+      };
+    },
+    close() {
+      return Promise.resolve();
+    }
+  };
+  return { chunks, writable, state };
+}
+
+describe("pipeTo with a backpressured sink", () => {
+  it("awaits in-flight writes before releasing the writer", async () => {
+    const { chunks, writable, state } = createBackpressuredSink();
+    const pending = asyncError();
+    let calls = 0;
+    let fragDone;
+
+    const stream = r.renderToStream(() => {
+      fragDone = sharedConfig.context.registerFragment("f1");
+      return r.ssr`<div>${() => {
+        if (++calls === 1) throw pending.err;
+        return "shell";
+      }}</div>`;
+    });
+
+    setTimeout(() => pending.resolve(), 5);
+    setTimeout(() => fragDone("<p>late</p>"), 20);
+
+    await stream.pipeTo(writable);
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // The fragment's reveal and its `_fr` resolution both belong on the wire.
+    const html = chunks.join("");
+    expect(html).toContain('$df("f1")');
+    expect(html).toMatch(/,!0\)/);
+
+    // ...and the lock must not have been released with a write still pending,
+    // or hosts with stricter stream semantics lose that chunk.
+    expect(state.inFlightAtRelease).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`renderToStream(...).pipeTo(w)` can lose its final chunk.

`buffer.write` issues `writer.write()` without awaiting the returned promise, and `writable.end()` then calls `writer.releaseLock()` synchronously:

```js
writable = { end() { writer.releaseLock(); w.close().catch(() => {}); resolve(); } };
buffer   = { write(payload) { writer.write(encoder.encode(payload)).catch(() => {}); } };
```

Whether a chunk still in flight at that point survives is left to the host's stream implementation — Node queues it anyway, workerd drops it. The chunk at risk is always the *last* one written, which for a streamed `<Loading>` boundary is its `<id>_fr` resolution script (the runtime queues that write, then `onDone` → `end()` fires in the same batch).

## Why it matters

Losing that one script is silent and total. The client's boundary keeps waiting on a promise that never resolves, so it renders `fallback()` into detached DOM while the server's streamed content sits in the document unclaimed. Every binding inside the boundary is then dead after hydration — **including plain signals with no async involvement** — and nothing errors, so the page looks correct while no update inside the boundary ever paints.

Reduced repro that made it obvious (three bindings, one click):

```jsx
const [count, setCount] = createSignal(0)
const message = createMemo(() => slowServerFn())   // suspends the boundary

<p>A (outside): <span>{count()}</span></p>
<Loading fallback={<p>Loading…</p>}>
  <p>B (inside):  <span>{count()}</span></p>
  <p>C (async):   <span>{message()}</span></p>
</Loading>
<button onClick={() => setCount(count() + 1)}>bump</button>
```

`A` goes 0 → 1; `B` — the same signal, inside the boundary — stays 0.

## Diagnosis trail

Found with `@tanstack/solid-router` on Cloudflare Workers (`solid-js` / `@solidjs/web` 2.0.0-beta.27). On the wire the reveal arrived but the resolution never did:

- `</html>` present, and the stream continues past it: `<template id="…1112">` + `$df("…1112")` both delivered.
- The only resolution calls in the document were the data ones (`)($R[4],"Hello World")`). No `$R[n]($R[m],!0)` anywhere.
- Matching client state: `_$HY.r["…_fr"]` had no `.s`, while the data key was `{ s: 1, v: … }`.
- Resolving that promise by hand in the console (`const r = $R[1]; r.s(true); r.p.s = 1`) made the boundary resume instantly and `B` start updating — confirming the client logic is fine and simply starved.

Instrumenting the handoff pinned the loss precisely: the runtime calls `buffer.write` for the `_fr` script, `onDone` runs, `close` follows — and no chunk for that write is ever handed to the consumer.

Verified against the bundled artifact in a real app (patched `@solidjs/web/dist/server.js`, stock client, `_$HY.fe` untouched):

| check | before | after |
| --- | --- | --- |
| `_fr` resolution on the wire | absent in every capture | `<script>$R[5]($R[1],!0)` present |
| `_$HY.r[…_fr]` client state | no `.s` | `s: 1` |
| probe A / B above | 0 / 0 | 1 / 1 |

Both directions re-checked with logging removed, so the timing change isn't an artifact of instrumentation.

## Fix

Chain the writes and await them in `end()`, so delivery no longer depends on how strictly a host treats a released lock.

## Test

`packages/runtime/test/ssr/stream-final-chunk.spec.js` asserts the invariant directly — no writes in flight when the lock is released — rather than relying on a platform that happens to drop the chunk. Fails before the change (`Expected: 0, Received: 3`), passes after.

The existing `pipeToWritable` spec can't catch this: its writer resolves writes synchronously, so nothing is ever in flight. That's also why a Node-hosted reproduction of the *symptom* isn't possible — Node's streams deliver the queued chunk regardless; the dropped-chunk behaviour needs workerd.

`packages/runtime`: 888 passed, 2 failed — both failures are in `test/dom/claims.spec.jsx` and reproduce identically on `next` without this change.
