### PR TITLE
Fix cached server component handoffs

### DIFF
--- a/.changeset/fix-cached-server-component-handoffs.md
+++ b/.changeset/fix-cached-server-component-handoffs.md
@@ -1,0 +1,5 @@
+---
+"@dom-expressions/runtime": patch
+---
+
+Fix cached server-component frame handoffs so nested document boundaries are not adopted as parent regions, and every live sibling is seeded from rebased retained state during cache-only rebinds.

--- a/packages/runtime/src/frame-client.js
+++ b/packages/runtime/src/frame-client.js
@@ -170,9 +170,10 @@ export function createFrameHost(options = {}) {
       const sibling = set.size ? set.values().next().value : undefined;
       set.add(frame);
       if (sibling) {
-        if (sibling.version !== undefined) {
-          frame.apply({ version: sibling.version, r: sibling.store });
-        }
+        // A retained-state replay leaves a valid store with no version
+        // baseline. Seed from it too, then preserve that rebased state.
+        frame.apply({ version: sibling.version ?? 0, r: sibling.store });
+        if (sibling.version === undefined) frame.rebase && frame.rebase();
         return;
       }
       // No live sibling: seed from the boundary's retained store (see above)
@@ -897,9 +898,10 @@ class FrameImpl {
       this.#slotRegions.set(slotKey, regions);
     }
     const endData = slotEnd(slotKey);
+    const prefix = `${this.#options.id}.`;
     let n = start.nextSibling;
     while (n && !(n.nodeType === COMMENT_NODE && n.data === endData)) {
-      collectRegionElements(n, regions);
+      collectRegionElements(n, regions, prefix);
       n = n.nextSibling;
     }
   }
@@ -1521,11 +1523,12 @@ function collectSlots(n, end, out) {
  * so the walk stops descending at each region element. Client wrapper
  * elements around a region are descended through.
  */
-function collectRegionElements(node, regions) {
+function collectRegionElements(node, regions, prefix) {
   if (node.nodeType !== ELEMENT_NODE) return;
   if (isFrameElement(node)) {
     const childId = node.getAttribute(FRAME_ID_ATTR);
-    if (childId) {
+    // Bare ids belong to nested document boundaries, not this frame's regions.
+    if (childId && childId.startsWith(prefix)) {
       const argKey = childId.slice(childId.lastIndexOf(".") + 1);
       if (!regions.has(argKey)) {
         regions.set(argKey, { childId, element: node, frame: undefined, adopt: true });
@@ -1533,7 +1536,7 @@ function collectRegionElements(node, regions) {
     }
     return;
   }
-  for (let c = node.firstChild; c; c = c.nextSibling) collectRegionElements(c, regions);
+  for (let c = node.firstChild; c; c = c.nextSibling) collectRegionElements(c, regions, prefix);
 }
 
 /**

--- a/packages/runtime/test/ssr/frame-client.spec.js
+++ b/packages/runtime/test/ssr/frame-client.spec.js
@@ -1823,6 +1823,23 @@ describe("adoption -> first morph with nested regions (#547)", () => {
     expect(received).toBe(existing);
   });
 
+  it("does not bind a nested document boundary as one of the parent's regions", () => {
+    boundary.innerHTML =
+      "<article><!--slot:children:start-->" +
+      '<dx-frame data-fid="noteView"><p>Note</p></dx-frame>' +
+      "<!--slot:children:end--></article>";
+    const host = createFrameHost(createMockSerializer());
+
+    createFrame(boundary, {
+      id: "shell",
+      host,
+      adopt: true,
+      slots: { children: () => undefined }
+    });
+
+    expect(host.get("noteView")).toBeUndefined();
+  });
+
   it("an ARMED adopted occurrence (t=0 record drained pre-adoption) does not re-call when the stream adds its used region as {$frame}; the region morphs in place", () => {
     boundary.innerHTML = adoptedDom;
     const host = createFrameHost(createMockSerializer());
@@ -2371,6 +2388,28 @@ describe("multi-mount fan-out and late-mount seeding", () => {
     host.apply({ type: "html", id: "m", version: 3, html: "<p>updated</p>" });
     expect(a.innerHTML).toBe("<p>updated</p>");
     expect(b.innerHTML).toBe("<p>updated</p>");
+  });
+
+  it("seeds every sibling when a cached handoff restores retained state", () => {
+    const host = createFrameHost(createMockSerializer());
+    const frameA = createFrame(a, { id: "story:1", host });
+    const frameB = createFrame(b, { id: "story:1", host });
+    host.apply({ type: "html", id: "story:1", version: 1, html: "<p>Story 1</p>" });
+
+    // A previous mount populated the target call's retained state. A warm
+    // cache hit later rebinds both live mounts without another stream.
+    const cached = document.createElement("div");
+    document.body.appendChild(cached);
+    const cachedFrame = createFrame(cached, { id: "story:2", host });
+    host.apply({ type: "html", id: "story:2", version: 1, html: "<p>Story 2</p>" });
+    cachedFrame.dispose();
+    cached.remove();
+
+    frameA.rebind("story:2");
+    frameB.rebind("story:2");
+
+    expect(a.innerHTML).toBe("<p>Story 2</p>");
+    expect(b.innerHTML).toBe("<p>Story 2</p>");
   });
 
   it("unregisters per frame: disposing one instance keeps the others live", () => {


### PR DESCRIPTION
## Summary

- restrict adopted region discovery to the owning frame namespace so nested document boundaries are not bound twice
- seed every joining frame from a rebased sibling store during cache-only handoffs
- add regressions for both failure modes

Fixes solidjs/solid#2965

## Testing

- `pnpm exec jest --no-cache --runInBand` (933 tests)
- Solid frame client suites (16 tests)
- `pnpm --dir examples/notes build`